### PR TITLE
Add Genie web search demo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,0 @@
-
-# Use bd merge for beads JSONL files
-.beads/issues.jsonl merge=beads

--- a/.gitignore
+++ b/.gitignore
@@ -82,12 +82,8 @@ tfplan
 
 # Claude Code
 .claude/
-.beads/
 .worktrees/
 
 # System Files
 .DS_Store
 Thumbs.db 
-
-# Dolt database files (added by bd init)
-.dolt/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,16 +1,27 @@
 # Agent Instructions
 
-This project uses **bd** (beads) for issue tracking. Run `bd onboard` to get started.
+This project uses **GitHub Issues** for task tracking. Use `gh issue` commands
+or the repo Issues tab to find, create, claim, and close work.
 
 ## Quick Reference
 
 ```bash
-bd ready              # Find available work
-bd show <id>          # View issue details
-bd update <id> --status in_progress  # Claim work
-bd close <id>         # Complete work
-bd sync               # Sync with git
+gh issue list --state open                       # Find available work
+gh issue view <number>                           # View issue details
+gh issue edit <number> --add-assignee @me        # Claim work
+gh issue create --title "..." --body "..."       # Create follow-up work
+gh issue close <number>                          # Complete work
 ```
+
+## Issue Tracking
+
+**IMPORTANT**: Use GitHub Issues for all durable task tracking.
+
+- Create issues for follow-up work that should survive the current session.
+- Link related work with issue references such as `Discovered from #123`.
+- Use labels for type and priority, such as `bug`, `feature`, `task`, `priority: high`, or `priority: backlog`.
+- Use `gh issue list --json number,title,labels,assignees,state` for programmatic issue queries.
+- Do NOT use repo-local issue trackers or duplicate durable task systems.
 
 ## Landing the Plane (Session Completion)
 
@@ -18,13 +29,12 @@ bd sync               # Sync with git
 
 **MANDATORY WORKFLOW:**
 
-1. **File issues for remaining work** - Create issues for anything that needs follow-up
+1. **File issues for remaining work** - Create GitHub Issues for anything that needs follow-up
 2. **Run quality gates** (if code changed) - Tests, linters, builds
-3. **Update issue status** - Close finished work, update in-progress items
+3. **Update issue status** - Close finished issues, update in-progress issues
 4. **PUSH TO REMOTE** - This is MANDATORY:
    ```bash
    git pull --rebase
-   bd sync
    git push
    git status  # MUST show "up to date with origin"
    ```
@@ -61,117 +71,3 @@ git checkout main
 git pull --rebase
 git branch -d <feature-branch>
 ```
-
-
-<!-- BEGIN BEADS INTEGRATION -->
-## Issue Tracking with bd (beads)
-
-**IMPORTANT**: This project uses **bd (beads)** for ALL issue tracking. Do NOT use markdown TODOs, task lists, or other tracking methods.
-
-### Why bd?
-
-- Dependency-aware: Track blockers and relationships between issues
-- Git-friendly: Dolt-powered version control with native sync
-- Agent-optimized: JSON output, ready work detection, discovered-from links
-- Prevents duplicate tracking systems and confusion
-
-### Quick Start
-
-**Check for ready work:**
-
-```bash
-bd ready --json
-```
-
-**Create new issues:**
-
-```bash
-bd create "Issue title" --description="Detailed context" -t bug|feature|task -p 0-4 --json
-bd create "Issue title" --description="What this issue is about" -p 1 --deps discovered-from:bd-123 --json
-```
-
-**Claim and update:**
-
-```bash
-bd update <id> --claim --json
-bd update bd-42 --priority 1 --json
-```
-
-**Complete work:**
-
-```bash
-bd close bd-42 --reason "Completed" --json
-```
-
-### Issue Types
-
-- `bug` - Something broken
-- `feature` - New functionality
-- `task` - Work item (tests, docs, refactoring)
-- `epic` - Large feature with subtasks
-- `chore` - Maintenance (dependencies, tooling)
-
-### Priorities
-
-- `0` - Critical (security, data loss, broken builds)
-- `1` - High (major features, important bugs)
-- `2` - Medium (default, nice-to-have)
-- `3` - Low (polish, optimization)
-- `4` - Backlog (future ideas)
-
-### Workflow for AI Agents
-
-1. **Check ready work**: `bd ready` shows unblocked issues
-2. **Claim your task atomically**: `bd update <id> --claim`
-3. **Work on it**: Implement, test, document
-4. **Discover new work?** Create linked issue:
-   - `bd create "Found bug" --description="Details about what was found" -p 1 --deps discovered-from:<parent-id>`
-5. **Complete**: `bd close <id> --reason "Done"`
-
-### Auto-Sync
-
-bd automatically syncs via Dolt:
-
-- Each write auto-commits to Dolt history
-- Use `bd dolt push`/`bd dolt pull` for remote sync
-- No manual export/import needed!
-
-### Important Rules
-
-- ✅ Use bd for ALL task tracking
-- ✅ Always use `--json` flag for programmatic use
-- ✅ Link discovered work with `discovered-from` dependencies
-- ✅ Check `bd ready` before asking "what should I work on?"
-- ❌ Do NOT create markdown TODO lists
-- ❌ Do NOT use external issue trackers
-- ❌ Do NOT duplicate tracking systems
-
-For more details, see README.md and docs/QUICKSTART.md.
-
-## Landing the Plane (Session Completion)
-
-**When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.
-
-**MANDATORY WORKFLOW:**
-
-1. **File issues for remaining work** - Create issues for anything that needs follow-up
-2. **Run quality gates** (if code changed) - Tests, linters, builds
-3. **Update issue status** - Close finished work, update in-progress items
-4. **PUSH TO REMOTE** - This is MANDATORY:
-   ```bash
-   git pull --rebase
-   bd sync
-   git push
-   git status  # MUST show "up to date with origin"
-   ```
-5. **Clean up** - Clear stashes, prune remote branches
-6. **Verify** - All changes committed AND pushed
-7. **Hand off** - Provide context for next session
-
-**CRITICAL RULES:**
-- Work is NOT complete until `git push` succeeds
-- NEVER stop before pushing - that leaves work stranded locally
-- NEVER say "ready to push when you are" - YOU must push
-- If push fails, resolve and retry until it succeeds
-
-<!-- END BEADS INTEGRATION -->

--- a/databricks/demos/genie_web_search/README.md
+++ b/databricks/demos/genie_web_search/README.md
@@ -1,0 +1,101 @@
+# Genie Web Search
+
+A Unity Catalog Python UDF that lets Databricks SQL, Spark, and Genie Code do
+live web searches. It is backed by Exa's free public MCP endpoint
+(`https://mcp.exa.ai/mcp`) and does not require an API key.
+
+## Files
+
+- `register_web_search.py` registers the UDF. Set `NAMESPACE` before running it.
+- `README.md` is this setup guide.
+
+## Requirements
+
+- Unity Catalog enabled workspace.
+- `USE CATALOG`, `USE SCHEMA`, and `CREATE FUNCTION` on your target schema.
+- Compute with internet egress to `mcp.exa.ai`. Serverless compute works out of the box.
+
+## Usage
+
+1. Pick a `<catalog>.<schema>` where you have `CREATE FUNCTION`.
+2. Edit `register_web_search.py` and set `NAMESPACE = "<catalog>.<schema>"`.
+3. Paste the file into a Databricks notebook cell on a UC-enabled workspace and run it.
+4. Verify the function:
+
+```sql
+SELECT <catalog>.<schema>.web_search('latest news on Databricks');
+```
+
+5. Wire it up as a Genie Code MCP tool using the manual steps below.
+
+## Configuration
+
+| Setting | Required | Purpose |
+| --- | --- | --- |
+| `NAMESPACE` | yes | `"<catalog>.<schema>"` where the function is registered. Empty string raises. |
+| `NUM_RESULTS` | no | Results per query. Defaults to `10`. |
+
+The function name is hard-coded as `web_search`.
+
+## Picking A Namespace
+
+Use the Databricks CLI to find a sensible target before editing the file:
+
+```bash
+databricks current-user me --output JSON
+databricks catalogs list --output JSON
+databricks schemas list <catalog> --output JSON
+databricks grants get-effective schema <catalog>.<schema> --output JSON
+```
+
+Heuristics:
+
+1. Look for a personal sandbox such as `users.<sanitized_email>`.
+2. Otherwise, look for a schema where you have `ALL_PRIVILEGES` or `CREATE_FUNCTION`.
+3. Avoid `main.default` and `hive_metastore.*` unless you explicitly want those.
+4. If nothing is obvious, ask the workspace owner instead of guessing.
+
+## Wire It Up As A Genie Code Tool
+
+This step is manual. There is no public API for it.
+
+1. Avatar (top-right) -> Settings -> Genie Code -> MCP Servers -> Add MCP server.
+2. Choose Unity Catalog function.
+3. Pick the catalog/schema where the function was registered.
+4. Toggle `web_search` on and save.
+5. Fully reload your Databricks tab. Genie Code only re-reads its tool list on session start.
+
+If an assistant is setting this up, it can register the UDF, but the human must
+complete the manual Genie Code MCP wiring.
+
+## Troubleshooting
+
+| Symptom | Fix |
+| --- | --- |
+| `SELECT web_search(...)` errors but registration succeeded | No internet egress. Use Serverless or allow outbound HTTPS to `mcp.exa.ai`. |
+| `CREATE FUNCTION` denied | Pick a different `NAMESPACE`. |
+| `ValueError: NAMESPACE must be...` | Set `NAMESPACE = "<catalog>.<schema>"` at the top of the script. |
+| Tool missing in Genie Code after wiring | Fully reload the Databricks tab. |
+
+## How It Works
+
+The UDF speaks JSON-RPC to Exa's hosted public MCP server, calls the
+`web_search_exa` tool, and returns the concatenated text blocks from the response.
+It uses only the Python standard library so it can run inside the UC Python sandbox
+with no extra dependencies.
+
+If Exa changes its public endpoint to require auth, add an `EXA_API_KEY` environment
+variable or Databricks secret to the UDF body.
+
+## Engineering Notes
+
+The `CREATE FUNCTION` SQL is built with plain string concatenation, not f-strings
+or `.format()`, because the embedded Python source contains `{}` characters that
+would clash with format placeholders.
+
+The UDF body is wrapped in a raw triple-quoted string (`r'''...'''`) so backslash
+escapes like `\n` survive into the UDF source. Without the `r` prefix, `'\n'.join(...)`
+becomes a literal newline in the source and produces an unterminated-string
+`SyntaxError` at UDF runtime.
+
+`NUM_RESULTS` is injected into the body via plain concatenation for the same reason.

--- a/databricks/demos/genie_web_search/register_web_search.py
+++ b/databricks/demos/genie_web_search/register_web_search.py
@@ -1,0 +1,160 @@
+"""
+Register a Unity Catalog Python UDF named web_search(query STRING) RETURNS STRING.
+
+The UDF performs a real-time web search via Exa's public MCP endpoint. Run this
+script in a Databricks notebook cell on a UC-enabled workspace after setting
+NAMESPACE below.
+"""
+
+# Required: "<catalog>.<schema>" where you have CREATE FUNCTION privileges.
+# See README.md for namespace selection, Genie Code wiring, and troubleshooting.
+NAMESPACE = ""
+NUM_RESULTS = 10
+
+FUNCTION_NAME = "web_search"
+
+_parts = NAMESPACE.split(".")
+if len(_parts) != 2 or not all(part.strip() for part in _parts):
+    raise ValueError(
+        "NAMESPACE must be '<catalog>.<schema>' (e.g. 'users.alice'). Got: "
+        + repr(NAMESPACE)
+    )
+FQN = NAMESPACE + "." + FUNCTION_NAME
+
+# Authoring conventions:
+# - CREATE FUNCTION SQL is built with plain string concatenation, not f-strings.
+# - udf_body is a raw triple-quoted string so backslash escapes survive.
+# - NUM_RESULTS is injected with plain concatenation.
+udf_body = (
+    r'''
+import json
+import urllib.error
+import urllib.request
+
+URL = "https://mcp.exa.ai/mcp"
+BASE_HEADERS = {
+    "Content-Type": "application/json",
+    "Accept": "application/json, text/event-stream",
+}
+NUM_RESULTS = '''
+    + str(NUM_RESULTS)
+    + r'''
+
+def _post(body, headers, timeout=30):
+    data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(URL, data=data, headers=headers, method="POST")
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        text = resp.read().decode("utf-8", errors="replace")
+        session = resp.headers.get("Mcp-Session-Id") or resp.headers.get("mcp-session-id")
+        return text, session
+
+def _parse(body):
+    body = (body or "").strip()
+    if not body:
+        return None
+    if body.startswith("{"):
+        try:
+            return json.loads(body)
+        except Exception:
+            return None
+    last = None
+    for line in body.splitlines():
+        line = line.strip()
+        if line.startswith("data:"):
+            try:
+                last = json.loads(line[5:].strip())
+            except Exception:
+                continue
+    return last
+
+def _run(query):
+    if query is None or not str(query).strip():
+        return json.dumps({"error": "query is empty"})
+
+    try:
+        _, session_id = _post(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {},
+                    "clientInfo": {"name": "databricks-uc-udf", "version": "1.0"},
+                },
+            },
+            BASE_HEADERS,
+        )
+
+        headers = dict(BASE_HEADERS)
+        if session_id:
+            headers["Mcp-Session-Id"] = session_id
+
+        # notifications/initialized returns 202 with no response body.
+        try:
+            _post(
+                {"jsonrpc": "2.0", "method": "notifications/initialized"},
+                headers,
+                timeout=10,
+            )
+        except Exception:
+            pass
+
+        body, _ = _post(
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {
+                    "name": "web_search_exa",
+                    "arguments": {"query": query, "numResults": NUM_RESULTS},
+                },
+            },
+            headers,
+            timeout=60,
+        )
+
+        parsed = _parse(body)
+        if not isinstance(parsed, dict):
+            return body or ""
+
+        if "error" in parsed:
+            return json.dumps(parsed["error"])
+
+        result = parsed.get("result") or {}
+        content = result.get("content") if isinstance(result, dict) else None
+        if isinstance(content, list):
+            texts = [
+                item.get("text", "")
+                for item in content
+                if isinstance(item, dict) and item.get("type") == "text"
+            ]
+            if texts:
+                return "\n".join(texts)
+
+        return json.dumps(result)
+    except urllib.error.HTTPError as e:
+        try:
+            err_body = e.read().decode("utf-8", errors="replace")
+        except Exception:
+            err_body = ""
+        return json.dumps({"error": "HTTP " + str(e.code), "body": err_body[:500]})
+    except Exception as e:
+        return json.dumps({"error": str(e)})
+
+return _run(query)
+'''
+)
+
+create_sql = (
+    "CREATE OR REPLACE FUNCTION " + FQN + "(\n"
+    "  query STRING COMMENT 'Natural-language web search query'\n"
+    ")\n"
+    "RETURNS STRING\n"
+    "LANGUAGE PYTHON\n"
+    "COMMENT 'Performs a real-time web search and returns the top results as a single text block with Title / URL / Published / Author / Highlights sections separated by ---. Use this whenever you need up-to-date information from the public internet that may not be in your training data.'\n"
+    "AS " + ("$" * 2) + udf_body + ("$" * 2) + ";"
+)
+
+spark.sql(create_sql)
+print("Registered " + FQN)


### PR DESCRIPTION
## Summary
- Add a Databricks demo for registering a Unity Catalog `web_search` UDF backed by Exa's public MCP endpoint.
- Document namespace selection, verification, and the manual Genie Code MCP wiring step.
- Replace retired beads/bd agent guidance with GitHub Issues workflow instructions.

## Test plan
- `python3` syntax compile for `databricks/demos/genie_web_search/register_web_search.py`
- Pre-commit secret scan
- Pre-push secret scan
- Repository scan for stale beads/bd/Dolt workflow references excluding generated lockfile false positives