### PR TITLE
feat: LangGraph Genie agent demo with MLflow 3 tracing

### DIFF
--- a/databricks/demos/langgraph_genie_agent/.gitignore
+++ b/databricks/demos/langgraph_genie_agent/.gitignore
@@ -1,0 +1,18 @@
+# uv.lock is gitignored because it resolves against the Databricks internal
+# PyPI proxy (pypi-proxy.dev.databricks.com), which is not reachable outside
+# Databricks corporate network. Committing it would break installs for all
+# non-Databricks users.
+uv.lock
+
+# Virtual environment
+.venv/
+
+# Python cache
+__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/
+
+# MLflow run artifacts (created by mlflow locally)
+mlruns/
+mlflow.db

--- a/databricks/demos/langgraph_genie_agent/README.md
+++ b/databricks/demos/langgraph_genie_agent/README.md
@@ -1,0 +1,151 @@
+# LangGraph Genie Agent
+
+A LangGraph ReAct-style agent that answers user questions by calling a
+Databricks Genie space as a tool. The agent is backed by a Databricks model
+serving endpoint (any chat model supported by the endpoint) and produces
+MLflow 3 traces for every run.
+
+The demo is intentionally minimal: one file (`agent.py`), standard Databricks
+SDK auth, no secrets on disk.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `agent.py` | Agent core — config, graph builder, Genie tool wrapper, MLflow setup, CLI entry point |
+| `tests/test_agent.py` | Pytest test suite; runs without a live workspace (LLM and Genie are mocked) |
+| `pyproject.toml` | uv-managed project; all commands via `uv run` |
+| `.gitignore` | Excludes `uv.lock`, `.venv/`, and MLflow local artifacts |
+| `README.md` | This file |
+
+## Requirements
+
+- Databricks workspace with Unity Catalog enabled.
+- A Genie space (note the space ID from the URL: `.../genie/spaces/<SPACE_ID>`).
+- A Databricks model serving endpoint that accepts chat messages (e.g. `databricks-claude-sonnet-4-5`, `databricks-meta-llama-3-3-70b-instruct`).
+- Databricks authentication — any of:
+  - `DATABRICKS_HOST` + `DATABRICKS_TOKEN` environment variables, or
+  - a configured Databricks CLI profile (`databricks auth login`).
+- Python ≥ 3.10.
+- `uv` — install via `brew install uv` or `curl -Lsf https://astral.sh/uv/install.sh | sh`.
+
+## Usage
+
+```bash
+# 1. Install dependencies
+uv sync
+
+# 2. Run tests (no workspace required — everything is mocked)
+uv run pytest
+
+# 3. Set required config
+export GENIE_SPACE_ID="<your-genie-space-id>"
+export LLM_ENDPOINT="databricks-claude-sonnet-4-5"
+
+# 4. (Optional) Databricks auth if not already configured
+export DATABRICKS_HOST="https://<your-workspace>.azuredatabricks.net"
+export DATABRICKS_TOKEN="<your-pat>"
+
+# 5. Ask a question
+uv run python agent.py "What were total sales last quarter?"
+```
+
+The agent prints the final answer and notes where to find the MLflow trace.
+
+## Configuration
+
+| Variable | Required | Default | Purpose |
+| --- | --- | --- | --- |
+| `GENIE_SPACE_ID` | yes | — | Databricks Genie space ID (from the space URL) |
+| `LLM_ENDPOINT` | yes | — | Databricks model serving endpoint name |
+| `MLFLOW_EXPERIMENT` | no | `/langgraph-genie-agent` | MLflow experiment path for traces |
+| `DATABRICKS_HOST` | no* | SDK default | Workspace URL (`https://...`) |
+| `DATABRICKS_TOKEN` | no* | SDK default | Personal access token |
+
+\* Required unless a Databricks CLI profile is already configured.
+
+A missing `GENIE_SPACE_ID` or `LLM_ENDPOINT` raises a `ValueError` that names
+each missing variable explicitly.
+
+## Viewing Traces in the MLflow UI
+
+After a run, open the MLflow UI:
+
+```bash
+uv run mlflow ui          # local tracking at http://localhost:5000
+```
+
+Navigate to the `/langgraph-genie-agent` experiment (or the name you set in
+`MLFLOW_EXPERIMENT`) and open the latest run. Each invocation produces one
+trace that shows the assistant and Genie tool spans.
+
+If your workspace is configured as the MLflow tracking server
+(`MLFLOW_TRACKING_URI=databricks`), traces appear directly in the Databricks
+Experiments UI under the experiment path.
+
+## How It Works
+
+```
+User question
+      │
+      ▼
+[assistant node] ← LLM (ChatDatabricks) bound to the ask_genie tool
+      │
+      ├─ tool_calls present ──► [genie_tool node] ── calls Genie space ──┐
+      │                                                                   │
+      └─ no tool_calls ──────────────────────────────────────────────────┘
+                                                                          │
+                                                                         ▼
+                                                                   [assistant node]
+                                                                          │
+                                                                   plain answer
+                                                                          │
+                                                                         END
+```
+
+1. The user question is wrapped in a `HumanMessage` and fed into the graph.
+2. The `assistant` node invokes the LLM. If the LLM decides it needs data, it
+   emits a tool call to `ask_genie`.
+3. The `genie_tool` node extracts the question from the tool call args and
+   calls `genie_fn(question)`, which calls `Genie.ask_question` from
+   `databricks_ai_bridge`.
+4. The Genie response is added to the message list as a `ToolMessage`, and
+   control returns to the `assistant` node.
+5. The LLM synthesises a final answer from the Genie data.
+6. MLflow `langchain.autolog()` records the entire run as a trace.
+
+## Troubleshooting
+
+| Symptom | Fix |
+| --- | --- |
+| `ValueError: Missing required environment variable(s): GENIE_SPACE_ID` | Set `export GENIE_SPACE_ID="<id>"` |
+| `ValueError: Missing required environment variable(s): LLM_ENDPOINT` | Set `export LLM_ENDPOINT="<endpoint>"` |
+| `databricks.sdk.errors.PermissionDenied` | Check that your PAT or CLI profile has access to the Genie space |
+| `RESOURCE_DOES_NOT_EXIST` from the serving endpoint | Verify `LLM_ENDPOINT` matches the exact name in your workspace |
+| `uv sync` fails to reach pypi.org | On Databricks-networked machines, set `UV_INDEX_URL=https://pypi-proxy.dev.databricks.com/simple/` |
+| Empty or truncated Genie answer | The Genie space may need more context; try a more specific question |
+| MLflow traces not appearing | Check `MLFLOW_TRACKING_URI` points to your server; confirm experiment exists |
+
+## Natural Next Steps
+
+- **Model Serving deployment** — wrap `build_agent` in an MLflow `pyfunc` model
+  and log it with `mlflow.langchain.log_model()`, then deploy via Databricks
+  Model Serving for a REST API endpoint.
+- **MLflow evaluation** — use `mlflow.evaluate()` with a question/answer dataset
+  to score the agent's accuracy against ground-truth Genie responses.
+
+## Engineering Notes
+
+`uv.lock` is gitignored in this directory because `uv sync` resolves against
+the Databricks internal PyPI proxy (`pypi-proxy.dev.databricks.com`), which is
+unreachable outside the Databricks corporate network. Committing a lockfile
+with those URLs would break installs for all external users. Run `uv sync` to
+regenerate the lockfile in your own environment.
+
+The Genie integration uses `Genie` from `databricks_ai_bridge.genie` (re-used
+internally by `databricks_langchain.GenieAgent`). The agent wraps it in a
+plain callable (`genie_fn`) rather than using `GenieAgent` directly, which
+makes the seam easy to mock in tests without patching deep library internals.
+`GenieAgent` returns a `RunnableLambda` intended for LangChain LCEL pipelines;
+for a ReAct tool loop, a `@tool`-decorated wrapper over a plain callable is
+the right approach.

--- a/databricks/demos/langgraph_genie_agent/README.md
+++ b/databricks/demos/langgraph_genie_agent/README.md
@@ -81,7 +81,10 @@ trace that shows the assistant and Genie tool spans.
 
 If your workspace is configured as the MLflow tracking server
 (`MLFLOW_TRACKING_URI=databricks`), traces appear directly in the Databricks
-Experiments UI under the experiment path.
+Experiments UI under the experiment path. In that case set `MLFLOW_EXPERIMENT`
+to a workspace path you can write to, e.g.
+`/Users/<you@example.com>/langgraph-genie-agent` — the default root-level path
+only works with a local tracking server.
 
 ## How It Works
 
@@ -122,6 +125,8 @@ User question
 | `ValueError: Missing required environment variable(s): LLM_ENDPOINT` | Set `export LLM_ENDPOINT="<endpoint>"` |
 | `databricks.sdk.errors.PermissionDenied` | Check that your PAT or CLI profile has access to the Genie space |
 | `RESOURCE_DOES_NOT_EXIST` from the serving endpoint | Verify `LLM_ENDPOINT` matches the exact name in your workspace |
+| `401: Credential was not sent or was of an unsupported type` plus a warning that two profiles match the same host | Multiple `~/.databrickscfg` profiles point at one workspace; disambiguate with `export DATABRICKS_CONFIG_PROFILE=<profile>` |
+| Experiment creation fails with `MLFLOW_TRACKING_URI=databricks` | Set `MLFLOW_EXPERIMENT` to a writable workspace path like `/Users/<you@example.com>/langgraph-genie-agent` |
 | `uv sync` fails to reach pypi.org | On Databricks-networked machines, set `UV_INDEX_URL=https://pypi-proxy.dev.databricks.com/simple/` |
 | Empty or truncated Genie answer | The Genie space may need more context; try a more specific question |
 | MLflow traces not appearing | Check `MLFLOW_TRACKING_URI` points to your server; confirm experiment exists |

--- a/databricks/demos/langgraph_genie_agent/agent.py
+++ b/databricks/demos/langgraph_genie_agent/agent.py
@@ -1,0 +1,266 @@
+"""
+LangGraph ReAct agent that answers user questions by calling a Databricks
+Genie space as a tool, backed by a Databricks-hosted LLM serving endpoint,
+with MLflow 3 tracing enabled.
+
+Usage:
+    uv run python agent.py "What were total sales last quarter?"
+
+Configuration (environment variables):
+    GENIE_SPACE_ID       (required) Databricks Genie space ID
+    LLM_ENDPOINT         (required) Databricks model serving endpoint name
+                         e.g. "databricks-claude-sonnet-4-5"
+    MLFLOW_EXPERIMENT    (optional) MLflow experiment name/path
+                         Default: "/langgraph-genie-agent"
+
+Databricks auth is handled implicitly via the SDK (env vars or CLI profile).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Any, Callable, Optional
+
+import mlflow
+from langchain_core.messages import AIMessage, BaseMessage, ToolMessage
+from langchain_core.tools import tool
+from langgraph.graph import END, START, StateGraph
+from langgraph.graph.message import MessagesState
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+GENIE_TOOL_NAME = "ask_genie"
+
+_DEFAULT_EXPERIMENT = "/langgraph-genie-agent"
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+def load_config() -> dict[str, str]:
+    """
+    Load and validate required configuration from environment variables.
+
+    Returns a dict with keys:
+        genie_space_id   - Databricks Genie space ID
+        llm_endpoint     - Databricks model serving endpoint name
+        mlflow_experiment - MLflow experiment path (with default)
+
+    Raises:
+        ValueError listing all missing required env vars.
+    """
+    missing = []
+    genie_space_id = os.environ.get("GENIE_SPACE_ID", "")
+    llm_endpoint = os.environ.get("LLM_ENDPOINT", "")
+
+    if not genie_space_id:
+        missing.append("GENIE_SPACE_ID")
+    if not llm_endpoint:
+        missing.append("LLM_ENDPOINT")
+
+    if missing:
+        raise ValueError(
+            f"Missing required environment variable(s): {', '.join(missing)}. "
+            "Set them before running the agent."
+        )
+
+    return {
+        "genie_space_id": genie_space_id,
+        "llm_endpoint": llm_endpoint,
+        "mlflow_experiment": os.environ.get("MLFLOW_EXPERIMENT", _DEFAULT_EXPERIMENT),
+    }
+
+
+# ---------------------------------------------------------------------------
+# MLflow tracing setup
+# ---------------------------------------------------------------------------
+
+
+def setup_tracing(experiment_name: Optional[str] = None) -> None:
+    """
+    Enable MLflow LangChain autologging and set the active experiment.
+
+    Args:
+        experiment_name: MLflow experiment name/path. Defaults to the
+            MLFLOW_EXPERIMENT env var or "/langgraph-genie-agent".
+    """
+    if experiment_name is None:
+        experiment_name = os.environ.get("MLFLOW_EXPERIMENT", _DEFAULT_EXPERIMENT)
+
+    mlflow.langchain.autolog()
+    mlflow.set_experiment(experiment_name)
+
+
+# ---------------------------------------------------------------------------
+# Genie tool factory
+# ---------------------------------------------------------------------------
+
+
+def make_genie_fn(genie_space_id: str) -> Callable[[str], str]:
+    """
+    Return a callable that asks a Databricks Genie space a question and
+    returns the answer as a string.
+
+    This is the seam that tests mock — all Genie I/O is isolated here.
+    The Genie space ID is captured in a closure so callers only pass the
+    question string.
+
+    Args:
+        genie_space_id: Databricks Genie space ID.
+
+    Returns:
+        A callable: (question: str) -> str
+    """
+    from databricks_ai_bridge.genie import Genie
+
+    genie = Genie(genie_space_id)
+
+    def _ask(question: str) -> str:
+        response = genie.ask_question(question)
+        # response.result may be a string or None; coerce to str
+        result = response.result if response.result is not None else ""
+        if hasattr(result, "to_markdown"):  # pandas DataFrame
+            return result.to_markdown(index=False)
+        return str(result)
+
+    return _ask
+
+
+# ---------------------------------------------------------------------------
+# Graph builder
+# ---------------------------------------------------------------------------
+
+
+def build_agent(
+    llm: Any,
+    genie_fn: Callable[[str], str],
+) -> Any:
+    """
+    Build and compile a LangGraph ReAct graph.
+
+    Nodes:
+      - assistant: calls the LLM (bound to the Genie tool)
+      - genie_tool: executes the Genie tool call
+
+    Edges:
+      START → assistant
+      assistant → genie_tool  (when the last message has tool calls)
+      assistant → END          (when the last message has no tool calls)
+      genie_tool → assistant
+
+    Args:
+        llm: A LangChain chat model (or mock). Will have bind_tools called on it.
+        genie_fn: Callable (question: str) -> str. Wraps the Genie API.
+
+    Returns:
+        A compiled LangGraph StateGraph.
+    """
+
+    # Build a LangChain @tool around the genie_fn callable so it can be bound
+    # to the LLM and discovered by the tool node.
+    @tool(GENIE_TOOL_NAME)
+    def ask_genie(question: str) -> str:
+        """
+        Ask a Databricks Genie space a natural-language question about your data.
+        Use this tool whenever the user needs data-driven answers.
+
+        Args:
+            question: The natural-language question to ask.
+
+        Returns:
+            The answer from Genie (plain text or markdown table).
+        """
+        return genie_fn(question)
+
+    tools = [ask_genie]
+    llm_with_tools = llm.bind_tools(tools)
+
+    # --- node functions -----------------------------------------------------
+
+    def assistant_node(state: MessagesState) -> dict:
+        response = llm_with_tools.invoke(state["messages"])
+        return {"messages": [response]}
+
+    def genie_tool_node(state: MessagesState) -> dict:
+        """Execute any pending tool calls in the last message."""
+        last_message = state["messages"][-1]
+        tool_messages = []
+
+        for tc in last_message.tool_calls:
+            if tc["name"] == GENIE_TOOL_NAME:
+                question = tc["args"].get("question", "")
+                result = genie_fn(question)
+                tool_messages.append(
+                    ToolMessage(content=result, tool_call_id=tc["id"])
+                )
+
+        return {"messages": tool_messages}
+
+    def should_continue(state: MessagesState) -> str:
+        """Route to 'genie_tool' if the last message has tool calls; else END."""
+        last_message = state["messages"][-1]
+        if isinstance(last_message, AIMessage) and last_message.tool_calls:
+            return "genie_tool"
+        return END
+
+    # --- graph assembly -----------------------------------------------------
+
+    graph = StateGraph(MessagesState)
+    graph.add_node("assistant", assistant_node)
+    graph.add_node("genie_tool", genie_tool_node)
+
+    graph.add_edge(START, "assistant")
+    graph.add_conditional_edges("assistant", should_continue)
+    graph.add_edge("genie_tool", "assistant")
+
+    return graph.compile()
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main(question: str) -> None:
+    """Ask one question and print the answer."""
+    cfg = load_config()
+    setup_tracing(cfg["mlflow_experiment"])
+
+    from databricks_langchain import ChatDatabricks
+
+    llm = ChatDatabricks(endpoint=cfg["llm_endpoint"])
+    genie_fn = make_genie_fn(cfg["genie_space_id"])
+
+    graph = build_agent(llm=llm, genie_fn=genie_fn)
+
+    from langchain_core.messages import HumanMessage
+
+    result = graph.invoke({"messages": [HumanMessage(content=question)]})
+    last_message = result["messages"][-1]
+    answer = last_message.content
+
+    print(f"\nAnswer: {answer}\n")
+
+    # Surface the MLflow run/trace URL if available
+    active_run = mlflow.active_run()
+    if active_run:
+        tracking_uri = mlflow.get_tracking_uri()
+        run_id = active_run.info.run_id
+        print(f"MLflow run: {tracking_uri}/#/experiments/.../runs/{run_id}")
+    else:
+        print(
+            "MLflow tracing is enabled. View traces in the MLflow UI at your "
+            "tracking server or Databricks workspace under Experiments."
+        )
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: uv run python agent.py \"<your question>\"")
+        sys.exit(1)
+    main(sys.argv[1])

--- a/databricks/demos/langgraph_genie_agent/agent.py
+++ b/databricks/demos/langgraph_genie_agent/agent.py
@@ -20,10 +20,10 @@ from __future__ import annotations
 
 import os
 import sys
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 import mlflow
-from langchain_core.messages import AIMessage, BaseMessage, ToolMessage
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langchain_core.tools import tool
 from langgraph.graph import END, START, StateGraph
 from langgraph.graph.message import MessagesState
@@ -81,17 +81,13 @@ def load_config() -> dict[str, str]:
 # ---------------------------------------------------------------------------
 
 
-def setup_tracing(experiment_name: Optional[str] = None) -> None:
+def setup_tracing(experiment_name: str = _DEFAULT_EXPERIMENT) -> None:
     """
     Enable MLflow LangChain autologging and set the active experiment.
 
     Args:
-        experiment_name: MLflow experiment name/path. Defaults to the
-            MLFLOW_EXPERIMENT env var or "/langgraph-genie-agent".
+        experiment_name: MLflow experiment name/path.
     """
-    if experiment_name is None:
-        experiment_name = os.environ.get("MLFLOW_EXPERIMENT", _DEFAULT_EXPERIMENT)
-
     mlflow.langchain.autolog()
     mlflow.set_experiment(experiment_name)
 
@@ -238,25 +234,14 @@ def main(question: str) -> None:
 
     graph = build_agent(llm=llm, genie_fn=genie_fn)
 
-    from langchain_core.messages import HumanMessage
-
     result = graph.invoke({"messages": [HumanMessage(content=question)]})
-    last_message = result["messages"][-1]
-    answer = last_message.content
+    answer = result["messages"][-1].content
 
     print(f"\nAnswer: {answer}\n")
-
-    # Surface the MLflow run/trace URL if available
-    active_run = mlflow.active_run()
-    if active_run:
-        tracking_uri = mlflow.get_tracking_uri()
-        run_id = active_run.info.run_id
-        print(f"MLflow run: {tracking_uri}/#/experiments/.../runs/{run_id}")
-    else:
-        print(
-            "MLflow tracing is enabled. View traces in the MLflow UI at your "
-            "tracking server or Databricks workspace under Experiments."
-        )
+    print(
+        f"MLflow trace logged to experiment '{cfg['mlflow_experiment']}' "
+        f"(tracking URI: {mlflow.get_tracking_uri()})."
+    )
 
 
 if __name__ == "__main__":

--- a/databricks/demos/langgraph_genie_agent/pyproject.toml
+++ b/databricks/demos/langgraph_genie_agent/pyproject.toml
@@ -1,0 +1,29 @@
+[project]
+name = "langgraph-genie-agent"
+version = "0.1.0"
+description = "LangGraph ReAct agent that answers questions by calling a Databricks Genie space as a tool"
+requires-python = ">=3.10"
+dependencies = [
+    "databricks-langchain>=0.19.0",
+    "langgraph>=0.2.0",
+    "mlflow>=3.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+    "pytest-mock>=3.0",
+]
+
+[dependency-groups]
+dev = [
+    "pytest>=7.0",
+    "pytest-mock>=3.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]

--- a/databricks/demos/langgraph_genie_agent/pyproject.toml
+++ b/databricks/demos/langgraph_genie_agent/pyproject.toml
@@ -9,21 +9,8 @@ dependencies = [
     "mlflow>=3.0",
 ]
 
-[project.optional-dependencies]
-dev = [
-    "pytest>=7.0",
-    "pytest-mock>=3.0",
-]
-
 [dependency-groups]
 dev = [
     "pytest>=7.0",
     "pytest-mock>=3.0",
 ]
-
-[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
-[tool.hatch.build.targets.wheel]
-packages = ["."]

--- a/databricks/demos/langgraph_genie_agent/tests/test_agent.py
+++ b/databricks/demos/langgraph_genie_agent/tests/test_agent.py
@@ -5,10 +5,8 @@ All tests run without a live Databricks workspace.
 LLM and Genie are mocked at the seams defined in agent.py.
 """
 
-import os
-import json
 import pytest
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock
 
 
 # ---------------------------------------------------------------------------
@@ -75,7 +73,7 @@ class TestGraphConstruction:
         )
         return fake_llm
 
-    def test_graph_has_expected_nodes(self, monkeypatch):
+    def test_graph_has_expected_nodes(self):
         """build_agent graph contains 'assistant' and 'genie_tool' nodes."""
         fake_llm = self._make_fake_llm()
         fake_genie_fn = MagicMock(return_value="some data")
@@ -87,7 +85,7 @@ class TestGraphConstruction:
         assert "assistant" in node_names, f"Expected 'assistant' node, got {node_names}"
         assert "genie_tool" in node_names, f"Expected 'genie_tool' node, got {node_names}"
 
-    def test_graph_compiles_without_error(self, monkeypatch):
+    def test_graph_compiles_without_error(self):
         """build_agent returns a compiled graph (StateGraph.compile succeeds)."""
         fake_llm = self._make_fake_llm()
         fake_genie_fn = MagicMock(return_value="some data")
@@ -105,30 +103,25 @@ class TestGraphConstruction:
 class TestGraphRouting:
     """End-to-end routing through the compiled graph using fake LLM and Genie."""
 
-    def _genie_tool_name(self):
-        """Return the tool name that the agent uses for the Genie tool."""
-        from agent import GENIE_TOOL_NAME
-        return GENIE_TOOL_NAME
-
-    def test_tool_call_path_calls_genie_and_returns_final_answer(self, monkeypatch):
+    def test_tool_call_path_calls_genie_and_returns_final_answer(self):
         """
         When the LLM first responds with a tool_call to the Genie tool and then
         responds with a final plain answer, the compiled graph:
           - calls the Genie function with a string that includes the user question, and
           - returns a final state whose last message content contains the final answer.
         """
-        from langchain_core.messages import AIMessage, ToolMessage, HumanMessage
+        from langchain_core.messages import AIMessage, HumanMessage
         from langchain_core.messages.tool import ToolCall
+
+        from agent import GENIE_TOOL_NAME
 
         user_question = "What were total sales last quarter?"
         genie_result = "Sales were $1.2M last quarter."
         final_answer = "Based on Genie data, sales were $1.2M last quarter."
 
-        tool_name = self._genie_tool_name()
-
         # First LLM call: returns a tool call
         tool_call = ToolCall(
-            name=tool_name,
+            name=GENIE_TOOL_NAME,
             args={"question": user_question},
             id="call-001",
         )
@@ -160,7 +153,7 @@ class TestGraphRouting:
             f"Expected final answer in last message, got: {last_msg.content!r}"
         )
 
-    def test_no_tool_call_path_goes_straight_to_end(self, monkeypatch):
+    def test_no_tool_call_path_goes_straight_to_end(self):
         """
         When the LLM responds with a plain answer (no tool calls), the graph
         goes straight to END without calling Genie.

--- a/databricks/demos/langgraph_genie_agent/tests/test_agent.py
+++ b/databricks/demos/langgraph_genie_agent/tests/test_agent.py
@@ -1,0 +1,211 @@
+"""
+Tests for langgraph_genie_agent.
+
+All tests run without a live Databricks workspace.
+LLM and Genie are mocked at the seams defined in agent.py.
+"""
+
+import os
+import json
+import pytest
+from unittest.mock import MagicMock, patch, call
+
+
+# ---------------------------------------------------------------------------
+# Config validation tests
+# ---------------------------------------------------------------------------
+
+class TestConfigValidation:
+    def test_missing_genie_space_id_raises_with_var_name(self, monkeypatch):
+        """load_config raises ValueError naming GENIE_SPACE_ID when it is absent."""
+        monkeypatch.delenv("GENIE_SPACE_ID", raising=False)
+        monkeypatch.setenv("LLM_ENDPOINT", "databricks-claude-sonnet-4-5")
+
+        from agent import load_config
+        with pytest.raises(ValueError, match="GENIE_SPACE_ID"):
+            load_config()
+
+    def test_missing_llm_endpoint_raises_with_var_name(self, monkeypatch):
+        """load_config raises ValueError naming LLM_ENDPOINT when it is absent."""
+        monkeypatch.setenv("GENIE_SPACE_ID", "space-abc")
+        monkeypatch.delenv("LLM_ENDPOINT", raising=False)
+
+        from agent import load_config
+        with pytest.raises(ValueError, match="LLM_ENDPOINT"):
+            load_config()
+
+    def test_both_missing_raises_with_both_var_names(self, monkeypatch):
+        """load_config raises ValueError listing both missing vars."""
+        monkeypatch.delenv("GENIE_SPACE_ID", raising=False)
+        monkeypatch.delenv("LLM_ENDPOINT", raising=False)
+
+        from agent import load_config
+        with pytest.raises(ValueError) as exc:
+            load_config()
+        msg = str(exc.value)
+        assert "GENIE_SPACE_ID" in msg
+        assert "LLM_ENDPOINT" in msg
+
+    def test_valid_config_returns_dict(self, monkeypatch):
+        """load_config returns a dict with genie_space_id and llm_endpoint when both vars are set."""
+        monkeypatch.setenv("GENIE_SPACE_ID", "space-xyz")
+        monkeypatch.setenv("LLM_ENDPOINT", "databricks-claude-sonnet-4-5")
+
+        from agent import load_config
+        cfg = load_config()
+        assert cfg["genie_space_id"] == "space-xyz"
+        assert cfg["llm_endpoint"] == "databricks-claude-sonnet-4-5"
+
+
+# ---------------------------------------------------------------------------
+# Graph construction tests
+# ---------------------------------------------------------------------------
+
+class TestGraphConstruction:
+    """build_agent returns a compiled LangGraph with expected nodes and edges."""
+
+    def _make_fake_llm(self):
+        """Return a minimal fake ChatModel (not bound to any real endpoint)."""
+        from langchain_core.messages import AIMessage
+        fake_llm = MagicMock()
+        fake_llm.bind_tools = MagicMock(return_value=fake_llm)
+        # Default: return a plain text answer with no tool calls
+        fake_llm.invoke = MagicMock(
+            return_value=AIMessage(content="42 is the answer.")
+        )
+        return fake_llm
+
+    def test_graph_has_expected_nodes(self, monkeypatch):
+        """build_agent graph contains 'assistant' and 'genie_tool' nodes."""
+        fake_llm = self._make_fake_llm()
+        fake_genie_fn = MagicMock(return_value="some data")
+
+        from agent import build_agent
+        graph = build_agent(llm=fake_llm, genie_fn=fake_genie_fn)
+
+        node_names = set(graph.nodes.keys())
+        assert "assistant" in node_names, f"Expected 'assistant' node, got {node_names}"
+        assert "genie_tool" in node_names, f"Expected 'genie_tool' node, got {node_names}"
+
+    def test_graph_compiles_without_error(self, monkeypatch):
+        """build_agent returns a compiled graph (StateGraph.compile succeeds)."""
+        fake_llm = self._make_fake_llm()
+        fake_genie_fn = MagicMock(return_value="some data")
+
+        from agent import build_agent
+        graph = build_agent(llm=fake_llm, genie_fn=fake_genie_fn)
+        # A compiled graph has an 'invoke' method
+        assert callable(getattr(graph, "invoke", None))
+
+
+# ---------------------------------------------------------------------------
+# Full-path routing tests
+# ---------------------------------------------------------------------------
+
+class TestGraphRouting:
+    """End-to-end routing through the compiled graph using fake LLM and Genie."""
+
+    def _genie_tool_name(self):
+        """Return the tool name that the agent uses for the Genie tool."""
+        from agent import GENIE_TOOL_NAME
+        return GENIE_TOOL_NAME
+
+    def test_tool_call_path_calls_genie_and_returns_final_answer(self, monkeypatch):
+        """
+        When the LLM first responds with a tool_call to the Genie tool and then
+        responds with a final plain answer, the compiled graph:
+          - calls the Genie function with a string that includes the user question, and
+          - returns a final state whose last message content contains the final answer.
+        """
+        from langchain_core.messages import AIMessage, ToolMessage, HumanMessage
+        from langchain_core.messages.tool import ToolCall
+
+        user_question = "What were total sales last quarter?"
+        genie_result = "Sales were $1.2M last quarter."
+        final_answer = "Based on Genie data, sales were $1.2M last quarter."
+
+        tool_name = self._genie_tool_name()
+
+        # First LLM call: returns a tool call
+        tool_call = ToolCall(
+            name=tool_name,
+            args={"question": user_question},
+            id="call-001",
+        )
+        first_response = AIMessage(content="", tool_calls=[tool_call])
+        # Second LLM call: returns a final plain answer
+        second_response = AIMessage(content=final_answer)
+
+        fake_llm = MagicMock()
+        fake_llm.bind_tools = MagicMock(return_value=fake_llm)
+        fake_llm.invoke = MagicMock(side_effect=[first_response, second_response])
+
+        fake_genie_fn = MagicMock(return_value=genie_result)
+
+        from agent import build_agent
+        graph = build_agent(llm=fake_llm, genie_fn=fake_genie_fn)
+
+        result = graph.invoke({"messages": [HumanMessage(content=user_question)]})
+
+        # Genie was called
+        assert fake_genie_fn.called, "Genie function was not called"
+        # The argument passed to Genie contains the user question
+        genie_call_arg = fake_genie_fn.call_args[0][0]
+        assert user_question in genie_call_arg, (
+            f"Expected user question in Genie call arg, got: {genie_call_arg!r}"
+        )
+        # Final state contains the final answer
+        last_msg = result["messages"][-1]
+        assert final_answer in last_msg.content, (
+            f"Expected final answer in last message, got: {last_msg.content!r}"
+        )
+
+    def test_no_tool_call_path_goes_straight_to_end(self, monkeypatch):
+        """
+        When the LLM responds with a plain answer (no tool calls), the graph
+        goes straight to END without calling Genie.
+        """
+        from langchain_core.messages import AIMessage, HumanMessage
+
+        final_answer = "The capital of France is Paris."
+
+        fake_llm = MagicMock()
+        fake_llm.bind_tools = MagicMock(return_value=fake_llm)
+        fake_llm.invoke = MagicMock(return_value=AIMessage(content=final_answer))
+
+        fake_genie_fn = MagicMock(return_value="should not be called")
+
+        from agent import build_agent
+        graph = build_agent(llm=fake_llm, genie_fn=fake_genie_fn)
+
+        result = graph.invoke({"messages": [HumanMessage(content="What is the capital of France?")]})
+
+        assert not fake_genie_fn.called, "Genie function should not be called on no-tool path"
+        last_msg = result["messages"][-1]
+        assert final_answer in last_msg.content
+
+
+# ---------------------------------------------------------------------------
+# MLflow setup tests
+# ---------------------------------------------------------------------------
+
+class TestMlflowSetup:
+    def test_setup_tracing_calls_autolog(self, monkeypatch):
+        """setup_tracing calls mlflow.langchain.autolog()."""
+        mock_mlflow = MagicMock()
+        monkeypatch.setattr("agent.mlflow", mock_mlflow)
+
+        from agent import setup_tracing
+        setup_tracing()
+
+        mock_mlflow.langchain.autolog.assert_called_once()
+
+    def test_setup_tracing_sets_experiment(self, monkeypatch):
+        """setup_tracing calls mlflow.set_experiment with the provided or default name."""
+        mock_mlflow = MagicMock()
+        monkeypatch.setattr("agent.mlflow", mock_mlflow)
+
+        from agent import setup_tracing
+        setup_tracing(experiment_name="/my-experiment")
+
+        mock_mlflow.set_experiment.assert_called_once_with("/my-experiment")


### PR DESCRIPTION
Closes #31

## What's new

`databricks/demos/langgraph_genie_agent/` — a LangGraph ReAct agent that answers questions by calling a Databricks Genie space as a tool, backed by a Databricks model serving endpoint, with MLflow 3 tracing via `mlflow.langchain.autolog()`.

- `agent.py` (~240 lines) — config validation, MLflow tracing setup, Genie tool seam (`databricks_ai_bridge.genie.Genie` wrapped in a plain callable), hand-rolled assistant/tool-node graph, CLI entry point
- `tests/test_agent.py` — 10 tests, all green with no live workspace (LLM + Genie mocked at the seams): config validation, graph construction, full-path tool-call routing, no-tool-call routing, MLflow setup
- `README.md` — repo demo conventions: config table, usage, trace viewing, troubleshooting
- `pyproject.toml` — uv-managed; `uv.lock` gitignored because it resolves against the Databricks-internal PyPI proxy

## Verification

- `uv run pytest` — 10/10 passing
- Live end-to-end run against a real workspace: agent called the "Workspace Usage Cost Analysis" Genie space, returned correct top-3 cost drivers, and logged an MLflow trace to `/Users/randy.pitcher@databricks.com/langgraph-genie-agent` (tracking URI `databricks`)
- Two real issues found during the live run are documented in the README troubleshooting table (ambiguous `~/.databrickscfg` profile 401, root-level experiment path failing on Databricks-hosted tracking)

## Notes

- `GenieAgent` from `databricks-langchain` returns a `RunnableLambda` meant for LCEL chains, so the demo wraps the lower-level `Genie` client in a `@tool` function instead — cleaner ReAct loop and trivially mockable
- Follow-up candidates (not in scope): Model Serving deployment, `mlflow.evaluate()` harness

🤖 Generated with [Claude Code](https://claude.com/claude-code)