### PR TITLE
dbt reference: close correctness, security, and hygiene gaps

### DIFF
--- a/databricks/demos/dbt/README.md
+++ b/databricks/demos/dbt/README.md
@@ -72,18 +72,25 @@ marts     cost_daily             cost_by_workspace   cost_by_sku      (tables: a
 - **Effective list price.** Cost uses `pricing.effective_list.default` (resolves list +
   promotional pricing) — the value Databricks documents for calculating cost.
 - **Incremental fact.** `int_usage_priced` is `materialized: incremental` (merge on `record_id`).
-  Incremental runs scan only recent usage with a 3-day lookback so late-arriving corrections
-  (`record_type` retraction / restatement) get re-merged. Full refresh is bounded by the
-  `usage_history_days` var (default 90; pass a smaller value for quick demos).
+  Incremental runs scan only recently-**ingested** usage: the 3-day lookback keys on
+  `ingestion_date`, not `usage_date`, because corrections (`record_type` retraction /
+  restatement) are new rows that carry the *original* usage date — sometimes weeks old —
+  with a fresh ingestion date. A usage-date lookback would silently miss them. Full refresh
+  is bounded by the `usage_history_days` var (default 90; pass a smaller value for quick demos).
 - **`list_cost`, not "spend".** `list_prices` is the published list price; it does **not**
   include account-level discounts, so `list_cost` is a list-price estimate, not invoiced spend.
 - **Account-level usage.** Some usage (storage, network, certain serverless features) has a
   NULL `workspace_id`; `cost_by_workspace` surfaces it as an explicit `(account-level)` bucket
   so it is attributed rather than silently dropped.
+- **Currency-safe rollups.** Every mart carries `currency_code` in its grain — costs are
+  never summed across currencies, so multi-currency accounts get correct numbers.
 - **Tests prove correctness, not just success.** Beyond `not_null`/`unique`/`accepted_values`,
-  two singular tests guard against the classic "green build, NULL costs" failure:
-  `assert_recent_cost_is_positive` (a recent settled day must have positive cost) and
-  `assert_dbu_usage_is_priced` (≤5% of recent DBU usage may be unpriced).
+  every mart has a `dbt_utils.unique_combination_of_columns` test pinning its grain (a
+  fan-out from a bad upstream join fails loudly), and two singular tests guard against the
+  classic "green build, NULL costs" failure: `assert_recent_cost_is_positive` (a recent
+  settled day must have positive cost) and `assert_dbu_usage_is_priced` (≤5% of recent DBU
+  usage may be unpriced). In production, a source-freshness task runs *before* the build,
+  so a stalled `system.billing` pipeline fails the run instead of staying green.
 
 ---
 
@@ -132,12 +139,15 @@ A matching `generate_database_name` override routes models to `default_catalog` 
 
 ### 1. Install dependencies (uv)
 
-This project pins Python via `.python-version` (3.12) and locks dbt deps in `uv.lock`.
+This project pins Python via `.python-version` (3.12). `uv.lock` is intentionally **not**
+committed (see `.gitignore`): on Databricks-managed machines `uv` rewrites registry sources
+to the internal PyPI proxy, which would be wrong for everyone else — so each clone resolves
+against its own registry configuration.
 
 ```bash
 cd databricks/demos/dbt
 uv sync                 # creates .venv with dbt-databricks
-uv run dbt deps         # installs dbt packages (dbt_utils, dbt_expectations, dbt_date)
+uv run dbt deps         # installs dbt packages (dbt_utils, dbt_expectations)
 ```
 
 ### 2. Configure the connection + authenticate (dev = SSO, one time)
@@ -146,7 +156,7 @@ Set the two required connection vars (no in-repo fallback), then log in:
 
 ```bash
 cp template.env .env           # then edit DBT_HOST + DBT_HTTP_PATH
-set -a; source .env; set +a    # dbt 1.12+/Fusion auto-load .env; on 1.10 source it yourself
+set -a; source .env; set +a    # dbt 1.12+/Fusion auto-load .env; this project is on core 1.11, so source it yourself
 
 databricks auth login --profile DEFAULT     # opens a browser for SSO
 ```
@@ -185,8 +195,20 @@ uv run dbt docs generate --target dev --profiles-dir . && uv run dbt docs serve
 This demo also includes a Databricks Asset Bundle (`databricks.yml`) for production operations:
 
 - A managed Unity Catalog volume for production dbt artifacts.
-- A daily serverless workflow job that runs `dbt build -s tag:hourly`, captures the production state artifacts, and regenerates dbt docs.
+- A daily serverless workflow job that checks source freshness, runs `dbt build -s tag:daily`,
+  captures the production state artifacts, and regenerates dbt docs.
 - A Databricks app that serves the generated dbt docs from the volume.
+
+Production runs as a **dedicated service principal** (`run_as` in the prod target), never the
+deploying human, and deploys to a shared workspace path (`/Workspace/Shared/.bundle/...`) so
+production isn't coupled to anyone's home directory. The bundle looks up the SP by display
+name (`dbt_prod_sp` by default); the deploying identity needs CAN_USE on it, and the SP needs
+SELECT on `system.billing`, ownership-level access to the production catalog/schemas, and
+WRITE on the artifacts volume.
+
+Production runs also apply **grants as code**: every `dbt build` grants `SELECT` on the marts
+to `account users` (see `+grants` in `dbt_project.yml`) — consumers get access as part of the
+run, not via manual GRANT statements.
 
 Default production artifact paths:
 
@@ -204,10 +226,13 @@ databricks bundle run dbt_production_daily -t prod
 databricks bundle run dbt_docs -t prod
 ```
 
-The bundle looks up a SQL warehouse named `dbt_wh` by default. Override it when deploying if your workspace uses a different warehouse:
+The bundle looks up a SQL warehouse named `dbt_wh` and a service principal named `dbt_prod_sp`
+by default. Override either when deploying if your workspace uses different names:
 
 ```bash
-databricks bundle deploy -t prod --var="warehouse_id=<warehouse-id>"
+databricks bundle deploy -t prod \
+  --var="warehouse_id=<warehouse-id>" \
+  --var="production_service_principal=<sp-application-id>"
 ```
 
 The docs app derives its `/Volumes/<catalog>/<schema>/<volume>` path from the same
@@ -229,6 +254,22 @@ DBT_DEFAULT_SCHEMA=dbt_rpw_dbt_databricks_reference_pr${PR_NUMBER}_build${RUN_NU
 
 Because the schema name carries the PR number **and** the build number, a re-run after a fix
 builds fully isolated from the previous attempt.
+
+**Slim CI.** The production job captures dbt state (`manifest.json`) to the artifacts volume,
+and the CI workflow downloads it to build **only changed models and their descendants**
+(`dbt build -s state:modified+ --defer --state prod_state`), deferring unmodified parents to
+the production relations. If the state download fails (first run, missing permissions), CI
+falls back to a full build.
+
+**Hygiene.** The per-PR teardown drops the ephemeral schema and is *not* allowed to fail
+silently. Cancelled runs can still leak schemas, so a sweep run-operation exists for that:
+
+```bash
+# dry run by default; pass dry_run: false to actually drop
+uv run dbt run-operation drop_stale_ci_schemas \
+  --args '{prefix: dbt_rpw_dbt_databricks_reference_pr, older_than_days: 3, dry_run: false}' \
+  --target ci --profiles-dir .
+```
 
 ---
 

--- a/databricks/demos/dbt/THE_ONE_TRUE_WAY.md
+++ b/databricks/demos/dbt/THE_ONE_TRUE_WAY.md
@@ -94,16 +94,24 @@ model never collide.
   (`DBT_DEV_USER` → OS `USER` → fallback) instead.
 - **In this repo:** `macros/config/get_clean_username.sql`.
 
-### 6. Every PR gets a disposable, fully-isolated CI schema
+### 6. Every PR gets a disposable, fully-isolated CI schema — and builds only what changed
 CI sets `default_schema` to a name carrying both the PR number and the build number, so a
 re-run after a fix builds completely separately from the previous attempt, and teardown is
-a single `drop schema cascade`.
+a single `drop schema cascade`. Production state captured to a UC volume pays for itself
+here: CI defers to it (`dbt build -s state:modified+ --defer --state ...`) so a PR builds
+only changed models and their descendants, falling back to a full build when state is
+unavailable.
 
 - **In this repo:** `ci/github-actions-dbt-ci.yml.example` + the `drop_schema` run-operation.
 
 ### 7. Least privilege, per environment
 Dev = SSO U2M as the human (no stored secret). CI/prod = dedicated M2M service principals,
-credentials only ever in the runtime's secret store. No shared "god" token.
+credentials only ever in the runtime's secret store. No shared "god" token. Production
+deployments must not run as the deploying human either: the DAB's prod target sets
+`run_as` to a dedicated service principal and deploys to a shared workspace path, so
+production survives people changing teams.
+
+- **In this repo:** `run_as` + `/Workspace/Shared` root path in `databricks.yml` (prod target).
 
 ### 8. Raw/source data is read-only and shared across environments
 Every environment reads the SAME upstream sources; only the outputs are namespaced. Dev
@@ -127,13 +135,20 @@ fear.
 
 ### 11. Automate warehouse hygiene as run-operations
 Dropping stale CI schemas, empty schemas, old relations — make these `dbt run-operation`
-macros, not manual cleanup.
+macros, not manual cleanup. Per-PR teardown must fail loudly (a swallowed drop means
+schemas silently pile up), and a scheduled sweep catches what teardown misses (cancelled
+runs, runner deaths).
 
-- **In this repo:** `macros/operations/drop_schema.sql`.
+- **In this repo:** `macros/operations/drop_schema.sql` (per-PR teardown) +
+  `macros/operations/drop_stale_ci_schemas.sql` (scheduled sweep, dry-run by default).
 
-### 12. Version-control everything; let dbt push docs + lineage into Unity Catalog
+### 12. Version-control everything; let dbt push docs + lineage + grants into Unity Catalog
 All SQL in git; `persist_docs` pushes model/column descriptions into UC so the catalog is
-self-documenting. (Grants-as-code via `+grants`/post-hooks is a natural next addition.)
+self-documenting, and `+grants` makes consumer access part of every production run instead
+of a manual GRANT someone forgets.
+
+- **In this repo:** `+grants` on the marts layer in `dbt_project.yml` — `SELECT` to
+  `account users` in production, an empty (revoke-stray-grants) list everywhere else.
 
 ---
 

--- a/databricks/demos/dbt/ci/github-actions-dbt-ci.yml.example
+++ b/databricks/demos/dbt/ci/github-actions-dbt-ci.yml.example
@@ -9,6 +9,20 @@
 # the `ci_testing` environment, so we just inject a build-scoped schema name. The
 # name carries both the PR number and the run number, so a re-run after a fix
 # builds completely separately from the previous attempt.
+#
+# Slim CI: the production job captures dbt state (manifest.json) to a UC volume.
+# When CI can download it, only changed models and their descendants are built
+# (`state:modified+`), with unmodified parents deferred to production relations
+# (`--defer`). First run / missing state falls back to a full build. The CI
+# service principal needs READ on the artifacts volume and SELECT on the
+# production schemas for deferral to work.
+#
+# Hygiene: the teardown step is NOT allowed to fail silently -- a failed drop is
+# signal that schemas are leaking. Cancelled runs can still leak (the teardown
+# never executes), which is what the `drop_stale_ci_schemas` run-operation is
+# for -- run it on a schedule:
+#   dbt run-operation drop_stale_ci_schemas \
+#     --args '{prefix: dbt_rpw_dbt_databricks_reference_pr, dry_run: false}' --target ci
 # =============================================================================
 name: dbt CI
 
@@ -44,26 +58,50 @@ jobs:
       # DBT_ENV_SECRET_ prefix => dbt masks it in logs and forbids it outside profiles.yml
       DBT_ENV_SECRET_DATABRICKS_CLIENT_SECRET: ${{ secrets.DBT_CLIENT_SECRET }}
 
+      # --- same credentials, Databricks CLI spelling (for the state download) ---
+      DATABRICKS_HOST: ${{ vars.DBT_HOST }}
+      DATABRICKS_CLIENT_ID: ${{ secrets.DBT_CLIENT_ID }}
+      DATABRICKS_CLIENT_SECRET: ${{ secrets.DBT_CLIENT_SECRET }}
+
+      # --- production state location (enables Slim CI) ----------------------
+      # /Volumes/<production_catalog>/<production_artifact_schema>/<production_artifact_volume>/state/latest
+      # -- the same path the production DAB job writes its --target-path to.
+      DBT_PROD_STATE_PATH: ${{ vars.DBT_PROD_STATE_PATH || 'dbfs:/Volumes/fe_randy_pitcher_workspace_catalog/dbt_artifacts/dbt_demo_artifacts/state/latest' }}
+
     steps:
       - uses: actions/checkout@v4
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 
+      - name: Install Databricks CLI
+        uses: databricks/setup-cli@main
+
       - name: Install dependencies
         run: |
           uv sync
           uv run dbt deps --profiles-dir .
 
+      - name: Download production state (enables Slim CI)
+        continue-on-error: true
+        run: |
+          databricks fs cp "$DBT_PROD_STATE_PATH/manifest.json" prod_state/manifest.json
+
       - name: Build & test (isolated CI schema)
         run: |
           echo "Building into schema: $DBT_DEFAULT_SCHEMA"
-          uv run dbt build --target ci --profiles-dir . --vars '{usage_history_days: 7}'
+          if [ -f prod_state/manifest.json ]; then
+            echo "Production manifest found -> Slim CI: build changed models + descendants, defer the rest to prod"
+            uv run dbt build -s state:modified+ --defer --state prod_state \
+              --target ci --profiles-dir . --vars '{usage_history_days: 7}'
+          else
+            echo "No production manifest -> full build"
+            uv run dbt build --target ci --profiles-dir . --vars '{usage_history_days: 7}'
+          fi
 
-      # Optional: tear down the ephemeral schema after the PR build.
-      # Requires a `drop_ci_schema` operation/macro, or use the Databricks CLI:
-      #   databricks schemas delete "${DBT_DEFAULT_CATALOG}.${DBT_DEFAULT_SCHEMA}" --force
+      # Tear down the ephemeral schema. No `|| true`: if the drop fails we want a red
+      # step, because silent failures here mean schemas pile up in the catalog.
       - name: Drop ephemeral CI schema
         if: always()
         run: |
-          uv run dbt run-operation drop_schema --args "{schema: $DBT_DEFAULT_SCHEMA}" --target ci --profiles-dir . || true
+          uv run dbt run-operation drop_schema --args "{schema: $DBT_DEFAULT_SCHEMA}" --target ci --profiles-dir .

--- a/databricks/demos/dbt/databricks.yml
+++ b/databricks/demos/dbt/databricks.yml
@@ -21,6 +21,14 @@ variables:
     description: Serverless or Pro SQL warehouse ID used by the dbt workflow.
     lookup:
       warehouse: dbt_wh
+  production_service_principal:
+    description: >-
+      Application ID of the service principal that owns and runs production (looked up
+      by display name). Production must NOT run as the deploying human -- least
+      privilege, and deploys survive people leaving. Override at deploy time if your
+      SP has a different name: --var="production_service_principal=<application-id>".
+    lookup:
+      service_principal: dbt_prod_sp
 
 targets:
   dev:
@@ -30,6 +38,9 @@ targets:
       production_catalog: analytics_dev
       production_schema: dbt_${workspace.current_user.short_name}
       production_artifact_schema: dbt_artifacts_${workspace.current_user.short_name}
+      # dev runs as the developer; short-circuit the SP lookup so dev deploys
+      # don't require the production service principal to exist.
+      production_service_principal: unused-in-dev
     workspace:
       root_path: /Workspace/Users/${workspace.current_user.userName}/.bundle/${bundle.name}/${bundle.target}
     presets:
@@ -39,8 +50,12 @@ targets:
 
   prod:
     mode: production
+    # Production runs as a dedicated M2M service principal, never the deploying user,
+    # and deploys to a shared path so it isn't coupled to anyone's home directory.
+    run_as:
+      service_principal_name: ${var.production_service_principal}
     workspace:
-      root_path: /Workspace/Users/${workspace.current_user.userName}/.bundle/${bundle.name}/${bundle.target}
+      root_path: /Workspace/Shared/.bundle/${bundle.name}/${bundle.target}
     presets:
       tags:
         env: prod

--- a/databricks/demos/dbt/dbt_project.yml
+++ b/databricks/demos/dbt/dbt_project.yml
@@ -37,22 +37,31 @@ models:
       columns: true
 
     # ---- layer-specific configuration ----
+    # `daily` is the production cadence tag: the DAB job runs `dbt build -s tag:daily`
+    # on a daily schedule. Models without it (e.g. managed_iceberg_examples) are
+    # intentionally outside the production DAG.
     staging:
-      +tags: [staging, hourly]
+      +tags: [staging, daily]
       +schema: staging
       +materialized: view
 
     modeled:
-      +tags: [modeled, hourly]
+      +tags: [modeled, daily]
       +schema: modeled
       +materialized: table
       +auto_liquid_cluster: true
 
     marts:
-      +tags: [mart, hourly]
+      +tags: [mart, daily]
       +schema: mart
       +materialized: table
       +auto_liquid_cluster: true
+      # Grants-as-code: in production, consumers get read access to the marts as part
+      # of every run -- no manual GRANTs. Empty list otherwise, which tells dbt to
+      # actively revoke stray grants on dev/CI sandboxes. The condition checks the CLI
+      # var (how the production job injects it) and falls back to the env var.
+      +grants:
+        select: "{{ ['account users'] if var('deployment_environment', env_var('DBT_DEPLOYMENT_ENVIRONMENT', 'development')) == 'production' else [] }}"
 
     managed_iceberg_examples:
       +materialized: table

--- a/databricks/demos/dbt/docs_app/app.py
+++ b/databricks/demos/dbt/docs_app/app.py
@@ -206,7 +206,7 @@ def _latest_run_summary(client: WorkspaceClient):
         "message": state_message or "",
         "updated_at": updated_at,
         "url": run.run_page_url or "",
-        "logs": _task_run_logs(client, run, "dbt_build_hourly"),
+        "logs": _task_run_logs(client, run, "dbt_build_daily"),
     }
 
 

--- a/databricks/demos/dbt/docs_app/requirements.txt
+++ b/databricks/demos/dbt/docs_app/requirements.txt
@@ -1,1 +1,1 @@
-databricks-sdk
+databricks-sdk>=0.77,<1

--- a/databricks/demos/dbt/macros/operations/drop_stale_ci_schemas.sql
+++ b/databricks/demos/dbt/macros/operations/drop_stale_ci_schemas.sql
@@ -1,0 +1,43 @@
+{#-
+  Drop CI schemas that outlived their PR. The per-PR teardown step in CI normally
+  cleans up after itself, but cancelled runs, runner failures, and auth hiccups leak
+  schemas -- this run-operation sweeps them up on a schedule (or ad hoc):
+
+      # see what would be dropped (default is dry_run: true)
+      dbt run-operation drop_stale_ci_schemas \
+        --args '{prefix: dbt_rpw_dbt_databricks_reference_pr}' --target ci
+
+      # actually drop
+      dbt run-operation drop_stale_ci_schemas \
+        --args '{prefix: dbt_rpw_dbt_databricks_reference_pr, older_than_days: 3, dry_run: false}' \
+        --target ci
+
+  `prefix` is required and must be non-empty -- it is what stops this from matching
+  every schema in the catalog. Staleness comes from information_schema.schemata.created.
+-#}
+{% macro drop_stale_ci_schemas(prefix, older_than_days=3, catalog=none, dry_run=true) %}
+  {%- if not prefix -%}
+    {{ exceptions.raise_compiler_error('drop_stale_ci_schemas requires a non-empty `prefix` -- refusing to match every schema in the catalog.') }}
+  {%- endif -%}
+  {%- set catalog = catalog or var('default_catalog', target.database) -%}
+  {%- if execute -%}
+    {%- set find_stale -%}
+      select schema_name
+      from {{ adapter.quote(catalog) }}.information_schema.schemata
+      where schema_name like '{{ prefix }}%'
+        and created < current_timestamp() - interval {{ older_than_days }} days
+      order by schema_name
+    {%- endset -%}
+    {%- set stale = run_query(find_stale) -%}
+    {%- if stale.rows | length == 0 -%}
+      {{ log('No schemas in ' ~ catalog ~ ' match ' ~ prefix ~ '% older than ' ~ older_than_days ~ ' days.', info=True) }}
+    {%- endif -%}
+    {%- for row in stale.rows -%}
+      {%- if dry_run -%}
+        {{ log('[dry_run] would drop ' ~ catalog ~ '.' ~ row[0] ~ ' (pass dry_run: false to drop)', info=True) }}
+      {%- else -%}
+        {{ drop_schema(row[0], catalog) }}
+      {%- endif -%}
+    {%- endfor -%}
+  {%- endif -%}
+{% endmacro %}

--- a/databricks/demos/dbt/models/managed_iceberg_examples/_managed_iceberg__models.yml
+++ b/databricks/demos/dbt/models/managed_iceberg_examples/_managed_iceberg__models.yml
@@ -1,0 +1,10 @@
+version: 2
+
+# These two models exist purely to demonstrate managed Iceberg table configuration
+# (format-version 2 vs 3). They are intentionally untagged, so they are OUTSIDE the
+# production DAG (`dbt build -s tag:daily` never selects them) and have no data tests.
+models:
+  - name: v2_iceberg_table
+    description: "Demo: managed Iceberg table pinned to format-version 2 via a model-level tblproperties override."
+  - name: v3_iceberg_table
+    description: "Demo: managed Iceberg table using the project default format-version 3."

--- a/databricks/demos/dbt/models/marts/finance/_finance__models.yml
+++ b/databricks/demos/dbt/models/marts/finance/_finance__models.yml
@@ -2,13 +2,17 @@ version: 2
 
 models:
   - name: cost_daily
-    description: "Daily list cost and usage by cloud -- the headline cost-monitoring rollup."
+    description: "Daily list cost and usage by cloud -- the headline cost-monitoring rollup. Grain: one row per usage_date + cloud + currency_code."
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns: [usage_date, cloud, currency_code]
     columns:
       - name: usage_date
         data_tests:
           - not_null
       - name: list_cost
-        description: "Total daily list cost (not invoiced spend)."
+        description: "Total daily list cost (not invoiced spend), expressed in `currency_code`."
         data_tests:
           - dbt_expectations.expect_column_values_to_be_between:
               arguments:
@@ -18,29 +22,47 @@ models:
                 severity: warn
 
   - name: cost_by_workspace
-    description: "Daily list cost by workspace."
+    description: "Daily list cost by workspace. Grain: one row per workspace_id + usage_date + cloud + currency_code."
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns: [workspace_id, usage_date, cloud, currency_code]
     columns:
       - name: workspace_id
+        description: "Workspace id, or '(account-level)' for usage billed at the account rather than a workspace."
         data_tests:
           - not_null
 
   - name: cost_by_sku
-    description: "Daily list cost by SKU and billing_origin_product."
+    description: "Daily list cost by SKU and billing_origin_product. Grain: one row per sku_name + billing_origin_product + usage_unit + usage_date + cloud + currency_code."
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns: [sku_name, billing_origin_product, usage_unit, usage_date, cloud, currency_code]
     columns:
       - name: sku_name
         data_tests:
           - not_null
 
   - name: cost_by_product
-    description: "Daily list cost by Databricks product (Jobs, SQL, Model Serving, DLT, ...)."
+    description: "Daily list cost by Databricks product (Jobs, SQL, Model Serving, DLT, ...). Grain: one row per billing_origin_product + usage_date + cloud + currency_code."
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns: [billing_origin_product, usage_date, cloud, currency_code]
     columns:
       - name: billing_origin_product
         data_tests:
           - not_null
 
   - name: cost_by_tag
-    description: "Showback: daily list cost attributed to the `Owner` custom tag."
+    description: "Showback: daily list cost attributed to the `Owner` custom tag. Grain: one row per owner + usage_date + cloud + currency_code."
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns: [owner, usage_date, cloud, currency_code]
     columns:
       - name: owner
+        description: "Value of the `Owner` custom tag, or '(untagged)' -- untagged rows are cost you can't yet attribute."
         data_tests:
           - not_null

--- a/databricks/demos/dbt/models/marts/finance/cost_by_product.sql
+++ b/databricks/demos/dbt/models/marts/finance/cost_by_product.sql
@@ -3,8 +3,9 @@ select
     billing_origin_product,
     usage_date,
     cloud,
+    currency_code,
     count(distinct workspace_id) as n_workspaces,
     sum(usage_quantity)          as usage_quantity,
     sum(list_cost)               as list_cost
 from {{ ref('int_usage_priced') }}
-group by billing_origin_product, usage_date, cloud
+group by billing_origin_product, usage_date, cloud, currency_code

--- a/databricks/demos/dbt/models/marts/finance/cost_by_sku.sql
+++ b/databricks/demos/dbt/models/marts/finance/cost_by_sku.sql
@@ -5,7 +5,8 @@ select
     usage_unit,
     usage_date,
     cloud,
+    currency_code,
     sum(usage_quantity) as usage_quantity,
     sum(list_cost)      as list_cost
 from {{ ref('int_usage_priced') }}
-group by sku_name, billing_origin_product, usage_unit, usage_date, cloud
+group by sku_name, billing_origin_product, usage_unit, usage_date, cloud, currency_code

--- a/databricks/demos/dbt/models/marts/finance/cost_by_tag.sql
+++ b/databricks/demos/dbt/models/marts/finance/cost_by_tag.sql
@@ -9,6 +9,7 @@ with tagged as (
         coalesce(custom_tags['Owner'], '(untagged)') as owner,
         usage_date,
         cloud,
+        currency_code,
         usage_quantity,
         list_cost
     from {{ ref('int_usage_priced') }}
@@ -18,7 +19,8 @@ select
     owner,
     usage_date,
     cloud,
+    currency_code,
     sum(usage_quantity) as usage_quantity,
     sum(list_cost)      as list_cost
 from tagged
-group by owner, usage_date, cloud
+group by owner, usage_date, cloud, currency_code

--- a/databricks/demos/dbt/models/modeled/int_usage_priced.sql
+++ b/databricks/demos/dbt/models/modeled/int_usage_priced.sql
@@ -13,9 +13,14 @@
   system.billing.usage is append-only and continuously updated, so a full rebuild
   every run would be wasteful. Instead:
     * full refresh / first run -> bounded to the last `usage_history_days` days
-    * incremental runs          -> scan only recent usage, with a lookback window so
-                                    late-arriving corrections / restatements get
-                                    re-merged on record_id.
+    * incremental runs          -> scan only recently-INGESTED usage, with a lookback
+                                    window keyed on ingestion_date.
+
+  Why ingestion_date and not usage_date: corrections (record_type RETRACTION /
+  RESTATEMENT) are new rows that carry the ORIGINAL usage_date -- which can be weeks
+  old -- with a fresh ingestion_date. A usage_date lookback would silently miss any
+  correction older than the window; an ingestion_date lookback catches them all.
+  The usage_date filter below is kept purely as a partition-pruning history bound.
 
   Output grain: one row per usage record, enriched with the effective list price and
   `list_cost` (= usage_quantity * effective list price). This is LIST price, NOT the
@@ -31,8 +36,8 @@ with usage as (
     where usage_date >= current_date() - interval {{ history_days }} days
 
     {% if is_incremental() %}
-    and usage_date >= (
-        select coalesce(max(usage_date), date '1900-01-01') - interval {{ lookback_days }} days
+    and ingestion_date >= (
+        select coalesce(max(ingestion_date), date '1900-01-01') - interval {{ lookback_days }} days
         from {{ this }}
     )
     {% endif %}

--- a/databricks/demos/dbt/models/staging/system_billing/_system_billing__models.yml
+++ b/databricks/demos/dbt/models/staging/system_billing/_system_billing__models.yml
@@ -1,0 +1,35 @@
+version: 2
+
+# Staging models are thin views over the FULL system tables, so data tests here would
+# scan unbounded history on every run. Descriptions live here (and are pushed into
+# Unity Catalog via persist_docs); data tests live downstream on the date-bounded
+# incremental model `int_usage_priced`.
+models:
+  - name: stg_billing__usage
+    description: >
+      1:1 cleaned view over system.billing.usage: renames nothing, flattens the
+      usage_metadata / identity_metadata / product_features structs into columns,
+      and keeps record_type so corrections (RETRACTION / RESTATEMENT) net out when
+      usage_quantity is summed.
+    columns:
+      - name: record_id
+        description: "Unique ID for this usage record."
+      - name: record_type
+        description: "ORIGINAL | RETRACTION | RESTATEMENT. Corrections are new rows carrying the original usage_date with a fresh ingestion_date."
+      - name: usage_quantity
+        description: "Number of units (e.g. DBUs) consumed for this record. Sum across record types to net out corrections."
+      - name: ingestion_date
+        description: "Date the record landed in system.billing.usage. The incremental lookback in int_usage_priced keys on this, NOT usage_date, so late corrections are never missed."
+
+  - name: stg_billing__list_prices
+    description: >
+      1:1 cleaned view over system.billing.list_prices: unpacks the pricing struct into
+      list_price and effective_list_price. Use effective_list_price downstream -- it is
+      the value Databricks documents for calculating cost.
+    columns:
+      - name: effective_list_price
+        description: "pricing.effective_list.default: resolves list + promotional pricing; the documented value for cost calculation."
+      - name: price_start_time
+        description: "Start of the effective-dated price window (inclusive)."
+      - name: price_end_time
+        description: "End of the effective-dated price window (exclusive); NULL for the current price."

--- a/databricks/demos/dbt/pyproject.toml
+++ b/databricks/demos/dbt/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "dbt"
+name = "rpw-dbt-databricks-reference"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [

--- a/databricks/demos/dbt/resources/dbt_production.job.yml
+++ b/databricks/demos/dbt/resources/dbt_production.job.yml
@@ -2,12 +2,23 @@ resources:
   jobs:
     dbt_production_daily:
       name: rpw-dbt-databricks-reference Production Daily
-      description: Builds the hourly-tagged reference models, captures production state, and regenerates docs.
+      description: Checks source freshness, builds the daily-tagged reference models, captures production state, and regenerates docs.
+      permissions:
+        - group_name: users
+          level: CAN_VIEW
+        # Setting ANY permissions here replaces the grant the app resource would
+        # otherwise add for itself -- so re-grant the docs app's service principal
+        # explicitly (bundle validate warns about exactly this).
+        - service_principal_name: ${resources.apps.dbt_docs.service_principal_client_id}
+          level: CAN_VIEW
       schedule:
         quartz_cron_expression: "0 0 6 * * ?"
         timezone_id: UTC
       tasks:
-        - task_key: dbt_build_hourly
+        # Source freshness runs FIRST and fails the run when system.billing is stale.
+        # The singular correctness tests anchor on max(usage_date) -- a relative check --
+        # so without this absolute check a stalled pipeline could stay green for weeks.
+        - task_key: dbt_source_freshness
           dbt_task:
             project_directory: ..
             source: WORKSPACE
@@ -17,13 +28,28 @@ resources:
             commands:
               - dbt deps
               - >-
-                dbt build -s tag:hourly
+                dbt source freshness
+                --vars '{"deployment_environment":"production","default_catalog":"${var.production_catalog}","default_schema":"${var.production_schema}"}'
+          environment_key: dbt
+        - task_key: dbt_build_daily
+          depends_on:
+            - task_key: dbt_source_freshness
+          dbt_task:
+            project_directory: ..
+            source: WORKSPACE
+            warehouse_id: ${var.warehouse_id}
+            catalog: ${var.production_catalog}
+            schema: ${var.production_schema}
+            commands:
+              - dbt deps
+              - >-
+                dbt build -s tag:daily
                 --vars '{"deployment_environment":"production","default_catalog":"${var.production_catalog}","default_schema":"${var.production_schema}"}'
                 --target-path /Volumes/${var.production_catalog}/${var.production_artifact_schema}/${var.production_artifact_volume}/state/latest
           environment_key: dbt
         - task_key: dbt_generate_docs
           depends_on:
-            - task_key: dbt_build_hourly
+            - task_key: dbt_build_daily
           run_if: ALL_DONE
           dbt_task:
             project_directory: ..

--- a/databricks/demos/dbt/template.env
+++ b/databricks/demos/dbt/template.env
@@ -2,7 +2,8 @@
 #
 # Loading:
 #   * dbt Core v1.12+ / dbt Fusion auto-load `.env` from the current directory.
-#   * On older dbt (this project is on 1.10), load it yourself first:
+#   * On older dbt (this project pins dbt-core 1.11 via dbt-databricks), load it
+#     yourself first:
 #         set -a; source .env; set +a
 #
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Review of the dbt reference implementation surfaced one real correctness bug, two principle-vs-implementation mismatches, and assorted doc drift. This PR closes all of it.

## Correctness
- **Incremental lookback now keys on `ingestion_date`, not `usage_date`.** Billing corrections (`RETRACTION`/`RESTATEMENT`) are new rows carrying the *original* usage_date — often weeks old — with a fresh ingestion_date. The old predicate silently dropped any correction older than 3 days until a full refresh.
- **Currency-safe marts**: `cost_by_sku`, `cost_by_product`, `cost_by_tag` now carry `currency_code` in their grain instead of summing across currencies.
- **Grain tests**: every mart gets `dbt_utils.unique_combination_of_columns` (dbt_utils was a declared dep that nothing used).
- **Production source freshness**: the daily job runs `dbt source freshness` before the build, so a stalled `system.billing` pipeline fails loudly — the singular tests only anchor on relative dates and would stay green.

## Least privilege
- Prod DAB target sets `run_as` to a dedicated service principal (looked up as `dbt_prod_sp`) and deploys to `/Workspace/Shared` instead of the deployer's home. Job gets explicit permissions (users CAN_VIEW + the docs app SP, per `bundle validate`'s guidance).
- Grants-as-code: marts grant `SELECT` to `account users` in production only; dev/CI render an empty (revoke-stray) grant list. Verified in the manifest for both environments.

## CI/CD
- **Slim CI**: the workflow downloads the production manifest from the artifacts volume and builds `state:modified+ --defer`, falling back to a full build when state is unavailable — the captured prod state finally has a consumer.
- Teardown no longer swallows failures (`|| true` removed), and a new `drop_stale_ci_schemas` run-operation (dry-run by default) sweeps schemas leaked by cancelled runs.

## Docs / consistency
- `hourly` tag → `daily` to match the actual cadence (job task_key + docs app reference updated).
- Staging and iceberg models documented; staging yml explains why data tests live downstream on the bounded incremental model.
- README fixed: `uv.lock` is intentionally not committed (was claimed committed), `dbt_date` removed from the package list (never installed), dbt version corrected to core 1.11.
- THE_ONE_TRUE_WAY principles 6/7/11/12 updated to match the implementation.
- `pyproject` renamed from `dbt`; docs app pins `databricks-sdk`.

## Verification
- `dbt parse` across all three deployment environments.
- Full dev build against the live workspace: **28/28 PASS** including the new grain tests.
- Second run of `int_usage_priced` exercises the new incremental predicate: PASS.
- `bundle validate -t dev`: clean. `-t prod` resolves everything except the `dbt_prod_sp` lookup.

## ⚠️ Follow-up required before the next prod deploy
A service principal named `dbt_prod_sp` must exist (creation was permission-blocked for the agent):
```
databricks service-principals create --display-name dbt_prod_sp
```
or override at deploy time with `--var="production_service_principal=<application-id>"`. The SP also needs CAN_USE on `dbt_wh`, catalog privileges on `fe_randy_pitcher_workspace_catalog`, SELECT on `system.billing`, and WRITE on the artifacts volume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)