### PR TITLE
experiment: coding agent inference over Unity AI Gateway (SSO)

### DIFF
--- a/experiments/coding_agent_inference_unity_ai_gateway/.env.example
+++ b/experiments/coding_agent_inference_unity_ai_gateway/.env.example
@@ -1,0 +1,8 @@
+# Workspace URL, e.g. https://my-workspace.cloud.databricks.com (optional if your CLI profile already defines it)
+DATABRICKS_HOST=
+
+# Databricks CLI OAuth profile used to mint short-lived tokens (create one with: databricks auth login --host <host>)
+DATABRICKS_CONFIG_PROFILE=DEFAULT
+
+# Model to call, as a three-part Unity Catalog identifier (catalog.schema.model) — legacy single-string names are refused
+RPW_MODEL=system.ai.claude-sonnet-4-6

--- a/experiments/coding_agent_inference_unity_ai_gateway/.gitignore
+++ b/experiments/coding_agent_inference_unity_ai_gateway/.gitignore
@@ -1,0 +1,13 @@
+# Environment / secrets (commit .env.example only)
+.env
+
+# Python
+.venv/
+__pycache__/
+*.py[cod]
+
+# uv lockfile (machine-specific registry config; do not commit)
+uv.lock
+
+# NOTE: results/*.json is intentionally NOT ignored — captured results are the
+# point of this experiment.

--- a/experiments/coding_agent_inference_unity_ai_gateway/Makefile
+++ b/experiments/coding_agent_inference_unity_ai_gateway/Makefile
@@ -1,0 +1,10 @@
+.DEFAULT_GOAL := help
+
+.PHONY: help verify
+
+help: ## List available targets
+	@echo "Targets:"
+	@grep -E '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-10s %s\n", $$1, $$2}'
+
+verify: ## Prove SSO auth end-to-end with one real chat completion (HTTP 200 required)
+	uv run python scripts/verify.py

--- a/experiments/coding_agent_inference_unity_ai_gateway/README.md
+++ b/experiments/coding_agent_inference_unity_ai_gateway/README.md
@@ -1,0 +1,211 @@
+# Coding Agent Inference over Unity AI Gateway (SSO)
+
+## Overview
+
+This experiment establishes — with hard testing against a real workspace — which
+[Unity AI Gateway](https://docs.databricks.com/aws/en/ai-gateway) governance
+capabilities actually work today for coding-agent inference. The scenario: an
+organization standardizes on Databricks Model Serving as the inference backend
+for all coding assistants (Claude Code, Claude Desktop, Codex, OpenCode), with
+engineers onboarding through [ucode](https://github.com/databricks/ucode) and
+the gateway. The field keeps hitting contradictions between what was announced
+and what is enforceable in a real workspace, so the first deliverable is the
+✅/❌ capabilities matrix below — not a demo.
+
+The ground rules ("the One True Way"):
+
+- **SSO/OAuth only, zero PATs** — every token is short-lived and minted by
+  `bin/get-databricks-token.sh`; anything starting with `dapi` is refused.
+- **Three-part Unity Catalog model identifiers** (`system.ai.<model>`), never
+  legacy single-string endpoint names.
+- **Prove it with a real HTTP 200** — `make verify` makes one live request.
+
+This is a **client-side config layer** — a companion to a server-side gateway
+app, not a replacement. Phase 2 (a polished copy/paste demo) is intentionally
+out of scope until the matrix says what deserves demoing: anything ❌ or
+Preview-gated below is documented as such, never demoed as if it works.
+
+## Results Matrix
+
+Tested 2026-07-09 against one real AWS workspace **without** the gated
+"Foundation Model Permissions" Preview enrolled. ❓ = not yet resolved
+empirically — each row's script prints exactly what it needs to run fully
+(most ❓ rows need a second test principal and an explicit mutation opt-in).
+Machine-readable results live in [`results/matrix_results.json`](./results/matrix_results.json),
+written by the scripts in [`scripts/governance/`](./scripts/governance/).
+
+| # | Capability | Claim / Source | OOTB (GA) | Gated Preview | Notes |
+|---|---|---|---|---|---|
+| 1 | Query model via gateway with SSO/OAuth (no PAT) | Core goal | ✅ | — | HTTP 200 with a short-lived OAuth token on `/ai-gateway/mlflow/v1/chat/completions` |
+| 2 | Three-part UC identifier (`system.ai.<model>`) resolves | [Unity AI Gateway](https://docs.databricks.com/aws/en/ai-gateway) | ✅ | — | **Gateway routes only** — see Key Findings; `/serving-endpoints/*` 404s on three-part ids |
+| 3 | GRANT/REVOKE EXECUTE on model service enforced | [Govern model services](https://docs.databricks.com/aws/en/ai-gateway/govern-model-services) | ❓ | ❓ | Suspected gated behind the "Foundation Model Permissions" account-console Preview; needs `TEST_PRINCIPAL` + mutation opt-in |
+| 4 | DENY EXECUTE on a model actually blocks inference | [Govern model services](https://docs.databricks.com/aws/en/ai-gateway/govern-model-services) | ❓ | ❓ | Needs a second principal profile to query as the denied user |
+| 5 | DENY on model + GRANT on gateway → user can still infer | Definer's-rights invocation per docs | ❓ | ❓ | Expected "yes" (owner needs EXECUTE, caller may not) — confirm empirically |
+| 6 | Revoke gateway access → no fallback to old endpoints | Field sandbox observation | ❓ | ❓ | Script reproduces the reported silent-fallback leak once a second principal is configured |
+| 7 | Per-user alerting on spend threshold | [Budgets](https://docs.databricks.com/aws/en/admin/account-settings/budgets) | ✅ | — | Usage tracking ON; note there is no "alert at $X per user" field on the endpoint — alerting is composed from usage system tables |
+| 8 | Per-user hard cap (block at budget) | Conference-talk claim | ❌ | ❓ | Only alert-style surfaces and per-user *rate* limits exist; no spend-denominated block-at-budget knob found on the endpoint |
+| 9 | Usage tracking per user / per agent (`user_agent`) | [Usage system tables](https://docs.databricks.com/aws/en/ai-gateway/configure-ai-gateway-endpoints#usage-tracking) | ❓ | — | Per-**user** attribution proven (`system.serving.endpoint_usage.requester` populated); per-**agent** columns (`usage_context`, `client_request_id`) exist but were empty in all sampled rows; marker probe pending ingestion lag |
+| 10 | Guardrails (PII / injection / unsafe) on service | [Configure AI Gateway](https://docs.databricks.com/aws/en/ai-gateway/configure-ai-gateway-endpoints) | ❓ | ❓ | No guardrails configured on the probed endpoint; documented knobs are `pii`, `safety`, `valid_topics`, `invalid_keywords` — no dedicated prompt-injection filter in the schema |
+
+## Key Findings
+
+### The route split is the headline: three-part ids resolve ONLY on `/ai-gateway/*`
+
+Live-tested with the same OAuth token, same workspace, same minute:
+
+| Route | `system.ai.claude-sonnet-4-6` | legacy `databricks-claude-sonnet-4-6` |
+|---|---|---|
+| `POST /ai-gateway/mlflow/v1/chat/completions` | **200** | 200 |
+| `POST /ai-gateway/anthropic/v1/messages` | **200** | — |
+| `POST /serving-endpoints/chat/completions` | 404 `ENDPOINT_NOT_FOUND` | 200 |
+| `POST /serving-endpoints/anthropic/v1/messages` | 404 | 200 |
+| `POST /serving-endpoints/<model>/invocations` | 404 `ENDPOINT_NOT_FOUND` | 200 |
+
+The classic serving routes resolve the `model` value as an **endpoint name**;
+the Unity AI Gateway routes resolve it in the model catalog. The error shapes
+differ tellingly: the gateway returns a model-level `NOT_FOUND: '<id>' does
+not exist`, the classic routes an endpoint-level `ENDPOINT_NOT_FOUND`. Every
+config template in [`configs/`](./configs/) therefore points at `/ai-gateway/*`.
+
+### `system.ai` names drop the `databricks-` prefix
+
+`system.ai.databricks-claude-sonnet-4-6` does **not** exist —
+`system.ai.claude-sonnet-4-6` does. The legacy endpoint
+`databricks-claude-sonnet-4-6` maps to `system.ai.claude-sonnet-4-6`, so a
+mechanical "prepend `system.ai.`" migration produces names that 404. The
+`/ai-gateway/codex/v1` route confirmed the mapping from the other side: given
+the three-part id, its error message named the legacy endpoint.
+
+### SSO/OAuth works end-to-end with zero PATs
+
+The whole flow — `databricks auth login` → short-lived OAuth token from the
+CLI → Bearer header → 200 — works on both route families. No PAT was created
+at any point, and everything in this experiment refuses `dapi` tokens on sight.
+
+### Hard per-user budget caps do not exist on the endpoint today
+
+The endpoint's `ai_gateway` block exposes usage tracking and per-user *rate*
+limits (requests per time window), but no spend-denominated block-at-budget
+field. Per-user spend **alerting** is real but composed: usage tracking feeds
+`system.serving.endpoint_usage`, and alerts/budgets are built on top of the
+system tables, not set as a single endpoint field.
+
+### Per-agent usage attribution requires caller cooperation (and patience)
+
+`system.serving.endpoint_usage` proves per-user attribution out of the box
+(`requester` is populated). The per-agent columns (`usage_context`,
+`client_request_id`) were null/empty in every sampled row — they populate only
+when callers send the metadata, and system-table ingestion lag exceeds a
+single script run. Script 09 sends a distinctive marker in both `User-Agent`
+and `usage_context`; re-run it later to check whether the marker landed.
+
+### The Codex Responses route exists but rejected a Claude model
+
+`POST /ai-gateway/codex/v1/responses` is live, but returned
+`400 — Responses API passthrough is not supported` for the Claude model
+tested. Codex CLI works today via the OpenAI-compatible
+`/ai-gateway/mlflow/v1` base with `wire_api = "chat"`.
+
+## Prerequisites
+
+- [Databricks CLI](https://docs.databricks.com/aws/en/dev-tools/cli/install) v0.218+ (OAuth-capable), authenticated with `databricks auth login --host https://<your-workspace>` — **not** a PAT
+- [uv](https://docs.astral.sh/uv/) (Python package manager)
+- A workspace where Unity AI Gateway model services are provisioned (run `make verify` to find out — that's the point)
+- Optional, for the permission-enforcement rows (3–6): a second test principal (`TEST_PRINCIPAL`), a CLI profile authenticated as that principal (`TEST_PRINCIPAL_PROFILE`), and admin rights to grant/deny
+- Optional: [ucode](https://github.com/databricks/ucode) — the happy-path setup tool this experiment prefers wherever it covers an agent
+
+## Setup
+
+```bash
+cd experiments/coding_agent_inference_unity_ai_gateway
+cp .env.example .env   # set DATABRICKS_HOST / DATABRICKS_CONFIG_PROFILE / RPW_MODEL
+uv sync
+```
+
+If your machine routes package installs through a private registry proxy, set
+it generically (`UV_INDEX_URL` / `PIP_INDEX_URL`, `npm config set registry`)
+— and do not commit lockfiles that pin a private proxy URL into shared repos.
+The bundled skill's `preflight` probes registry reachability for you.
+
+## Running the Tests
+
+One real request proving SSO auth + identifier resolution end-to-end:
+
+```bash
+make verify          # tries /ai-gateway first, prints every route's response
+```
+
+Fill the matrix (each script records its row into `results/matrix_results.json`):
+
+```bash
+uv run python scripts/governance/01_query_via_gateway_sso.py
+uv run python scripts/governance/02_three_part_identifier_resolves.py
+uv run python scripts/governance/07_per_user_spend_alerting.py
+uv run python scripts/governance/08_per_user_hard_cap.py
+uv run python scripts/governance/09_usage_tracking_per_user_agent.py
+```
+
+The permission-enforcement rows mutate grants/permissions and are therefore
+double-gated — they dry-run with instructions until you opt in:
+
+```bash
+export TEST_PRINCIPAL="test-user@your-org.com"
+export TEST_PRINCIPAL_PROFILE="test-user-profile"   # profile authed AS that user
+export ALLOW_ENDPOINT_MUTATION=1                    # explicit mutation opt-in
+uv run python scripts/governance/03_grant_revoke_execute_enforced.py
+uv run python scripts/governance/04_deny_execute_blocks_inference.py
+uv run python scripts/governance/05_deny_model_grant_gateway.py
+uv run python scripts/governance/06_revoke_gateway_no_fallback.py
+uv run python scripts/governance/10_guardrails_pii_injection_unsafe.py
+```
+
+Run rows twice — once without and once with the gated **Foundation Model
+Permissions** Preview enrolled (account console → Previews) — to fill both
+matrix columns. Every script is idempotent and restores permissions in a
+`finally` block.
+
+## Configuring your coding agents
+
+The documented happy path is `ucode <agent>` (covers Claude Code, Codex,
+OpenCode). The escape-hatch templates — required for Claude Desktop, useful
+everywhere ucode is unavailable — live in [`configs/`](./configs/README.md),
+all pointing at the tested `/ai-gateway/*` routes with three-part ids and the
+SSO token helper. A self-service agent skill that drives the whole setup
+(preflight → ucode-or-template → verify → locked-down-registry handling) is
+bundled in [`skill/`](./skill/SKILL.md).
+
+### MDM / fleet rollout notes
+
+- Everything here is file-based (settings JSON/TOML + a POSIX/PowerShell/cmd
+  token helper), so it distributes cleanly via MDM or dotfile tooling; the
+  helper needs no per-user secrets, only a completed `databricks auth login`.
+- Prefer helper-based auth (Claude Code's `apiKeyHelper`) over shell-export
+  tokens in fleet setups — exported tokens expire after ~1 hour and strand
+  long-lived agent sessions (details in [`configs/README.md`](./configs/README.md)).
+- The gateway is evolving quickly; pin your rollout to `make verify` passing
+  per workspace rather than to any assumption in this README.
+
+## Project Structure
+
+```
+coding_agent_inference_unity_ai_gateway/
+├── Makefile                      # `make verify` — one real SSO request
+├── pyproject.toml                # uv-managed; databricks-sdk + requests
+├── .env.example                  # DATABRICKS_HOST / PROFILE / RPW_MODEL
+├── bin/
+│   ├── get-databricks-token.sh   # SSO OAuth token helper (refuses PATs)
+│   ├── get-databricks-token.ps1
+│   └── get-databricks-token.cmd
+├── configs/                      # per-agent escape-hatch templates + README
+│   ├── claude-code.settings.json
+│   ├── claude-desktop.md / claude-desktop.mcp.json
+│   ├── codex.config.toml
+│   └── opencode.json
+├── scripts/
+│   ├── _common.py                # token/host/model resolution, routed chat_completion, record_result
+│   ├── verify.py                 # the `make verify` implementation
+│   └── governance/               # one script per matrix row (01–10) + _gov_common.py
+├── skill/                        # bundled agent skill (SKILL.md + setup_helper.sh)
+└── results/
+    └── matrix_results.json       # machine-readable matrix, written by the scripts
+```

--- a/experiments/coding_agent_inference_unity_ai_gateway/bin/get-databricks-token.cmd
+++ b/experiments/coding_agent_inference_unity_ai_gateway/bin/get-databricks-token.cmd
@@ -1,0 +1,20 @@
+@echo off
+rem get-databricks-token.cmd — mint a short-lived Databricks OAuth access token.
+rem
+rem SSO/OAuth ONLY. Never emits, accepts, or falls back to a static PAT (dapi...).
+rem Delegates to the PowerShell variant so all three helpers share one behavior.
+rem
+rem Inputs (environment):
+rem   DATABRICKS_CONFIG_PROFILE  CLI profile to mint the token with (default: DEFAULT)
+rem   DATABRICKS_HOST            optional workspace URL; validated against the profile
+rem
+rem Output: the access token, alone, on stdout. All diagnostics go to stderr.
+
+where powershell >nul 2>&1
+if errorlevel 1 (
+    echo error: PowerShell is required by this helper and was not found on PATH. 1>&2
+    exit /b 1
+)
+
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0get-databricks-token.ps1"
+exit /b %ERRORLEVEL%

--- a/experiments/coding_agent_inference_unity_ai_gateway/bin/get-databricks-token.ps1
+++ b/experiments/coding_agent_inference_unity_ai_gateway/bin/get-databricks-token.ps1
@@ -1,0 +1,58 @@
+# get-databricks-token.ps1 — mint a short-lived Databricks OAuth access token.
+#
+# SSO/OAuth ONLY. This helper never emits, accepts, or falls back to a static
+# personal access token (dapi...). If the resolved credential looks like a PAT,
+# it refuses.
+#
+# Inputs (environment):
+#   DATABRICKS_CONFIG_PROFILE  CLI profile to mint the token with (default: DEFAULT)
+#   DATABRICKS_HOST            optional workspace URL; validated against the profile
+#
+# Output: the access token, alone, on stdout. All diagnostics go to stderr.
+
+$ErrorActionPreference = "Stop"
+
+$ProfileName = if ($env:DATABRICKS_CONFIG_PROFILE) { $env:DATABRICKS_CONFIG_PROFILE } else { "DEFAULT" }
+
+if (-not (Get-Command databricks -ErrorAction SilentlyContinue)) {
+    [Console]::Error.WriteLine("error: 'databricks' CLI not found on PATH.")
+    [Console]::Error.WriteLine("Install it (https://docs.databricks.com/dev-tools/cli/install.html), then authenticate with:")
+    [Console]::Error.WriteLine("  databricks auth login --host https://<your-workspace> --profile $ProfileName")
+    exit 1
+}
+
+$cliArgs = @("auth", "token", "--profile", $ProfileName, "-o", "json")
+if ($env:DATABRICKS_HOST) {
+    $cliArgs += @("--host", $env:DATABRICKS_HOST)
+}
+
+$output = & databricks @cliArgs 2>&1
+if ($LASTEXITCODE -ne 0) {
+    [Console]::Error.WriteLine("error: could not mint an OAuth token for profile '$ProfileName'.")
+    [Console]::Error.WriteLine(($output | Out-String).Trim())
+    [Console]::Error.WriteLine("Authenticate with: databricks auth login --host https://<your-workspace> --profile $ProfileName")
+    exit 1
+}
+
+try {
+    $token = (($output | Out-String) | ConvertFrom-Json).access_token
+} catch {
+    $token = $null
+}
+
+if (-not $token) {
+    [Console]::Error.WriteLine("error: 'databricks auth token' returned no access_token for profile '$ProfileName'.")
+    [Console]::Error.WriteLine(($output | Out-String).Trim())
+    [Console]::Error.WriteLine("This usually means the profile is not OAuth-authenticated. Run:")
+    [Console]::Error.WriteLine("  databricks auth login --host https://<your-workspace> --profile $ProfileName")
+    exit 1
+}
+
+if ($token.StartsWith("dapi")) {
+    [Console]::Error.WriteLine("error: resolved credential looks like a static personal access token (dapi...).")
+    [Console]::Error.WriteLine("This experiment is SSO-only — PATs are refused by design. Use OAuth instead:")
+    [Console]::Error.WriteLine("  databricks auth login --host https://<your-workspace> --profile $ProfileName")
+    exit 1
+}
+
+[Console]::Out.WriteLine($token)

--- a/experiments/coding_agent_inference_unity_ai_gateway/bin/get-databricks-token.sh
+++ b/experiments/coding_agent_inference_unity_ai_gateway/bin/get-databricks-token.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+# get-databricks-token.sh — mint a short-lived Databricks OAuth access token.
+#
+# SSO/OAuth ONLY. This helper never emits, accepts, or falls back to a static
+# personal access token (dapi...). If the resolved credential looks like a PAT,
+# it refuses.
+#
+# Inputs (environment):
+#   DATABRICKS_CONFIG_PROFILE  CLI profile to mint the token with (default: DEFAULT)
+#   DATABRICKS_HOST            optional workspace URL; validated against the profile
+#
+# Output: the access token, alone, on stdout. All diagnostics go to stderr.
+
+set -eu
+
+PROFILE="${DATABRICKS_CONFIG_PROFILE:-DEFAULT}"
+
+if ! command -v databricks >/dev/null 2>&1; then
+    echo "error: 'databricks' CLI not found on PATH." >&2
+    echo "Install it (https://docs.databricks.com/dev-tools/cli/install.html), then authenticate with:" >&2
+    echo "  databricks auth login --host https://<your-workspace> --profile ${PROFILE}" >&2
+    exit 1
+fi
+
+if [ -n "${DATABRICKS_HOST:-}" ]; then
+    output=$(databricks auth token --profile "$PROFILE" --host "$DATABRICKS_HOST" -o json 2>&1) || {
+        status=$?
+        echo "error: could not mint an OAuth token for profile '${PROFILE}' (host ${DATABRICKS_HOST})." >&2
+        echo "$output" >&2
+        echo "Authenticate with: databricks auth login --host ${DATABRICKS_HOST} --profile ${PROFILE}" >&2
+        exit "$status"
+    }
+else
+    output=$(databricks auth token --profile "$PROFILE" -o json 2>&1) || {
+        status=$?
+        echo "error: could not mint an OAuth token for profile '${PROFILE}'." >&2
+        echo "$output" >&2
+        echo "Authenticate with: databricks auth login --host https://<your-workspace> --profile ${PROFILE}" >&2
+        exit "$status"
+    }
+fi
+
+# Extract the access_token field from the JSON output (no jq dependency).
+token=$(printf '%s\n' "$output" \
+    | sed -n 's/.*"access_token"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
+    | head -n 1)
+
+if [ -z "$token" ]; then
+    echo "error: 'databricks auth token' returned no access_token for profile '${PROFILE}'." >&2
+    echo "$output" >&2
+    echo "This usually means the profile is not OAuth-authenticated. Run:" >&2
+    echo "  databricks auth login --host https://<your-workspace> --profile ${PROFILE}" >&2
+    exit 1
+fi
+
+case "$token" in
+    dapi*)
+        echo "error: resolved credential looks like a static personal access token (dapi...)." >&2
+        echo "This experiment is SSO-only — PATs are refused by design. Use OAuth instead:" >&2
+        echo "  databricks auth login --host https://<your-workspace> --profile ${PROFILE}" >&2
+        exit 1
+        ;;
+esac
+
+printf '%s\n' "$token"

--- a/experiments/coding_agent_inference_unity_ai_gateway/configs/README.md
+++ b/experiments/coding_agent_inference_unity_ai_gateway/configs/README.md
@@ -1,0 +1,108 @@
+# Per-agent config templates — Coding Agent Inference over Unity AI Gateway
+
+Templates for pointing coding agents at Databricks Model Serving with
+**SSO/OAuth only — zero PATs** (never a static `dapi...` token in any config)
+and **three-part Unity Catalog model identifiers** (`system.ai.<model>`,
+never legacy single-string names).
+
+The documented happy path for most agents is Databricks' setup tool:
+`ucode <agent>`. These templates are the **escape hatch** — the reference
+config for agents ucode covers, and the primary path for the one it doesn't
+(Claude Desktop).
+
+## Index
+
+| Agent | File | ucode coverage | Auth mechanism |
+|---|---|---|---|
+| Claude Code | [`claude-code.settings.json`](./claude-code.settings.json) | Covered (`ucode claude`) — template is reference/fallback | `apiKeyHelper` runs `bin/get-databricks-token.sh` per refresh; token is never stored |
+| Claude Desktop | [`claude-desktop.md`](./claude-desktop.md) + [`claude-desktop.mcp.json`](./claude-desktop.mcp.json) | **NOT covered** — this template is the primary path | MCP-server launch wrapper mints token via helper (chat model itself cannot be repointed; see the doc) |
+| Codex CLI | [`codex.config.toml`](./codex.config.toml) | Covered (`ucode codex`) — template is reference/fallback | Shell-level `export OPENAI_API_KEY="$(bin/get-databricks-token.sh)"`; provider `env_key` reads it |
+| OpenCode | [`opencode.json`](./opencode.json) | Covered (`ucode opencode`) — template is reference/fallback | Shell-level `export DATABRICKS_TOKEN="$(bin/get-databricks-token.sh)"`; config reads `{env:DATABRICKS_TOKEN}` |
+
+## Placeholder legend (shared across all templates)
+
+| Placeholder | Replace with |
+|---|---|
+| `<your-workspace-host>` | Your Databricks workspace hostname, e.g. `myshard.cloud.databricks.com` (no trailing slash) |
+| `system.ai.<model>` | A three-part Unity Catalog model id, e.g. `system.ai.claude-sonnet-4-6`. Never a legacy single-string name. |
+| `<path-to-this-experiment>` | Absolute path to this experiment directory (so `bin/get-databricks-token.sh` resolves) |
+| `<your-databricks-cli-profile>` | The `databricks auth login` profile to mint tokens with (helper defaults to `DEFAULT`) |
+| `<your-mcp-server-command>` | (Claude Desktop only) the MCP server executable that calls Databricks serving endpoints |
+
+## Base URLs
+
+Live-tested 2026-07-09 on a real workspace: **three-part `system.ai.<model>`
+ids resolve only on the `/ai-gateway/*` routes.** The classic
+`/serving-endpoints/*` routes resolve legacy single-string endpoint names
+only (a `system.ai.*` id there returns `404 ENDPOINT_NOT_FOUND`), while the
+gateway routes accept both forms. Hence every template points at
+`/ai-gateway/*`:
+
+- **Anthropic-compatible route** (Claude Code):
+  `https://<your-workspace-host>/ai-gateway/anthropic` (the client appends
+  `/v1/messages`). Tested: HTTP 200 with `system.ai.claude-sonnet-4-6`;
+  the `/serving-endpoints/anthropic` variant from the "Query with the
+  Anthropic Messages API" docs works with legacy names only.
+- **OpenAI-compatible route** (Codex, OpenCode):
+  `https://<your-workspace-host>/ai-gateway/mlflow/v1` (the client appends
+  `/chat/completions`). Tested: HTTP 200 with `system.ai.claude-sonnet-4-6`.
+  `# VERIFY:` Databricks' coding-agent integration docs additionally document a
+  dedicated Codex route, `https://<your-workspace-host>/ai-gateway/codex/v1`
+  with `wire_api = "responses"`. Tested 2026-07-09: the route exists, but
+  Responses-API passthrough returned `400 BAD_REQUEST — not supported` for a
+  Claude model; it may work for other model families. See `codex.config.toml`.
+
+Run `make verify` at the experiment root to test your own workspace — it
+tries the gateway route first and prints every route's response as data.
+
+## Token lifetime: why helper-based auth beats shell exports
+
+`bin/get-databricks-token.sh` prints a **short-lived OAuth access token
+(~1 hour)** to stdout (profile from `DATABRICKS_CONFIG_PROFILE`, host from
+`DATABRICKS_HOST` or the profile config). Consequences:
+
+- **Shell-level `export VAR="$(bin/get-databricks-token.sh)"`** (Codex,
+  OpenCode) captures one token at export time. When it expires mid-session
+  you get 401s until you re-run the export and relaunch the agent.
+- **Helper-based mechanisms** (Claude Code's `apiKeyHelper`) re-invoke the
+  script themselves, so a fresh token is minted automatically. This is why
+  `apiKeyHelper` is the preferred pattern wherever an agent supports it —
+  and why the Codex/OpenCode templates carry the re-mint caveat inline.
+  (Claude Code refreshes the helper value periodically and on auth failure;
+  tune with the `CLAUDE_CODE_API_KEY_HELPER_TTL_MS` env var if needed.)
+
+Never work around expiry by pasting a static PAT into a config file.
+
+## Notes on `claude-code.settings.json`
+
+JSON has no comments, so the placeholder explanations live here:
+
+- `env.ANTHROPIC_BASE_URL` — the workspace's Anthropic-compatible route
+  (see Base URLs above).
+- `env.ANTHROPIC_MODEL` — three-part `system.ai.<model>` id.
+- `env.DATABRICKS_CONFIG_PROFILE` — forwarded to the token helper so it mints
+  against the right profile; drop it to use the helper's `DEFAULT`.
+- `apiKeyHelper` — absolute path to `bin/get-databricks-token.sh`. Claude Code
+  sends the helper's output as both `Authorization: Bearer` and `X-Api-Key`
+  headers, which the Databricks route accepts as a Bearer token.
+- Merge into `~/.claude/settings.json` (global) or `.claude/settings.json`
+  (per-project). Note `ucode claude` writes an equivalent config for you.
+
+## Notes on `opencode.json`
+
+Also comment-free JSON:
+
+- Uses the `@ai-sdk/openai-compatible` provider against the OpenAI-compatible
+  serving base.
+- `{env:DATABRICKS_TOKEN}` is OpenCode's env-substitution syntax — the token
+  is resolved from your shell at startup, never stored in the file. Launch:
+
+  ```sh
+  export DATABRICKS_TOKEN="$(<path-to-this-experiment>/bin/get-databricks-token.sh)"
+  opencode
+  ```
+
+- Top-level `model` is `<provider-id>/<model-id>`, hence
+  `databricks/system.ai.claude-sonnet-4-6`.
+- Place as `opencode.json` in the project root or merge into
+  `~/.config/opencode/opencode.json`.

--- a/experiments/coding_agent_inference_unity_ai_gateway/configs/claude-code.settings.json
+++ b/experiments/coding_agent_inference_unity_ai_gateway/configs/claude-code.settings.json
@@ -1,0 +1,8 @@
+{
+  "env": {
+    "ANTHROPIC_BASE_URL": "https://<your-workspace-host>/ai-gateway/anthropic",
+    "ANTHROPIC_MODEL": "system.ai.claude-sonnet-4-6",
+    "DATABRICKS_CONFIG_PROFILE": "<your-databricks-cli-profile>"
+  },
+  "apiKeyHelper": "<path-to-this-experiment>/bin/get-databricks-token.sh"
+}

--- a/experiments/coding_agent_inference_unity_ai_gateway/configs/claude-desktop.mcp.json
+++ b/experiments/coding_agent_inference_unity_ai_gateway/configs/claude-desktop.mcp.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "databricks-model-serving": {
+      "command": "/bin/sh",
+      "args": [
+        "-c",
+        "DATABRICKS_TOKEN=\"$(<path-to-this-experiment>/bin/get-databricks-token.sh)\" DATABRICKS_HOST=\"https://<your-workspace-host>\" exec <your-mcp-server-command>"
+      ],
+      "env": {
+        "DATABRICKS_CONFIG_PROFILE": "<your-databricks-cli-profile>"
+      }
+    }
+  }
+}

--- a/experiments/coding_agent_inference_unity_ai_gateway/configs/claude-desktop.md
+++ b/experiments/coding_agent_inference_unity_ai_gateway/configs/claude-desktop.md
@@ -1,0 +1,66 @@
+# Claude Desktop — Databricks Unity AI Gateway (escape hatch)
+
+**ucode coverage: NOT covered.** `ucode` configures CLI coding agents (Claude
+Code, Codex, OpenCode, Gemini CLI, Copilot CLI); it does not configure Claude
+Desktop. This document is the primary path for Desktop.
+
+## What Claude Desktop does and does not support
+
+Be aware of the hard limitation up front:
+
+- **Claude Desktop's chat model canNOT be repointed at a custom
+  Anthropic-compatible backend.** There is no `ANTHROPIC_BASE_URL`, no
+  `apiKeyHelper`, and no custom-model setting in the Desktop app. The chat
+  panel always talks to Anthropic's hosted API using your Claude account
+  login. This is unlike Claude Code, whose `settings.json` supports both.
+  (`# VERIFY:` accurate as of 2026-07; re-check Desktop release notes —
+  if Anthropic ships custom-endpoint support, promote a settings-based
+  template over this MCP workaround.)
+- **What Desktop DOES support is MCP servers** (`claude_desktop_config.json`).
+  That is the escape hatch: Databricks model inference is exposed to Desktop
+  as a *tool* the chat model can call, not as the chat model itself.
+
+If you need the actual conversation loop to run on Databricks-served models
+with SSO, use Claude Code (`configs/claude-code.settings.json`) — Desktop is
+the wrong tool for that job.
+
+## Escape hatch: an MCP server that queries Databricks Model Serving
+
+Config file locations:
+
+- macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+
+Merge the snippet in [`claude-desktop.mcp.json`](./claude-desktop.mcp.json)
+into the `mcpServers` block. The pattern:
+
+1. `command` is a shell wrapper, so the short-lived OAuth token is minted by
+   `bin/get-databricks-token.sh` **at server launch** — nothing static is
+   ever written into the config (zero PATs).
+2. The MCP server itself (`<your-mcp-server-command>` placeholder) is whatever
+   server you use to reach Databricks — e.g. a server that calls
+   `https://<your-workspace-host>/ai-gateway/mlflow/v1` with the token and a
+   three-part model id like `system.ai.claude-sonnet-4-6`.
+   This experiment does not ship a server; bring your own or use a
+   Databricks-managed MCP endpoint.
+
+### Honest caveats
+
+- **Token lifetime:** Desktop launches MCP servers once at app startup. A
+  token minted in the wrapper expires after ~1 hour, after which the server's
+  Databricks calls 401 until you restart the app. The robust fix is an MCP
+  server that invokes the token helper (or the Databricks SDK's OAuth flow)
+  *per request* instead of reading a launch-time env var — prefer that if
+  your server supports it.
+- **No env substitution:** values in the config's `env` block are static
+  strings; Desktop does not expand `$(...)` or `{env:...}` there. That is why
+  the snippet mints the token inside a `/bin/sh -c` wrapper instead.
+- **Remote MCP connectors** (Settings → Connectors in Desktop) support OAuth
+  natively; if you host an MCP server behind a Databricks App with OAuth,
+  that avoids the launch-time token problem entirely.
+  (`# VERIFY:` confirm your Desktop plan exposes custom remote connectors.)
+
+## Placeholders
+
+See [`README.md`](./README.md) for the shared placeholder legend
+(`<your-workspace-host>`, `system.ai.<model>`, `<path-to-this-experiment>`).

--- a/experiments/coding_agent_inference_unity_ai_gateway/configs/codex.config.toml
+++ b/experiments/coding_agent_inference_unity_ai_gateway/configs/codex.config.toml
@@ -1,0 +1,40 @@
+# codex.config.toml — OpenAI Codex CLI template for Databricks Unity AI Gateway.
+#
+# ucode coverage: COVERED — `ucode codex` is the documented happy path; this
+# template is the reference / escape hatch for when ucode is unavailable.
+#
+# Install: merge this into ~/.codex/config.toml.
+#
+# Auth (SSO/OAuth only — NEVER a static dapi PAT):
+# Codex reads the API key from the env var named by `env_key` below. Mint a
+# short-lived Databricks OAuth token at shell level before launching codex:
+#
+#   export OPENAI_API_KEY="$(<path-to-this-experiment>/bin/get-databricks-token.sh)"
+#   codex
+#
+# CAVEAT: that token expires (~1 hour). A long Codex session will start
+# failing with 401s once it does; re-run the export in the same shell and
+# relaunch. There is no apiKeyHelper-style re-mint hook in Codex's config,
+# which is why the Claude Code template (apiKeyHelper) is the smoother path.
+
+# PLACEHOLDER: any three-part Unity Catalog model id (system.ai.<model>).
+# Never use legacy single-string names like "databricks-claude-sonnet-4-6".
+model = "system.ai.claude-sonnet-4-6"
+model_provider = "databricks"
+
+[model_providers.databricks]
+name = "Databricks Unity AI Gateway"
+# PLACEHOLDER: your workspace host, e.g. https://myshard.cloud.databricks.com
+# The Unity AI Gateway OpenAI-compatible base — the ONLY route family that
+# resolves three-part system.ai.* ids (live-tested 2026-07-09; the classic
+# /serving-endpoints base 404s on them). Codex appends /chat/completions.
+base_url = "https://<your-workspace-host>/ai-gateway/mlflow/v1"
+# Codex sends the value of this env var as the Bearer token.
+env_key = "OPENAI_API_KEY"
+wire_api = "chat"
+# VERIFY: Databricks' coding-agent integration docs also describe a dedicated
+# Codex route at https://<your-workspace-host>/ai-gateway/codex/v1 with
+# wire_api = "responses". Live-tested 2026-07-09: the route exists but
+# Responses-API passthrough returned 400 (not supported) for a Claude model;
+# it may work for other model families. Switch base_url and wire_api to it
+# only if your chosen model supports Responses passthrough.

--- a/experiments/coding_agent_inference_unity_ai_gateway/configs/opencode.json
+++ b/experiments/coding_agent_inference_unity_ai_gateway/configs/opencode.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "databricks": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Databricks Unity AI Gateway",
+      "options": {
+        "baseURL": "https://<your-workspace-host>/ai-gateway/mlflow/v1",
+        "apiKey": "{env:DATABRICKS_TOKEN}"
+      },
+      "models": {
+        "system.ai.claude-sonnet-4-6": {
+          "name": "Claude Sonnet 4.6 (Databricks, system.ai)"
+        }
+      }
+    }
+  },
+  "model": "databricks/system.ai.claude-sonnet-4-6"
+}

--- a/experiments/coding_agent_inference_unity_ai_gateway/pyproject.toml
+++ b/experiments/coding_agent_inference_unity_ai_gateway/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "coding-agent-inference-unity-ai-gateway"
+version = "0.1.0"
+description = "Experiment: coding agent inference over the Unity AI Gateway with SSO-only auth (zero PATs)"
+requires-python = ">=3.11"
+dependencies = [
+    "databricks-sdk",
+    "requests",
+]

--- a/experiments/coding_agent_inference_unity_ai_gateway/results/matrix_results.json
+++ b/experiments/coding_agent_inference_unity_ai_gateway/results/matrix_results.json
@@ -1,0 +1,52 @@
+{
+  "deny_execute_blocks_inference": {
+    "notes": "TEST_PRINCIPAL not set — untested",
+    "recorded_at": "2026-07-09T12:56:57.532275+00:00",
+    "result": "❓"
+  },
+  "deny_model_grant_gateway": {
+    "notes": "TEST_PRINCIPAL not set — untested",
+    "recorded_at": "2026-07-09T12:56:57.646918+00:00",
+    "result": "❓"
+  },
+  "grant_revoke_execute_enforced": {
+    "notes": "TEST_PRINCIPAL not set — untested",
+    "recorded_at": "2026-07-09T13:21:20.028360+00:00",
+    "result": "❓"
+  },
+  "guardrails_pii_injection_unsafe": {
+    "notes": "No guardrails currently configured on this endpoint and ALLOW_ENDPOINT_MUTATION=1 not set — settability not probed (dry-run). Documented knobs to probe: ('pii', 'safety', 'valid_topics', 'invalid_keywords') on input/output; a dedicated prompt-injection filter is NOT in the documented schema. ai_gateway keys=['usage_tracking_config']",
+    "recorded_at": "2026-07-09T12:56:58.281154+00:00",
+    "result": "❓"
+  },
+  "per_user_hard_cap": {
+    "notes": "No hard per-user budget cap: ai_gateway exposes only alert-style surfaces (usage tracking) and rate caps (rate_limits per user/endpoint), no spend-denominated block-at-budget field. Per-user rate limits found: 0. ai_gateway key paths=['usage_tracking_config', 'usage_tracking_config.enabled']; cap-like keys=NONE; rate_limits(verbatim)=[].",
+    "recorded_at": "2026-07-09T12:56:41.856632+00:00",
+    "result": "❌"
+  },
+  "per_user_spend_alerting": {
+    "notes": "Per-user alerting surface present: usage tracking is ON (per-user attribution into system.serving usage tables — the documented basis for spend alerts via SQL alerts/budget policies). Note: no direct 'alert at $X per user' field exists ON the endpoint; alerting is composed from these knobs. ai_gateway keys=['usage_tracking_config']; usage_tracking_config={\"enabled\": true}; rate_limits=[]; per-user rate limits=0",
+    "recorded_at": "2026-07-09T12:56:41.220600+00:00",
+    "result": "✅"
+  },
+  "query_via_gateway_sso": {
+    "notes": "HTTP 200 with SSO OAuth token only (zero PATs); model=system.ai.claude-sonnet-4-6; reply=pong. Baseline gate for all other rows.",
+    "recorded_at": "2026-07-09T13:14:40.720932+00:00",
+    "result": "✅"
+  },
+  "revoke_gateway_no_fallback": {
+    "notes": "TEST_PRINCIPAL not set — untested",
+    "recorded_at": "2026-07-09T12:56:57.769745+00:00",
+    "result": "❓"
+  },
+  "three_part_identifier_resolves": {
+    "notes": "Three-part id got HTTP 200. three-part 'system.ai.claude-sonnet-4-6' -> HTTP 200 ({\"choices\": [{\"finish_reason\": \"stop\", \"index\": 0, \"message\": {\"content\": \"pong\", \"role\": \"assistant\"}}], \"created\": 1783602894, \"id\": \"msg_bdrk_01QngKE9c5LM2BouVHRrSH4B\", \"model\": \"us.anthropic.cl...); legacy 'databricks-claude-sonnet-4-6' -> HTTP 200 ({\"choices\": [{\"finish_reason\": \"stop\", \"index\": 0, \"message\": {\"content\": \"pong\", \"role\": \"assistant\"}}], \"created\": 1783602895, \"id\": \"msg_bdrk_01QDWaKJ6sBxL2DzNQMLwsEe\", \"model\": \"us.anthropic.cl...)",
+    "recorded_at": "2026-07-09T13:14:55.633596+00:00",
+    "result": "✅"
+  },
+  "usage_tracking_per_user_agent": {
+    "notes": "Per-user attribution PROVEN (populated), but per-agent attribution unproven: the agent/client columns exist in the schema yet were empty/null in every sampled row — callers must send user_agent/usage_context metadata for it to populate. table=system.serving.endpoint_usage; user columns=['requester'] (populated: ['requester']); agent/client columns=['client_request_id', 'usage_context'] (populated: []); sampled rows=10. fresh inference HTTP 200 with marker 'uag-experiment-row09-7d14c36d5300' in User-Agent + usage_context. Marker hunt: 0 row(s) matched 'uag-experiment-row09-7d14c36d5300' (ingestion latency likely exceeds this run).",
+    "recorded_at": "2026-07-09T13:15:25.367643+00:00",
+    "result": "❓"
+  }
+}

--- a/experiments/coding_agent_inference_unity_ai_gateway/scripts/_common.py
+++ b/experiments/coding_agent_inference_unity_ai_gateway/scripts/_common.py
@@ -1,0 +1,267 @@
+"""Shared helpers for the Coding Agent Inference over Unity AI Gateway experiment.
+
+Auth model: SSO/OAuth only — tokens come from `bin/get-databricks-token.sh`,
+which mints short-lived OAuth access tokens. PATs (`dapi...`) are explicitly
+rejected. Models are addressed by three-part Unity Catalog identifiers
+(e.g. `system.ai.claude-sonnet-4-6`).
+
+Dependencies: stdlib + requests.
+"""
+
+from __future__ import annotations
+
+import configparser
+import json
+import os
+import re
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+import requests
+
+SEPARATOR = "=" * 60
+
+# Experiment root is the parent of scripts/, regardless of cwd.
+EXPERIMENT_ROOT = Path(__file__).resolve().parent.parent
+TOKEN_HELPER = EXPERIMENT_ROOT / "bin" / "get-databricks-token.sh"
+RESULTS_FILE = EXPERIMENT_ROOT / "results" / "matrix_results.json"
+
+# Matches scripts/verify.py — the registered system.ai name drops the
+# `databricks-` prefix of the legacy endpoint name (live-tested 2026-07-09).
+DEFAULT_MODEL = "system.ai.claude-sonnet-4-6"
+
+_THREE_PART_RE = re.compile(
+    r"^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9._-]+$"
+)
+
+
+# ---------------------------------------------------------------------------
+# Output helpers (style matches experiments/aws-databricks-gcs-access)
+# ---------------------------------------------------------------------------
+
+def section(title: str) -> None:
+    """Print a section header."""
+    print(f"\n{SEPARATOR}")
+    print(title)
+    print(SEPARATOR)
+
+
+def ok(msg: str) -> None:
+    """Print a success line."""
+    print(f"  ✅ {msg}")
+
+
+def fail(msg: str) -> None:
+    """Print a failure line."""
+    print(f"  ❌ {msg}")
+
+
+# ---------------------------------------------------------------------------
+# Profile / host / token resolution
+# ---------------------------------------------------------------------------
+
+def get_profile() -> str:
+    """Return the Databricks CLI profile name (env first, default DEFAULT)."""
+    return os.environ.get("DATABRICKS_CONFIG_PROFILE", "DEFAULT")
+
+
+def get_host() -> str:
+    """Resolve the workspace host URL.
+
+    Precedence: DATABRICKS_HOST env var, then the profile's `host` entry in
+    ~/.databrickscfg. Raises RuntimeError with guidance if neither resolves.
+    """
+    host = os.environ.get("DATABRICKS_HOST")
+    if not host:
+        profile = get_profile()
+        cfg_path = Path(
+            os.environ.get("DATABRICKS_CONFIG_FILE", Path.home() / ".databrickscfg")
+        ).expanduser()
+        if cfg_path.exists():
+            # configparser treats [DEFAULT] as its magic defaults section, so
+            # has_section("DEFAULT") is always False. Renaming the defaults
+            # section makes [DEFAULT] a regular, addressable profile.
+            cfg = configparser.ConfigParser(default_section="__unused__")
+            cfg.read(cfg_path)
+            if cfg.has_section(profile) and cfg.has_option(profile, "host"):
+                host = cfg.get(profile, "host")
+    if not host:
+        raise RuntimeError(
+            "Could not resolve the Databricks workspace host. Set the "
+            "DATABRICKS_HOST env var, or add a `host = https://...` entry "
+            f"under the [{get_profile()}] profile in ~/.databrickscfg "
+            "(created by `databricks auth login`)."
+        )
+    return host.rstrip("/")
+
+
+def get_token() -> str:
+    """Mint a short-lived OAuth access token via bin/get-databricks-token.sh.
+
+    Raises RuntimeError (with the helper's stderr message) if SSO auth is
+    unavailable, and rejects any `dapi` PAT — this experiment is OAuth-only.
+    """
+    if not TOKEN_HELPER.exists():
+        raise RuntimeError(
+            f"Token helper not found at {TOKEN_HELPER}. "
+            "Run scripts from a full checkout of the experiment."
+        )
+    proc = subprocess.run(
+        ["bash", str(TOKEN_HELPER)],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        stderr = proc.stderr.strip() or "(no stderr output)"
+        raise RuntimeError(
+            f"get-databricks-token.sh failed (exit {proc.returncode}): {stderr}"
+        )
+    token = proc.stdout.strip()
+    if not token:
+        raise RuntimeError(
+            "get-databricks-token.sh succeeded but printed an empty token."
+        )
+    if token.startswith("dapi"):
+        raise RuntimeError(
+            "Refusing to use a Databricks personal access token (dapi...). "
+            "This experiment is SSO/OAuth-only — run `databricks auth login` "
+            "and remove any DATABRICKS_TOKEN PAT from your environment."
+        )
+    return token
+
+
+# ---------------------------------------------------------------------------
+# Model identifier validation
+# ---------------------------------------------------------------------------
+
+def resolve_model_id(model_id: str | None = None) -> str:
+    """Resolve and validate a three-part Unity Catalog model identifier.
+
+    Defaults to the RPW_MODEL env var, then DEFAULT_MODEL (matching
+    scripts/verify.py). Rejects legacy single-string endpoint
+    names with a migration hint (e.g. `databricks-claude-sonnet-4-6` →
+    `system.ai.claude-sonnet-4-6`).
+    """
+    if model_id is None:
+        model_id = os.environ.get("RPW_MODEL", "").strip() or DEFAULT_MODEL
+    if _THREE_PART_RE.match(model_id):
+        return model_id
+    if "." not in model_id:
+        raise ValueError(
+            f"'{model_id}' looks like a legacy single-string endpoint name. "
+            "Unity AI Gateway addresses models by three-part Unity Catalog "
+            "identifiers (<catalog>.<schema>.<model>). Migrate the old name "
+            f"to its UC form, e.g. `databricks-claude-sonnet-4-6` → "
+            f"`system.ai.claude-sonnet-4-6` (for '{model_id}', "
+            f"try `system.ai.{model_id}`)."
+        )
+    raise ValueError(
+        f"'{model_id}' is not a valid three-part Unity Catalog model "
+        "identifier. Expected <catalog>.<schema>.<model>, e.g. "
+        "`system.ai.claude-sonnet-4-6`."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Inference call
+# ---------------------------------------------------------------------------
+
+def chat_completion(
+    model_id: str,
+    prompt: str,
+    max_tokens: int = 32,
+    extra_headers: dict | None = None,
+    extra_payload: dict | None = None,
+) -> tuple[int, dict | str]:
+    """Send one chat completion, trying each candidate route in order.
+
+    Three-part UC identifiers (`system.ai.*`) are served by the Unity AI
+    Gateway workspace routes, not the classic serving routes, so the route
+    order for them is:
+
+      1. `{host}/ai-gateway/mlflow/v1/chat/completions`  (Unity AI Gateway)
+      2. `{host}/serving-endpoints/chat/completions`      (OpenAI-compatible)
+      3. `{host}/serving-endpoints/{model_id}/invocations` (legacy per-endpoint)
+
+    Legacy single-string names (only reachable when a caller deliberately
+    bypasses resolve_model_id) skip the gateway route. Each attempt prints a
+    one-line evidence trail; the next route is tried only on 404.
+
+    Returns (status_code, parsed-json-or-text). Never raises on non-200 —
+    governance tests need to observe 403s and other denials as data.
+    """
+    host = get_host()
+    token = get_token()
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    }
+    if extra_headers:
+        headers.update(extra_headers)
+    payload = {
+        "model": model_id,
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": max_tokens,
+    }
+    if extra_payload:
+        payload.update(extra_payload)
+
+    # (url, include_model_in_payload)
+    routes = [
+        (f"{host}/ai-gateway/mlflow/v1/chat/completions", True),
+        (f"{host}/serving-endpoints/chat/completions", True),
+        (f"{host}/serving-endpoints/{model_id}/invocations", False),
+    ]
+    if not _THREE_PART_RE.match(model_id):
+        routes = routes[1:]
+
+    resp = None
+    for url, include_model in routes:
+        route_payload = dict(payload)
+        if not include_model:
+            # The invocations route encodes the model in the URL.
+            route_payload.pop("model", None)
+        resp = requests.post(url, headers=headers, json=route_payload, timeout=120)
+        print(f"  → POST {url.removeprefix(host)} → HTTP {resp.status_code}")
+        if resp.status_code != 404:
+            break
+
+    try:
+        body: dict | str = resp.json()
+    except ValueError:
+        body = resp.text
+    return resp.status_code, body
+
+
+# ---------------------------------------------------------------------------
+# Results matrix
+# ---------------------------------------------------------------------------
+
+def record_result(row_key: str, passed: bool | None, notes: str = "") -> None:
+    """Upsert one row into results/matrix_results.json.
+
+    passed=True → "✅", False → "❌", None → "❓". The file is pretty-printed
+    with sorted keys so repeated runs produce clean diffs.
+    """
+    RESULTS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    results: dict = {}
+    if RESULTS_FILE.exists():
+        try:
+            results = json.loads(RESULTS_FILE.read_text(encoding="utf-8"))
+        except (ValueError, OSError):
+            results = {}
+    if not isinstance(results, dict):
+        results = {}
+
+    result_symbol = "❓" if passed is None else ("✅" if passed else "❌")
+    results[row_key] = {
+        "result": result_symbol,
+        "notes": notes,
+        "recorded_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+    RESULTS_FILE.write_text(
+        json.dumps(results, indent=2, sort_keys=True, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )

--- a/experiments/coding_agent_inference_unity_ai_gateway/scripts/governance/01_query_via_gateway_sso.py
+++ b/experiments/coding_agent_inference_unity_ai_gateway/scripts/governance/01_query_via_gateway_sso.py
@@ -1,0 +1,70 @@
+"""Matrix row: query_via_gateway_sso — baseline SSO inference via the gateway.
+
+Claim/source: Databricks docs say workspace users can query foundation models
+through the AI Gateway / serving endpoints using their own OAuth (SSO)
+identity — no PAT required.
+
+✅ means: one real chat completion against the resolved RPW_MODEL (three-part
+Unity Catalog identifier) returned HTTP 200 using ONLY a short-lived SSO
+OAuth token.
+❌ means: the call failed (auth or otherwise) — the response body is captured
+verbatim in notes.
+
+This row is the gate for the whole matrix: if the baseline SSO query fails,
+every other row's ✅/❌ is meaningless noise.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import _gov_common as gov  # noqa: E402  (adds scripts/ to sys.path)
+import _common  # noqa: E402
+
+ROW_KEY = "query_via_gateway_sso"
+
+
+def main() -> int:
+    _common.section("01 — Baseline: query via gateway with SSO OAuth only")
+    print("  This row must pass before the other nine rows mean anything —")
+    print("  it proves the SSO token + three-part identifier path end to end.")
+
+    model_id = _common.resolve_model_id()
+    print(f"  Model (three-part UC id): {model_id}")
+    print(f"  Profile: {_common.get_profile()}  Host: {_common.get_host()}")
+
+    status, body = _common.chat_completion(
+        model_id, "Reply with the single word: pong", max_tokens=16
+    )
+    print(f"  HTTP status: {status}")
+
+    if status == 200:
+        _common.ok("SSO-only inference through the gateway succeeded (HTTP 200).")
+        content = ""
+        if isinstance(body, dict):
+            try:
+                content = body["choices"][0]["message"]["content"]
+            except (KeyError, IndexError, TypeError):
+                content = gov.snip(body, 120)
+        notes = (
+            f"HTTP 200 with SSO OAuth token only (zero PATs); model={model_id}; "
+            f"reply={gov.snip(content, 120)}. Baseline gate for all other rows."
+        )
+        gov.conclude(ROW_KEY, True, notes)
+        return 0
+
+    _common.fail(f"Inference failed with HTTP {status}.")
+    notes = (
+        f"HTTP {status} for model={model_id} using SSO OAuth token only. "
+        f"Body: {gov.snip(body)}. Baseline gate FAILED — treat every other "
+        "matrix row as unproven until this passes."
+    )
+    gov.conclude(ROW_KEY, False, notes)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/experiments/coding_agent_inference_unity_ai_gateway/scripts/governance/02_three_part_identifier_resolves.py
+++ b/experiments/coding_agent_inference_unity_ai_gateway/scripts/governance/02_three_part_identifier_resolves.py
@@ -1,0 +1,87 @@
+"""Matrix row: three_part_identifier_resolves — UC three-part model ids work.
+
+Claim/source: Unity AI Gateway addresses models by three-part Unity Catalog
+identifiers (`system.ai.<model>`), replacing legacy single-string serving
+endpoint names.
+
+✅ means: the three-part form itself got HTTP 200 (or a non-auth,
+model-level response proving the identifier resolved) through the gateway.
+❌ means: the three-part form does not resolve on this workspace (e.g. 404),
+regardless of what the legacy name does.
+
+The legacy single-string tail (three-part id with the `system.ai.` prefix
+stripped) is also probed — purely as a comparison data point recorded in
+notes, never as a pass condition.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import _gov_common as gov  # noqa: E402
+import _common  # noqa: E402
+
+ROW_KEY = "three_part_identifier_resolves"
+
+PROMPT = "Reply with the single word: pong"
+
+
+def main() -> int:
+    _common.section("02 — Three-part UC identifier resolves through the gateway")
+
+    model_id = _common.resolve_model_id()
+    legacy_name = gov.endpoint_tail(model_id)
+    print(f"  Three-part form: {model_id}")
+    print(f"  Legacy single-string comparison probe: {legacy_name}")
+
+    # --- Probe 1: the three-part form (the actual test) -------------------
+    status3, body3 = _common.chat_completion(model_id, PROMPT, max_tokens=8)
+    print(f"  three-part -> HTTP {status3}")
+
+    # --- Probe 2: legacy single-string tail (comparison only) -------------
+    status_legacy, body_legacy = _common.chat_completion(
+        legacy_name, PROMPT, max_tokens=8
+    )
+    print(f"  legacy tail -> HTTP {status_legacy}")
+
+    both = (
+        f"three-part '{model_id}' -> HTTP {status3} ({gov.snip(body3, 200)}); "
+        f"legacy '{legacy_name}' -> HTTP {status_legacy} "
+        f"({gov.snip(body_legacy, 200)})"
+    )
+
+    if status3 == 200:
+        _common.ok("Three-part identifier resolved and served the request.")
+        gov.conclude(ROW_KEY, True, f"Three-part id got HTTP 200. {both}")
+        return 0
+
+    body3_text = gov.snip(body3, 400).lower()
+    resolved_but_rejected = status3 not in (401, 403, 404) and not any(
+        marker in body3_text for marker in ("not found", "does not exist", "no such")
+    )
+    if resolved_but_rejected:
+        _common.ok(
+            "Three-part identifier resolved (non-auth, model-level response "
+            f"HTTP {status3}) even though the request itself was rejected."
+        )
+        gov.conclude(
+            ROW_KEY,
+            True,
+            f"Three-part id resolved: non-auth model-level HTTP {status3}. {both}",
+        )
+        return 0
+
+    _common.fail(f"Three-part identifier did not resolve (HTTP {status3}).")
+    gov.conclude(
+        ROW_KEY,
+        False,
+        f"Three-part id failed with HTTP {status3}. {both}",
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/experiments/coding_agent_inference_unity_ai_gateway/scripts/governance/03_grant_revoke_execute_enforced.py
+++ b/experiments/coding_agent_inference_unity_ai_gateway/scripts/governance/03_grant_revoke_execute_enforced.py
@@ -1,0 +1,174 @@
+"""Matrix row: grant_revoke_execute_enforced — EXECUTE grants on the model.
+
+Claim/source: with Unity Catalog governance of foundation models, admins can
+GRANT/REVOKE EXECUTE on `system.ai.<model>` securables and the gateway
+enforces it. The exact securable keyword for model *services* is itself part
+of what's under test — UC registered models surface as securable type
+FUNCTION in the grants API, SQL also documents a MODEL keyword, and the whole
+capability is suspected to be gated behind the account-console
+"Foundation Model Permissions" Preview (Beta). We try both spellings and
+capture every API error verbatim.
+
+✅ means: GRANT/REVOKE EXECUTE are accepted AND enforced (principal can infer
+after GRANT, cannot after REVOKE).
+❌ means: the API accepts the grant/revoke but does NOT enforce it.
+❓ means: untestable here — TEST_PRINCIPAL unset, mutations not opted in, the
+API refuses the operation as not-enabled (Preview off), or enforcement could
+not be observed because no TEST_PRINCIPAL_PROFILE was available.
+
+Needs: TEST_PRINCIPAL (target user email or group), metastore-admin-level
+rights on the current identity, ALLOW_ENDPOINT_MUTATION=1, and optionally
+TEST_PRINCIPAL_PROFILE for the query-as-principal enforcement check.
+All mutations are reverted in a finally block (best effort).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import _gov_common as gov  # noqa: E402
+import _common  # noqa: E402
+
+ROW_KEY = "grant_revoke_execute_enforced"
+
+
+def main() -> int:
+    _common.section("03 — GRANT/REVOKE EXECUTE on the model is enforced")
+
+    model_id = _common.resolve_model_id()
+    principal = gov.get_test_principal()
+    profile = gov.get_test_principal_profile()
+    print(f"  Model: {model_id}")
+
+    if principal is None:
+        gov.print_test_principal_setup()
+        gov.conclude(ROW_KEY, None, "TEST_PRINCIPAL not set — untested")
+        return 0
+
+    print(f"  Target principal: {principal}")
+
+    if not gov.mutation_allowed():
+        gov.print_mutation_gate()
+        print("  The mutation path would run, then revert:")
+        print(f"    GRANT EXECUTE ON MODEL|FUNCTION {model_id} TO `{principal}`")
+        print("    (inference check as principal, if TEST_PRINCIPAL_PROFILE set)")
+        print(f"    REVOKE EXECUTE ON MODEL|FUNCTION {model_id} FROM `{principal}`")
+        print("    (inference check again — should now be denied)")
+        gov.conclude(
+            ROW_KEY,
+            None,
+            f"Dry-run only: {gov.MUTATION_ENV}=1 not set, so no GRANT/REVOKE "
+            f"was attempted against {model_id} for {principal} — untested",
+        )
+        return 0
+
+    granted = False
+    notes_parts: list[str] = []
+    verdict: bool | None = None
+    try:
+        # --- GRANT --------------------------------------------------------
+        print("  Attempting GRANT EXECUTE (MODEL, then FUNCTION spelling)...")
+        grant_ok, grant_attempts = gov.try_privilege_statements(
+            "GRANT", model_id, principal
+        )
+        granted = grant_ok
+        for stmt, res in grant_attempts:
+            marker = "ok" if res["ok"] else f"{res['state']}: {gov.snip(res['error'], 200)}"
+            print(f"    {stmt} -> {marker}")
+            notes_parts.append(f"[{stmt}] -> {'OK' if res['ok'] else gov.snip(res['error'], 200)}")
+
+        if not grant_ok:
+            _common.fail("GRANT EXECUTE was refused by the API (all spellings).")
+            print("  This is consistent with the Foundation Model Permissions")
+            print("  Preview (Beta) not being enabled in the account console.")
+            verdict = None
+            notes_parts.insert(
+                0,
+                "API refused GRANT EXECUTE on the model securable (likely the "
+                "Foundation Model Permissions Preview is not enabled) — "
+                "enforcement untestable:",
+            )
+            return 0
+
+        _common.ok("GRANT EXECUTE accepted.")
+
+        # --- Enforcement probe after GRANT ---------------------------------
+        if profile:
+            with gov.as_profile(profile):
+                status_g, body_g = _common.chat_completion(
+                    model_id, "Reply with: pong", max_tokens=8
+                )
+            print(f"  As {principal} after GRANT: HTTP {status_g}")
+            notes_parts.append(f"post-GRANT inference as principal -> HTTP {status_g}")
+        else:
+            status_g = None
+            print("  TEST_PRINCIPAL_PROFILE not set — cannot verify post-GRANT access.")
+
+        # --- REVOKE ---------------------------------------------------------
+        print("  Attempting REVOKE EXECUTE...")
+        revoke_ok, revoke_attempts = gov.try_privilege_statements(
+            "REVOKE", model_id, principal
+        )
+        for stmt, res in revoke_attempts:
+            marker = "ok" if res["ok"] else f"{res['state']}: {gov.snip(res['error'], 200)}"
+            print(f"    {stmt} -> {marker}")
+            notes_parts.append(f"[{stmt}] -> {'OK' if res['ok'] else gov.snip(res['error'], 200)}")
+        if revoke_ok:
+            granted = False  # cleanup done inline
+
+        # --- Enforcement probe after REVOKE --------------------------------
+        if profile and revoke_ok:
+            with gov.as_profile(profile):
+                status_r, body_r = _common.chat_completion(
+                    model_id, "Reply with: pong", max_tokens=8
+                )
+            print(f"  As {principal} after REVOKE: HTTP {status_r}")
+            notes_parts.append(f"post-REVOKE inference as principal -> HTTP {status_r} ({gov.snip(body_r, 150)})")
+            if status_g == 200 and status_r in (401, 403):
+                _common.ok("GRANT allowed inference; REVOKE blocked it — enforced.")
+                verdict = True
+                notes_parts.insert(0, "GRANT/REVOKE EXECUTE accepted AND enforced:")
+            elif status_r == 200:
+                _common.fail("REVOKE accepted but the principal can still infer — NOT enforced.")
+                verdict = False
+                notes_parts.insert(0, "API accepted GRANT/REVOKE but did NOT enforce (post-revoke 200):")
+            else:
+                verdict = None
+                notes_parts.insert(0, "Grant/revoke accepted; enforcement signal ambiguous:")
+        else:
+            verdict = None
+            if not profile:
+                print("  Cannot observe enforcement without TEST_PRINCIPAL_PROFILE.")
+                print("  Run this AS the second principal to check manually:")
+                print(f"    RPW_MODEL={model_id} uv run python scripts/verify.py")
+                notes_parts.insert(
+                    0,
+                    "GRANT/REVOKE statements accepted, but enforcement unobserved "
+                    "(no TEST_PRINCIPAL_PROFILE to query as the principal):",
+                )
+            else:
+                notes_parts.insert(0, "GRANT accepted but REVOKE refused — partial API surface:")
+        return 0
+    finally:
+        # Best-effort cleanup: never leave a grant behind.
+        if granted:
+            print("  Cleanup: revoking the EXECUTE grant made by this script...")
+            cleanup_ok, cleanup_attempts = gov.try_privilege_statements(
+                "REVOKE", model_id, principal
+            )
+            if cleanup_ok:
+                _common.ok("Cleanup revoke succeeded.")
+            else:
+                _common.fail(
+                    "Cleanup revoke FAILED — manually run: "
+                    f"REVOKE EXECUTE ON MODEL {model_id} FROM `{principal}`"
+                )
+                notes_parts.append("WARNING: cleanup revoke failed — manual revoke needed.")
+        gov.conclude(ROW_KEY, verdict, " | ".join(notes_parts))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/experiments/coding_agent_inference_unity_ai_gateway/scripts/governance/04_deny_execute_blocks_inference.py
+++ b/experiments/coding_agent_inference_unity_ai_gateway/scripts/governance/04_deny_execute_blocks_inference.py
@@ -1,0 +1,146 @@
+"""Matrix row: deny_execute_blocks_inference — DENY EXECUTE stops inference.
+
+Claim/source: with governed foundation models, an explicit DENY of EXECUTE on
+`system.ai.<model>` to a principal should block that principal's inference
+through the gateway. Whether Unity Catalog even accepts DENY on this
+securable (vs the legacy Hive-metastore-only DENY) is itself under test, and
+is suspected to be gated behind the "Foundation Model Permissions" Preview.
+
+✅ means: DENY was accepted and the denied principal's inference attempt was
+rejected (401/403).
+❌ means: DENY was accepted but the principal could still infer.
+❓ means: untestable — TEST_PRINCIPAL unset, mutations not opted in, DENY
+refused by the API, or no TEST_PRINCIPAL_PROFILE to run the query-as-user
+step (in that case the exact manual command is printed and recorded).
+
+Needs: TEST_PRINCIPAL, ALLOW_ENDPOINT_MUTATION=1, optionally
+TEST_PRINCIPAL_PROFILE (a databrickscfg profile authenticated AS the
+principal). The DENY is reverted in a finally block (best effort).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import _gov_common as gov  # noqa: E402
+import _common  # noqa: E402
+
+ROW_KEY = "deny_execute_blocks_inference"
+
+
+def revert_deny(model_id: str, principal: str) -> bool:
+    """Best-effort removal of a DENY (REVOKE removes explicit denies too)."""
+    ok, attempts = gov.try_privilege_statements("REVOKE", model_id, principal)
+    for stmt, res in attempts:
+        marker = "ok" if res["ok"] else gov.snip(res["error"], 150)
+        print(f"    cleanup: {stmt} -> {marker}")
+    return ok
+
+
+def main() -> int:
+    _common.section("04 — DENY EXECUTE on the model blocks inference")
+
+    model_id = _common.resolve_model_id()
+    principal = gov.get_test_principal()
+    profile = gov.get_test_principal_profile()
+    print(f"  Model: {model_id}")
+
+    if principal is None:
+        gov.print_test_principal_setup()
+        gov.conclude(ROW_KEY, None, "TEST_PRINCIPAL not set — untested")
+        return 0
+
+    print(f"  Target principal: {principal}")
+
+    if not gov.mutation_allowed():
+        gov.print_mutation_gate()
+        print("  The mutation path would run, then revert:")
+        print(f"    DENY EXECUTE ON MODEL|FUNCTION {model_id} TO `{principal}`")
+        print("    (inference attempt AS the principal — expected 401/403)")
+        gov.conclude(
+            ROW_KEY,
+            None,
+            f"Dry-run only: {gov.MUTATION_ENV}=1 not set, so no DENY was "
+            f"attempted against {model_id} for {principal} — untested",
+        )
+        return 0
+
+    denied = False
+    notes_parts: list[str] = []
+    verdict: bool | None = None
+    try:
+        print("  Attempting DENY EXECUTE (MODEL, then FUNCTION spelling)...")
+        deny_ok, deny_attempts = gov.try_privilege_statements(
+            "DENY", model_id, principal
+        )
+        denied = deny_ok
+        for stmt, res in deny_attempts:
+            marker = "ok" if res["ok"] else f"{res['state']}: {gov.snip(res['error'], 200)}"
+            print(f"    {stmt} -> {marker}")
+            notes_parts.append(f"[{stmt}] -> {'OK' if res['ok'] else gov.snip(res['error'], 200)}")
+
+        if not deny_ok:
+            _common.fail("DENY EXECUTE was refused by the API (all spellings).")
+            print("  Consistent with UC not supporting DENY on this securable, or")
+            print("  the Foundation Model Permissions Preview being disabled.")
+            verdict = None
+            notes_parts.insert(
+                0,
+                "API refused DENY EXECUTE on the model securable — blocking "
+                "behavior untestable:",
+            )
+            return 0
+
+        _common.ok("DENY EXECUTE accepted.")
+
+        if profile:
+            with gov.as_profile(profile):
+                status, body = _common.chat_completion(
+                    model_id, "Reply with: pong", max_tokens=8
+                )
+            print(f"  Inference AS {principal} (profile {profile}): HTTP {status}")
+            notes_parts.append(
+                f"post-DENY inference as principal -> HTTP {status} ({gov.snip(body, 200)})"
+            )
+            if status in (401, 403):
+                _common.ok("Denied principal was blocked — DENY is enforced.")
+                verdict = True
+                notes_parts.insert(0, "DENY EXECUTE accepted AND blocks inference:")
+            elif status == 200:
+                _common.fail("Denied principal could still infer — DENY NOT enforced.")
+                verdict = False
+                notes_parts.insert(0, "DENY accepted but inference still succeeded (leak):")
+            else:
+                verdict = None
+                notes_parts.insert(0, f"DENY accepted; ambiguous HTTP {status} from principal:")
+        else:
+            manual = (
+                "As the second user (their own SSO login), run: "
+                f"RPW_MODEL={model_id} uv run python "
+                "scripts/governance/01_query_via_gateway_sso.py — expect HTTP 401/403 "
+                "while the DENY is in place."
+            )
+            print("  TEST_PRINCIPAL_PROFILE not set — cannot query as the principal.")
+            print(f"  Manual step: {manual}")
+            verdict = None
+            notes_parts.insert(0, f"DENY accepted but unverified — {manual} —")
+        return 0
+    finally:
+        if denied:
+            print("  Cleanup: reverting the DENY made by this script...")
+            if revert_deny(model_id, principal):
+                _common.ok("DENY reverted.")
+            else:
+                _common.fail(
+                    "Could not revert the DENY — manually run: "
+                    f"REVOKE EXECUTE ON MODEL {model_id} FROM `{principal}`"
+                )
+                notes_parts.append("WARNING: DENY cleanup failed — manual revoke needed.")
+        gov.conclude(ROW_KEY, verdict, " | ".join(notes_parts))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/experiments/coding_agent_inference_unity_ai_gateway/scripts/governance/05_deny_model_grant_gateway.py
+++ b/experiments/coding_agent_inference_unity_ai_gateway/scripts/governance/05_deny_model_grant_gateway.py
@@ -1,0 +1,175 @@
+"""Matrix row: deny_model_grant_gateway — definer's rights on the gateway.
+
+Claim/source: Databricks serving endpoints run with definer's rights — the
+endpoint OWNER needs EXECUTE on the underlying model; the CALLER only needs
+CAN_QUERY on the endpoint. Docs therefore imply a principal with DENY on the
+model but a GRANT on the gateway/serving endpoint can STILL infer.
+
+✅ means: inference succeeded despite the model-level DENY — the
+counterintuitive-but-DOCUMENTED definer's-rights behavior confirmed
+empirically ("works as documented"). Read the notes: ✅ here does NOT mean
+model-level denies gate endpoint traffic — it means the documented ownership
+model held.
+❌ means: the model DENY blocked the endpoint-permission-holding caller
+(docs contradicted).
+❓ means: untestable — TEST_PRINCIPAL unset, mutations not opted in, the DENY
+or endpoint grant was refused by the API, or no TEST_PRINCIPAL_PROFILE to
+query as the principal.
+
+Needs: TEST_PRINCIPAL, ALLOW_ENDPOINT_MUTATION=1, ideally
+TEST_PRINCIPAL_PROFILE. All mutations (model DENY, endpoint CAN_QUERY grant)
+are reverted in a finally block (best effort) — the endpoint ACL is
+snapshotted first and restored with a full-replace PUT.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import _gov_common as gov  # noqa: E402
+import _common  # noqa: E402
+
+ROW_KEY = "deny_model_grant_gateway"
+
+
+def main() -> int:
+    _common.section("05 — DENY on model + GRANT on gateway endpoint (definer's rights)")
+
+    model_id = _common.resolve_model_id()
+    endpoint_name = gov.endpoint_tail(model_id)
+    principal = gov.get_test_principal()
+    profile = gov.get_test_principal_profile()
+    print(f"  Model securable: {model_id}")
+    print(f"  Serving endpoint: {endpoint_name}")
+
+    if principal is None:
+        gov.print_test_principal_setup()
+        gov.conclude(ROW_KEY, None, "TEST_PRINCIPAL not set — untested")
+        return 0
+
+    print(f"  Target principal: {principal}")
+
+    if not gov.mutation_allowed():
+        gov.print_mutation_gate()
+        print("  The mutation path would run, then revert:")
+        print(f"    1. DENY EXECUTE ON MODEL|FUNCTION {model_id} TO `{principal}`")
+        print(f"    2. PATCH permissions/serving-endpoints/{endpoint_name}: CAN_QUERY for {principal}")
+        print("    3. Inference AS the principal — docs predict SUCCESS (definer's rights)")
+        gov.conclude(
+            ROW_KEY,
+            None,
+            f"Dry-run only: {gov.MUTATION_ENV}=1 not set — no DENY/grant "
+            "attempted, definer's-rights behavior untested",
+        )
+        return 0
+
+    denied = False
+    acl_snapshot: list[dict] | None = None
+    endpoint_id: str | None = None
+    notes_parts: list[str] = []
+    verdict: bool | None = None
+    try:
+        # --- 1. DENY EXECUTE on the model ----------------------------------
+        print("  Step 1: DENY EXECUTE on the model...")
+        deny_ok, deny_attempts = gov.try_privilege_statements("DENY", model_id, principal)
+        denied = deny_ok
+        for stmt, res in deny_attempts:
+            marker = "ok" if res["ok"] else f"{res['state']}: {gov.snip(res['error'], 150)}"
+            print(f"    {stmt} -> {marker}")
+            notes_parts.append(f"[{stmt}] -> {'OK' if res['ok'] else gov.snip(res['error'], 150)}")
+        if not deny_ok:
+            _common.fail("DENY refused by the API — the definer's-rights contrast can't be set up.")
+            verdict = None
+            notes_parts.insert(0, "DENY on the model was refused — untestable:")
+            return 0
+
+        # --- 2. GRANT CAN_QUERY on the serving endpoint --------------------
+        print("  Step 2: grant CAN_QUERY on the serving endpoint...")
+        endpoint_id = gov.get_endpoint_id(endpoint_name)
+        if not endpoint_id:
+            _common.fail(f"Could not resolve endpoint id for '{endpoint_name}'.")
+            verdict = None
+            notes_parts.insert(0, f"Endpoint '{endpoint_name}' not found/resolvable — untestable:")
+            return 0
+        acl_status, acl_body = gov.get_endpoint_acl(endpoint_id)
+        if acl_status == 200 and isinstance(acl_body, dict):
+            acl_snapshot = gov.direct_acl_entries(acl_body)
+        grant_status, grant_body = gov.grant_endpoint_can_query(endpoint_id, principal)
+        print(f"    PATCH permissions -> HTTP {grant_status}")
+        notes_parts.append(
+            f"endpoint CAN_QUERY grant -> HTTP {grant_status} ({gov.snip(grant_body, 150)})"
+        )
+        if grant_status != 200:
+            _common.fail("Endpoint permission grant refused (pay-per-token endpoints may not support per-principal ACLs).")
+            verdict = None
+            notes_parts.insert(0, "Endpoint CAN_QUERY grant refused — untestable:")
+            return 0
+
+        # --- 3. Inference AS the principal ---------------------------------
+        if not profile:
+            manual = (
+                "As the second user, run: "
+                f"RPW_MODEL={model_id} uv run python "
+                "scripts/governance/01_query_via_gateway_sso.py — docs predict "
+                "HTTP 200 despite the model DENY (definer's rights)."
+            )
+            print(f"  TEST_PRINCIPAL_PROFILE not set. Manual step: {manual}")
+            verdict = None
+            notes_parts.insert(0, f"DENY+grant in place but unverified — {manual} —")
+            return 0
+
+        with gov.as_profile(profile):
+            status, body = _common.chat_completion(model_id, "Reply with: pong", max_tokens=8)
+        print(f"  Step 3: inference AS {principal}: HTTP {status}")
+        notes_parts.append(f"inference as principal -> HTTP {status} ({gov.snip(body, 200)})")
+
+        if status == 200:
+            _common.ok(
+                "Inference SUCCEEDED despite the model-level DENY — this is the "
+                "counterintuitive-but-documented definer's-rights behavior: the "
+                "endpoint owner's EXECUTE is what counts; the caller only needs "
+                "CAN_QUERY on the endpoint."
+            )
+            verdict = True
+            notes_parts.insert(
+                0,
+                "Definer's rights confirmed as documented: model DENY + endpoint "
+                "CAN_QUERY -> inference still succeeds. Governance implication: "
+                "model-level denies do NOT gate endpoint traffic — endpoint "
+                "permissions are the real control plane:",
+            )
+        elif status in (401, 403):
+            _common.fail("Model DENY blocked the endpoint-permitted caller — contradicts documented definer's rights.")
+            verdict = False
+            notes_parts.insert(0, "Docs contradicted: model DENY blocked despite endpoint grant:")
+        else:
+            verdict = None
+            notes_parts.insert(0, f"Ambiguous HTTP {status} — neither clean success nor auth denial:")
+        return 0
+    finally:
+        if denied:
+            print("  Cleanup: reverting model DENY...")
+            ok_cleanup, attempts = gov.try_privilege_statements("REVOKE", model_id, principal)
+            if ok_cleanup:
+                _common.ok("Model DENY reverted.")
+            else:
+                _common.fail(
+                    f"DENY cleanup failed — manually run: REVOKE EXECUTE ON MODEL {model_id} FROM `{principal}`"
+                )
+                notes_parts.append("WARNING: model DENY cleanup failed — manual revoke needed.")
+        if endpoint_id and acl_snapshot is not None:
+            print("  Cleanup: restoring the endpoint's original ACL...")
+            restore_status, restore_body = gov.put_endpoint_acl(endpoint_id, acl_snapshot)
+            if restore_status == 200:
+                _common.ok("Endpoint ACL restored.")
+            else:
+                _common.fail(f"Endpoint ACL restore failed (HTTP {restore_status}): {gov.snip(restore_body, 150)}")
+                notes_parts.append("WARNING: endpoint ACL restore failed — check permissions UI.")
+        gov.conclude(ROW_KEY, verdict, " | ".join(notes_parts))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/experiments/coding_agent_inference_unity_ai_gateway/scripts/governance/06_revoke_gateway_no_fallback.py
+++ b/experiments/coding_agent_inference_unity_ai_gateway/scripts/governance/06_revoke_gateway_no_fallback.py
@@ -1,0 +1,197 @@
+"""Matrix row: revoke_gateway_no_fallback — revocation has no legacy leak.
+
+Claim/source: field reports of a leak where revoking a principal's gateway /
+serving-endpoint permission does not stop them: the workspace's LEGACY
+pay-per-token endpoints (plain `databricks-claude-*` names under
+/serving-endpoints) keep serving that principal, so access silently falls
+back around the revocation. This script is the hard repro.
+
+✅ means: revocation is airtight — after removing the principal's endpoint
+permission, BOTH (a) gateway inference with the three-part id and (b) direct
+calls to the legacy pay-per-token endpoints are refused for that principal.
+❌ means: the leak reproduces — the principal can still infer via legacy
+endpoints after the gateway revoke.
+❓ means: untestable — TEST_PRINCIPAL unset, mutations not opted in, or no
+TEST_PRINCIPAL_PROFILE to run the as-principal probes (instructions are
+printed and recorded).
+
+Needs: TEST_PRINCIPAL, ALLOW_ENDPOINT_MUTATION=1 (the revoke is a permission
+mutation), TEST_PRINCIPAL_PROFILE for the as-principal probes. The endpoint
+ACL is snapshotted before the revoke and restored in a finally block.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import _gov_common as gov  # noqa: E402
+import _common  # noqa: E402
+
+ROW_KEY = "revoke_gateway_no_fallback"
+
+
+def matches_principal(acl_entry: dict, principal: str) -> bool:
+    return principal in (
+        acl_entry.get("user_name"),
+        acl_entry.get("group_name"),
+        acl_entry.get("service_principal_name"),
+    )
+
+
+def main() -> int:
+    _common.section("06 — Gateway revoke leaves NO legacy pay-per-token fallback")
+
+    model_id = _common.resolve_model_id()
+    endpoint_name = gov.endpoint_tail(model_id)
+    principal = gov.get_test_principal()
+    profile = gov.get_test_principal_profile()
+    print(f"  Gateway model id: {model_id}")
+    print(f"  Legacy endpoint name under test: {endpoint_name}")
+
+    if principal is None:
+        gov.print_test_principal_setup()
+        gov.conclude(ROW_KEY, None, "TEST_PRINCIPAL not set — untested")
+        return 0
+
+    print(f"  Target principal: {principal}")
+
+    if not gov.mutation_allowed():
+        gov.print_mutation_gate()
+        print("  The mutation path would run, then restore the original ACL:")
+        print(f"    1. Remove {principal}'s direct permission entries on serving endpoint '{endpoint_name}'")
+        print(f"    2. AS the principal: chat_completion('{model_id}')  # expect 401/403")
+        print("    3. AS the principal: GET /api/2.0/serving-endpoints (enumerate legacy databricks-* endpoints)")
+        print(f"    4. AS the principal: POST /serving-endpoints/{endpoint_name}/invocations  # leak if 200")
+        gov.conclude(
+            ROW_KEY,
+            None,
+            f"Dry-run only: {gov.MUTATION_ENV}=1 not set — revoke-then-probe "
+            "sequence not executed, leak repro untested",
+        )
+        return 0
+
+    endpoint_id: str | None = None
+    acl_snapshot: list[dict] | None = None
+    notes_parts: list[str] = []
+    verdict: bool | None = None
+    try:
+        # --- 1. Revoke: replace ACL without the principal's entries --------
+        print("  Step 1: revoking the principal's direct endpoint permissions...")
+        endpoint_id = gov.get_endpoint_id(endpoint_name)
+        if not endpoint_id:
+            _common.fail(f"Could not resolve endpoint id for '{endpoint_name}'.")
+            verdict = None
+            notes_parts.insert(0, f"Endpoint '{endpoint_name}' not found — untestable:")
+            return 0
+        acl_status, acl_body = gov.get_endpoint_acl(endpoint_id)
+        if acl_status != 200 or not isinstance(acl_body, dict):
+            _common.fail(f"Could not read endpoint ACL (HTTP {acl_status}).")
+            verdict = None
+            notes_parts.insert(0, f"ACL read failed HTTP {acl_status} ({gov.snip(acl_body, 150)}) — untestable:")
+            return 0
+        original_entries = gov.direct_acl_entries(acl_body)
+        stripped_entries = [e for e in original_entries if not matches_principal(e, principal)]
+        had_direct = len(stripped_entries) != len(original_entries)
+        print(f"    Principal had direct entries: {had_direct}")
+        if had_direct:
+            acl_snapshot = original_entries  # only restore if we changed something
+            put_status, put_body = gov.put_endpoint_acl(endpoint_id, stripped_entries)
+            print(f"    PUT stripped ACL -> HTTP {put_status}")
+            notes_parts.append(f"revoke (PUT stripped ACL) -> HTTP {put_status}")
+            if put_status != 200:
+                _common.fail(f"Revoke PUT failed: {gov.snip(put_body, 150)}")
+                verdict = None
+                notes_parts.insert(0, "Could not revoke the endpoint permission — untestable:")
+                return 0
+        else:
+            notes_parts.append(
+                "principal had no direct endpoint permission entries (revoked "
+                "state already in effect — any remaining access is inherited/workspace-default)"
+            )
+
+        # --- 2-4. Probe AS the principal ------------------------------------
+        if not profile:
+            manual = (
+                "As the second user: (a) RPW_MODEL="
+                f"{model_id} uv run python scripts/governance/01_query_via_gateway_sso.py "
+                "(expect 401/403); (b) databricks serving-endpoints list --profile <their-profile> "
+                f"and POST /serving-endpoints/{endpoint_name}/invocations with their OAuth "
+                "token — HTTP 200 there reproduces the legacy-fallback leak."
+            )
+            print("  TEST_PRINCIPAL_PROFILE not set — cannot probe as the principal.")
+            print(f"  Manual steps: {manual}")
+            verdict = None
+            notes_parts.insert(0, f"Revoke done but probes need the second identity — {manual} —")
+            return 0
+
+        with gov.as_profile(profile):
+            principal_token = _common.get_token()
+            # (a) gateway route with the three-part id
+            gw_status, gw_body = _common.chat_completion(model_id, "Reply with: pong", max_tokens=8)
+        print(f"  (a) gateway three-part inference as principal -> HTTP {gw_status}")
+        notes_parts.append(f"gateway probe -> HTTP {gw_status} ({gov.snip(gw_body, 150)})")
+
+        # (b) enumerate + hit legacy pay-per-token endpoints as the principal
+        list_status, list_body = gov.api_request(
+            "GET", "/api/2.0/serving-endpoints", token=principal_token
+        )
+        legacy_names: list[str] = []
+        if list_status == 200 and isinstance(list_body, dict):
+            legacy_names = [
+                e.get("name", "")
+                for e in list_body.get("endpoints", [])
+                if e.get("name", "").startswith("databricks-")
+            ]
+        print(f"  (b) legacy endpoint enumeration as principal -> HTTP {list_status}, {len(legacy_names)} databricks-* endpoints visible")
+        notes_parts.append(f"legacy enumeration -> HTTP {list_status}, visible={legacy_names[:5]}")
+
+        probe_targets = [endpoint_name] + [n for n in legacy_names if n != endpoint_name][:2]
+        leaked: list[str] = []
+        for name in probe_targets:
+            inv_status, inv_body = gov.api_request(
+                "POST",
+                f"/serving-endpoints/{name}/invocations",
+                payload={"messages": [{"role": "user", "content": "Reply with: pong"}], "max_tokens": 8},
+                token=principal_token,
+            )
+            print(f"      legacy invocations '{name}' -> HTTP {inv_status}")
+            notes_parts.append(f"legacy '{name}' -> HTTP {inv_status}")
+            if inv_status == 200:
+                leaked.append(name)
+
+        gateway_blocked = gw_status in (401, 403)
+        if leaked:
+            _common.fail(
+                f"LEAK REPRODUCED: principal still infers via legacy endpoint(s) {leaked} after the gateway revoke."
+            )
+            verdict = False
+            notes_parts.insert(0, f"Leak reproduced — legacy fallback endpoints {leaked} still serve the revoked principal:")
+        elif gateway_blocked:
+            _common.ok("Revocation is airtight: gateway blocked AND no legacy endpoint served the principal.")
+            verdict = True
+            notes_parts.insert(0, "No fallback: gateway 401/403 and all legacy probes refused:")
+        elif gw_status == 200:
+            _common.fail("Gateway itself still served the principal after revoke (workspace-default/inherited access?).")
+            verdict = False
+            notes_parts.insert(0, "Gateway still serves the revoked principal (inherited/default access leak):")
+        else:
+            verdict = None
+            notes_parts.insert(0, f"Ambiguous: gateway HTTP {gw_status}, no legacy 200s:")
+        return 0
+    finally:
+        if endpoint_id and acl_snapshot is not None:
+            print("  Cleanup: restoring the endpoint's original ACL...")
+            restore_status, restore_body = gov.put_endpoint_acl(endpoint_id, acl_snapshot)
+            if restore_status == 200:
+                _common.ok("Endpoint ACL restored.")
+            else:
+                _common.fail(f"ACL restore failed (HTTP {restore_status}): {gov.snip(restore_body, 150)}")
+                notes_parts.append("WARNING: endpoint ACL restore failed — check permissions UI.")
+        gov.conclude(ROW_KEY, verdict, " | ".join(notes_parts))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/experiments/coding_agent_inference_unity_ai_gateway/scripts/governance/07_per_user_spend_alerting.py
+++ b/experiments/coding_agent_inference_unity_ai_gateway/scripts/governance/07_per_user_spend_alerting.py
@@ -1,0 +1,148 @@
+"""Matrix row: per_user_spend_alerting — AI Gateway per-user usage/alerting.
+
+Claim/source: Databricks AI Gateway docs — endpoints support usage tracking
+(per-user attribution into system tables) and per-user rate limits, which
+together are the supported path to per-user spend ALERTING (system-table
+queries + SQL alerts / budget policies). Believed ✅.
+
+✅ means: the per-user alerting configuration surface exists on this
+endpoint — usage tracking (per-user attribution) is enabled/settable, and
+the ai_gateway config exposes per-user knobs; notes list the exact fields.
+❌ means: no usage-tracking / per-user config surface exists at all.
+❓ means: the endpoint's ai_gateway config could not be read and (without
+ALLOW_ENDPOINT_MUTATION=1) settability could not be probed.
+
+This is a configuration-surface probe ONLY — it never generates spend.
+Read-only by default; with ALLOW_ENDPOINT_MUTATION=1 it will additionally
+attempt to enable usage tracking via PUT .../ai-gateway and restore the
+original config in a finally block.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import _gov_common as gov  # noqa: E402
+import _common  # noqa: E402
+
+ROW_KEY = "per_user_spend_alerting"
+
+
+def main() -> int:
+    _common.section("07 — Per-user spend alerting config surface (AI Gateway)")
+
+    model_id = _common.resolve_model_id()
+    endpoint_name = gov.endpoint_tail(model_id)
+    print(f"  Model: {model_id}")
+    print(f"  Endpoint probed: {endpoint_name}")
+    print("  Configuration-surface probe only — this script never generates spend.")
+
+    status, body = gov.get_serving_endpoint(endpoint_name)
+    print(f"  GET /api/2.0/serving-endpoints/{endpoint_name} -> HTTP {status}")
+    if status != 200 or not isinstance(body, dict):
+        gov.conclude(
+            ROW_KEY,
+            None,
+            f"Could not read endpoint '{endpoint_name}' (HTTP {status}: "
+            f"{gov.snip(body, 200)}) — ai_gateway alerting surface unobservable",
+        )
+        return 1
+
+    ai_gateway = body.get("ai_gateway", {}) or {}
+    print(f"  ai_gateway config present: {bool(ai_gateway)}")
+    if ai_gateway:
+        print(f"  ai_gateway keys: {sorted(ai_gateway.keys())}")
+        print(f"  ai_gateway (verbatim): {json.dumps(ai_gateway, indent=2, sort_keys=True)}")
+
+    usage_cfg = ai_gateway.get("usage_tracking_config") or {}
+    usage_enabled = bool(usage_cfg.get("enabled"))
+    rate_limits = ai_gateway.get("rate_limits") or []
+    per_user_limits = [rl for rl in rate_limits if rl.get("key") == "user"]
+
+    field_report = (
+        f"ai_gateway keys={sorted(ai_gateway.keys()) if ai_gateway else '(absent)'}; "
+        f"usage_tracking_config={gov.snip(usage_cfg, 150) or '(absent)'}; "
+        f"rate_limits={gov.snip(rate_limits, 200) or '(absent)'}; "
+        f"per-user rate limits={len(per_user_limits)}"
+    )
+
+    if usage_enabled:
+        _common.ok("usage_tracking_config.enabled=true — per-user attribution flows to system tables.")
+        gov.conclude(
+            ROW_KEY,
+            True,
+            "Per-user alerting surface present: usage tracking is ON (per-user "
+            "attribution into system.serving usage tables — the documented "
+            "basis for spend alerts via SQL alerts/budget policies). Note: no "
+            "direct 'alert at $X per user' field exists ON the endpoint; "
+            f"alerting is composed from these knobs. {field_report}",
+        )
+        return 0
+
+    # Usage tracking not enabled (or ai_gateway absent). Settability probe is
+    # a mutation — gate it.
+    if not gov.mutation_allowed():
+        gov.print_mutation_gate()
+        print("  The mutation path would attempt (then restore):")
+        print(f"    PUT /api/2.0/serving-endpoints/{endpoint_name}/ai-gateway")
+        print('    {"usage_tracking_config": {"enabled": true}}')
+        gov.conclude(
+            ROW_KEY,
+            None,
+            "usage tracking not currently enabled on this endpoint and "
+            f"{gov.MUTATION_ENV}=1 not set, so settability was not probed. "
+            f"{field_report}",
+        )
+        return 0
+
+    original_gateway = ai_gateway
+    mutated = False
+    try:
+        put_status, put_body = gov.api_request(
+            "PUT",
+            f"/api/2.0/serving-endpoints/{endpoint_name}/ai-gateway",
+            payload={"usage_tracking_config": {"enabled": True}},
+        )
+        mutated = put_status == 200
+        print(f"  PUT ai-gateway usage_tracking enabled -> HTTP {put_status}")
+        if put_status == 200:
+            _common.ok("Usage tracking accepted configuration — alerting surface is settable.")
+            gov.conclude(
+                ROW_KEY,
+                True,
+                "usage_tracking_config accepted enabled=true via PUT ai-gateway "
+                f"(restored afterwards). {field_report}",
+            )
+            return 0
+        _common.fail("The endpoint refused usage-tracking configuration.")
+        gov.conclude(
+            ROW_KEY,
+            False,
+            f"PUT ai-gateway usage_tracking -> HTTP {put_status} "
+            f"({gov.snip(put_body, 200)}) — no per-user alerting surface on "
+            f"this endpoint. {field_report}",
+        )
+        return 1
+    finally:
+        if mutated:
+            print("  Cleanup: restoring the original ai_gateway config...")
+            restore_status, restore_body = gov.api_request(
+                "PUT",
+                f"/api/2.0/serving-endpoints/{endpoint_name}/ai-gateway",
+                payload=original_gateway,
+            )
+            if restore_status == 200:
+                _common.ok("ai_gateway config restored.")
+            else:
+                _common.fail(
+                    f"ai_gateway restore failed (HTTP {restore_status}): "
+                    f"{gov.snip(restore_body, 150)} — restore manually in the UI."
+                )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/experiments/coding_agent_inference_unity_ai_gateway/scripts/governance/08_per_user_hard_cap.py
+++ b/experiments/coding_agent_inference_unity_ai_gateway/scripts/governance/08_per_user_hard_cap.py
@@ -1,0 +1,144 @@
+"""Matrix row: per_user_hard_cap — a HARD per-user budget cap (block mode).
+
+Claim/source: a Data+AI Summit talk claimed per-user budget caps that BLOCK
+at budget. Current AI Gateway docs only show usage tracking (alert-style,
+after-the-fact) and rate limits (requests/tokens per renewal period — rate
+caps, not spend caps). Believed ❌ today.
+
+✅ means: a real block-at-budget knob exists on the endpoint/gateway config
+AND accepts a value (e.g. a spend/budget field with a block/enforce mode).
+❌ means: only alert-style surfaces exist — usage tracking and/or rate
+limits, with NO spend-denominated cap that blocks; the verbatim field list
+is in notes.
+❓ means: the endpoint config could not be read at all.
+
+Configuration-surface probe ONLY — never generates spend. Read-only by
+default; with ALLOW_ENDPOINT_MUTATION=1 it additionally offers the API a
+hypothetical budget-cap payload to prove the schema rejects it, restoring
+the original config in a finally block.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import _gov_common as gov  # noqa: E402
+import _common  # noqa: E402
+
+ROW_KEY = "per_user_hard_cap"
+
+# Key fragments that would indicate a spend-denominated cap with block-mode.
+CAP_MARKERS = ("budget", "spend", "cost", "dollar", "cap", "block")
+
+
+def main() -> int:
+    _common.section("08 — HARD per-user budget cap (block-at-budget) probe")
+
+    model_id = _common.resolve_model_id()
+    endpoint_name = gov.endpoint_tail(model_id)
+    print(f"  Model: {model_id}")
+    print(f"  Endpoint probed: {endpoint_name}")
+    print("  Configuration-surface probe only — this script never generates spend.")
+
+    status, body = gov.get_serving_endpoint(endpoint_name)
+    print(f"  GET /api/2.0/serving-endpoints/{endpoint_name} -> HTTP {status}")
+    if status != 200 or not isinstance(body, dict):
+        gov.conclude(
+            ROW_KEY,
+            None,
+            f"Could not read endpoint '{endpoint_name}' (HTTP {status}: "
+            f"{gov.snip(body, 200)}) — cap surface unobservable",
+        )
+        return 1
+
+    ai_gateway = body.get("ai_gateway", {}) or {}
+    all_keys = sorted(set(gov.collect_keys(ai_gateway)))
+    print(f"  ai_gateway present: {bool(ai_gateway)}")
+    print(f"  ai_gateway key paths (verbatim): {all_keys or '(none)'}")
+    if ai_gateway:
+        print(f"  ai_gateway (verbatim): {json.dumps(ai_gateway, indent=2, sort_keys=True)}")
+
+    cap_like = [
+        k for k in all_keys if any(m in k.lower() for m in CAP_MARKERS)
+    ]
+    rate_limits = ai_gateway.get("rate_limits") or []
+    per_user_rate = [rl for rl in rate_limits if rl.get("key") == "user"]
+
+    field_report = (
+        f"ai_gateway key paths={all_keys or '(none)'}; cap-like keys={cap_like or 'NONE'}; "
+        f"rate_limits(verbatim)={gov.snip(rate_limits, 250) or '(absent)'}"
+    )
+
+    mutation_probe_note = ""
+    if gov.mutation_allowed():
+        # Offer the API a hypothetical budget-cap field; a schema rejection is
+        # positive evidence the knob does not exist. This does not change any
+        # real config on success-rejection, but treat it as a mutation attempt
+        # anyway and restore if it somehow lands.
+        probe_payload = dict(ai_gateway) if ai_gateway else {}
+        probe_payload["budget_config"] = {
+            "per_user_monthly_usd": 1,
+            "on_exceeded": "BLOCK",
+        }
+        put_status, put_body = gov.api_request(
+            "PUT",
+            f"/api/2.0/serving-endpoints/{endpoint_name}/ai-gateway",
+            payload=probe_payload,
+        )
+        print(f"  Mutation probe: PUT hypothetical budget_config -> HTTP {put_status}")
+        mutation_probe_note = (
+            f" Mutation probe: PUT hypothetical budget_config -> HTTP {put_status} "
+            f"({gov.snip(put_body, 200)})."
+        )
+        if put_status == 200:
+            # Unexpected: the API accepted a budget field — restore immediately.
+            print("  Unexpected acceptance — restoring original ai_gateway config...")
+            gov.api_request(
+                "PUT",
+                f"/api/2.0/serving-endpoints/{endpoint_name}/ai-gateway",
+                payload=ai_gateway,
+            )
+            gov.conclude(
+                ROW_KEY,
+                True,
+                "A budget_config field was ACCEPTED by PUT ai-gateway — a "
+                "block-at-budget knob may exist (verify enforcement "
+                f"separately). {field_report}.{mutation_probe_note}",
+            )
+            return 0
+    else:
+        print(f"  ({gov.MUTATION_ENV}=1 would additionally offer the API a hypothetical")
+        print("   budget_config payload to prove the schema rejects it.)")
+
+    if cap_like:
+        gov.conclude(
+            ROW_KEY,
+            True,
+            f"Found cap-like config keys on the endpoint: {cap_like} — inspect "
+            f"whether they block (vs alert). {field_report}.{mutation_probe_note}",
+        )
+        return 0
+
+    _common.fail("No spend-denominated block-at-budget knob exists on this endpoint.")
+    print("  What DOES exist: usage tracking (after-the-fact attribution) and")
+    print("  rate_limits (requests/tokens per renewal period — rate caps, not")
+    print("  spend caps). The Summit-talk claim of a per-user block-at-budget")
+    print("  cap is not present in this workspace's API surface.")
+    gov.conclude(
+        ROW_KEY,
+        False,
+        "No hard per-user budget cap: ai_gateway exposes only alert-style "
+        "surfaces (usage tracking) and rate caps (rate_limits per user/"
+        "endpoint), no spend-denominated block-at-budget field. "
+        f"Per-user rate limits found: {len(per_user_rate)}. {field_report}."
+        f"{mutation_probe_note}",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/experiments/coding_agent_inference_unity_ai_gateway/scripts/governance/09_usage_tracking_per_user_agent.py
+++ b/experiments/coding_agent_inference_unity_ai_gateway/scripts/governance/09_usage_tracking_per_user_agent.py
@@ -1,0 +1,196 @@
+"""Matrix row: usage_tracking_per_user_agent — per-user + per-agent usage rows.
+
+Claim/source: AI Gateway usage tracking docs — inference usage lands in
+system tables (system.serving.*) with per-user attribution and client
+metadata, enabling per-user/per-agent chargeback and monitoring.
+
+✅ means: the usage system table exists, is queryable with the SSO token via
+the SQL Statements API, and exposes BOTH a per-user identity column AND a
+user_agent/client-identity column; notes name the exact table and columns.
+❓ means: partial proof — e.g. per-user attribution visible but no
+user_agent column, the table exists but has no rows yet (ingestion latency
+may exceed this script's runtime), or no SQL warehouse was available.
+❌ means: no usage system table with per-user attribution exists at all.
+
+Method: make one tiny real inference first with a distinctive User-Agent
+header and a `usage_context` payload marker (via _common.chat_completion's
+extra_headers/extra_payload), then discover tables via SHOW TABLES IN
+system.serving and columns via DESCRIBE, sample rows, and additionally hunt
+for the marker itself (ingestion latency may hide it — that's noted, not
+failed). Read-only apart from the one tiny inference; no mutations, no gate.
+"""
+
+from __future__ import annotations
+
+import sys
+import uuid
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import _gov_common as gov  # noqa: E402
+import _common  # noqa: E402
+
+ROW_KEY = "usage_tracking_per_user_agent"
+
+USER_COL_MARKERS = ("requester", "user", "created_by", "executed_as", "run_as")
+# usage_context is the documented per-agent/per-client attribution mechanism
+# (a caller-supplied map on the request); user_agent/client_* are candidates.
+AGENT_COL_MARKERS = ("user_agent", "client", "agent", "usage_context")
+
+
+def main() -> int:
+    _common.section("09 — Usage tracking: per-user and per-agent attribution")
+
+    model_id = _common.resolve_model_id()
+    print(f"  Model: {model_id}")
+
+    # --- Step 1: one tiny real inference so a fresh usage row should exist --
+    # Distinctive marker in BOTH the User-Agent header and the documented
+    # usage_context payload field, so either attribution mechanism can match.
+    marker = f"uag-experiment-row09-{uuid.uuid4().hex[:12]}"
+    status, body = _common.chat_completion(
+        model_id,
+        "Reply with: pong",
+        max_tokens=8,
+        extra_headers={"User-Agent": marker},
+        extra_payload={"usage_context": {"client": marker}},
+    )
+    print(f"  Fresh inference for attribution: HTTP {status} (marker: {marker})")
+    inference_note = f"fresh inference HTTP {status} with marker '{marker}' in User-Agent + usage_context"
+
+    # --- Step 2: discover the usage tables ---------------------------------
+    try:
+        gov.get_warehouse_id()
+    except RuntimeError as exc:
+        gov.conclude(ROW_KEY, None, f"No SQL warehouse available — {exc}")
+        return 1
+
+    show = gov.sql_exec("SHOW TABLES IN system.serving")
+    if not show["ok"]:
+        gov.conclude(
+            ROW_KEY,
+            None,
+            "Could not enumerate system.serving tables via the SQL Statements "
+            f"API ({show['state']}: {gov.snip(show['error'], 250)}). "
+            f"{inference_note}",
+        )
+        return 1
+    tables = [row[1] for row in show["rows"]]
+    print(f"  Tables in system.serving: {tables}")
+
+    # Prefer the documented usage table; fall back to anything usage-like.
+    candidates = [t for t in tables if "usage" in t.lower()] or tables
+    if not candidates:
+        gov.conclude(
+            ROW_KEY,
+            False,
+            f"system.serving contains no tables — no usage tracking surface. {inference_note}",
+        )
+        return 1
+    table = f"system.serving.{candidates[0]}"
+    print(f"  Probing table: {table}")
+
+    desc = gov.sql_exec(f"DESCRIBE TABLE {table}")
+    if not desc["ok"]:
+        gov.conclude(
+            ROW_KEY,
+            None,
+            f"{table} exists but DESCRIBE failed ({gov.snip(desc['error'], 250)}). {inference_note}",
+        )
+        return 1
+    columns = [row[0] for row in desc["rows"] if row and row[0] and not row[0].startswith("#")]
+    print(f"  Columns: {columns}")
+
+    user_cols = [c for c in columns if any(m in c.lower() for m in USER_COL_MARKERS)]
+    agent_cols = [c for c in columns if any(m in c.lower() for m in AGENT_COL_MARKERS)]
+    print(f"  Per-user identity columns: {user_cols or 'NONE'}")
+    print(f"  User-agent / client columns: {agent_cols or 'NONE'}")
+
+    # --- Step 3: sample rows to prove attribution is POPULATED --------------
+    # A column merely existing is not attribution — the values must be there.
+    selected = (user_cols + agent_cols)[:6] or [columns[0]]
+    sample = gov.sql_exec(f"SELECT {', '.join(selected)} FROM {table} LIMIT 10")
+    rows_seen = len(sample["rows"]) if sample["ok"] else 0
+    print(f"  Sample query ok={sample['ok']}, rows returned: {rows_seen}")
+    if sample["ok"] and sample["rows"]:
+        print(f"  Sample (verbatim, truncated): {gov.snip(sample['rows'], 300)}")
+
+    def populated(col: str) -> bool:
+        if not (sample["ok"] and sample["rows"] and col in selected):
+            return False
+        idx = selected.index(col)
+        return any(
+            row[idx] not in (None, "", "null", "{}") for row in sample["rows"]
+        )
+
+    user_populated = [c for c in user_cols if populated(c)]
+    agent_populated = [c for c in agent_cols if populated(c)]
+    print(f"  Populated per-user columns: {user_populated or 'NONE'}")
+    print(f"  Populated agent/client columns: {agent_populated or 'NONE'}")
+
+    # --- Step 3b: hunt for THIS run's marker (best-effort; lag expected) ----
+    marker_note = ""
+    if agent_cols:
+        predicate = " OR ".join(
+            f"CAST({c} AS STRING) LIKE '%{marker}%'" for c in agent_cols
+        )
+        hunt = gov.sql_exec(
+            f"SELECT COUNT(*) FROM {table} WHERE {predicate}"
+        )
+        if hunt["ok"]:
+            hits = int(hunt["rows"][0][0]) if hunt["rows"] else 0
+            marker_note = (
+                f" Marker hunt: {hits} row(s) matched '{marker}'"
+                + ("" if hits else " (ingestion latency likely exceeds this run)")
+                + "."
+            )
+            print(f"  Marker rows found: {hits}")
+            if hits:
+                agent_populated = agent_populated or agent_cols
+
+    detail = (
+        f"table={table}; user columns={user_cols} (populated: {user_populated}); "
+        f"agent/client columns={agent_cols} (populated: {agent_populated}); "
+        f"sampled rows={rows_seen}"
+        + ("" if sample["ok"] else f"; sample query error={gov.snip(sample['error'], 150)}")
+        + f". {inference_note}.{marker_note}"
+    )
+
+    if user_populated and agent_populated:
+        _common.ok("Per-user AND per-agent attribution populated in the usage system table.")
+        gov.conclude(
+            ROW_KEY,
+            True,
+            "Per-user + agent/client attribution proven with populated values "
+            "in the usage system table. Freshness caveat: ingestion latency "
+            f"may exceed this run, so the just-made inference row itself was "
+            f"not chased. {detail}",
+        )
+        return 0
+    if user_populated:
+        gov.conclude(
+            ROW_KEY,
+            None,
+            "Per-user attribution PROVEN (populated), but per-agent attribution "
+            "unproven: the agent/client columns exist in the schema yet were "
+            "empty/null in every sampled row — callers must send user_agent/"
+            f"usage_context metadata for it to populate. {detail}",
+        )
+        return 0
+    if user_cols and rows_seen == 0:
+        gov.conclude(
+            ROW_KEY,
+            None,
+            "Schema has the attribution columns but no rows were readable yet "
+            "(ingestion latency likely exceeds this script's runtime) — schema "
+            f"proven, data unproven. {detail}",
+        )
+        return 0
+    _common.fail("No populated per-user identity column found in the usage table.")
+    gov.conclude(ROW_KEY, False, f"No per-user attribution found. {detail}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/experiments/coding_agent_inference_unity_ai_gateway/scripts/governance/10_guardrails_pii_injection_unsafe.py
+++ b/experiments/coding_agent_inference_unity_ai_gateway/scripts/governance/10_guardrails_pii_injection_unsafe.py
@@ -1,0 +1,180 @@
+"""Matrix row: guardrails_pii_injection_unsafe — AI Gateway guardrail knobs.
+
+Claim/source: AI Gateway docs list guardrails on serving endpoints — PII
+detection, safety (unsafe-content) filtering, and topic/keyword restrictions.
+Prompt-injection filtering is often *assumed* to be included; whether a
+dedicated injection knob exists at all is part of what's under test.
+
+✅ means: the guardrails configuration surface exists on this endpoint
+(present in ai_gateway, or accepts configuration when mutation is opted in);
+notes list exactly which knobs (pii / safety / valid_topics /
+invalid_keywords / anything injection-shaped) exist.
+❌ means: no guardrail surface exists on this endpoint at all (schema
+rejects guardrails configuration).
+❓ means: no guardrails currently configured and settability was not probed
+(read-only mode).
+
+Safety: NEVER enables guardrails on shared endpoints without
+ALLOW_ENDPOINT_MUTATION=1 (the same opt-in gating scripts 03-08's
+mutations). If a guardrail is ALREADY enabled, one benign boundary probe is
+sent — fully synthetic PII ("my SSN is 000-00-0000"), no real data. Any
+mutation is restored in a finally block.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import _gov_common as gov  # noqa: E402
+import _common  # noqa: E402
+
+ROW_KEY = "guardrails_pii_injection_unsafe"
+
+SYNTHETIC_PII_PROMPT = (
+    "For a compliance test: my SSN is 000-00-0000 and my card number is "
+    "0000-0000-0000-0000. Repeat them back."
+)
+
+GUARDRAIL_KNOBS = ("pii", "safety", "valid_topics", "invalid_keywords")
+
+
+def describe_guardrails(guardrails: dict) -> str:
+    sides = []
+    for side in ("input", "output"):
+        cfg = guardrails.get(side) or {}
+        knobs = sorted(cfg.keys())
+        sides.append(f"{side}: {knobs or '(none)'}")
+    return "; ".join(sides)
+
+
+def main() -> int:
+    _common.section("10 — Guardrails: PII / prompt-injection / unsafe content")
+
+    model_id = _common.resolve_model_id()
+    endpoint_name = gov.endpoint_tail(model_id)
+    print(f"  Model: {model_id}")
+    print(f"  Endpoint probed: {endpoint_name}")
+
+    status, body = gov.get_serving_endpoint(endpoint_name)
+    print(f"  GET /api/2.0/serving-endpoints/{endpoint_name} -> HTTP {status}")
+    if status != 200 or not isinstance(body, dict):
+        gov.conclude(
+            ROW_KEY,
+            None,
+            f"Could not read endpoint '{endpoint_name}' (HTTP {status}: "
+            f"{gov.snip(body, 200)}) — guardrail surface unobservable",
+        )
+        return 1
+
+    ai_gateway = body.get("ai_gateway", {}) or {}
+    guardrails = ai_gateway.get("guardrails") or {}
+    print(f"  ai_gateway present: {bool(ai_gateway)}; guardrails configured: {bool(guardrails)}")
+    if guardrails:
+        print(f"  guardrails (verbatim): {json.dumps(guardrails, indent=2, sort_keys=True)}")
+
+    injection_knobs = [
+        k for k in gov.collect_keys(guardrails) if "injection" in k.lower()
+    ]
+
+    # --- Case A: guardrails already enabled — safe to send one benign probe -
+    if guardrails:
+        knob_report = describe_guardrails(guardrails)
+        print("  A guardrail is already enabled — sending ONE benign synthetic-PII boundary probe.")
+        probe_status, probe_body = _common.chat_completion(
+            model_id, SYNTHETIC_PII_PROMPT, max_tokens=48
+        )
+        print(f"  Synthetic-PII probe -> HTTP {probe_status}: {gov.snip(probe_body, 200)}")
+        gov.conclude(
+            ROW_KEY,
+            True,
+            f"Guardrail surface exists and is configured ({knob_report}). "
+            f"Synthetic-PII boundary probe (000-00-0000) -> HTTP {probe_status} "
+            f"({gov.snip(probe_body, 200)}). No dedicated prompt-injection knob "
+            f"observed{' (injection-shaped keys: ' + str(injection_knobs) + ')' if injection_knobs else ''} — "
+            "documented knobs are pii/safety/valid_topics/invalid_keywords.",
+        )
+        return 0
+
+    # --- Case B: not configured; probing settability is a mutation ---------
+    if not gov.mutation_allowed():
+        gov.print_mutation_gate()
+        print("  The mutation path would attempt (then restore):")
+        print(f"    PUT /api/2.0/serving-endpoints/{endpoint_name}/ai-gateway")
+        print('    {"guardrails": {"input": {"pii": {"behavior": "BLOCK"}, "safety": true}}}')
+        print("  Never enable guardrails on shared endpoints without this opt-in.")
+        gov.conclude(
+            ROW_KEY,
+            None,
+            "No guardrails currently configured on this endpoint and "
+            f"{gov.MUTATION_ENV}=1 not set — settability not probed (dry-run). "
+            f"Documented knobs to probe: {GUARDRAIL_KNOBS} on input/output; a "
+            "dedicated prompt-injection filter is NOT in the documented schema. "
+            f"ai_gateway keys={sorted(ai_gateway.keys()) if ai_gateway else '(absent)'}",
+        )
+        return 0
+
+    original_gateway = ai_gateway
+    mutated = False
+    try:
+        probe_payload = dict(ai_gateway) if ai_gateway else {}
+        probe_payload["guardrails"] = {
+            "input": {"pii": {"behavior": "BLOCK"}, "safety": True}
+        }
+        put_status, put_body = gov.api_request(
+            "PUT",
+            f"/api/2.0/serving-endpoints/{endpoint_name}/ai-gateway",
+            payload=probe_payload,
+        )
+        mutated = put_status == 200
+        print(f"  PUT ai-gateway guardrails -> HTTP {put_status}: {gov.snip(put_body, 200)}")
+        if put_status == 200:
+            _common.ok("Guardrails accepted configuration (pii BLOCK + safety on input).")
+            print("  Sending ONE benign synthetic-PII boundary probe while enabled...")
+            probe_status, probe_body = _common.chat_completion(
+                model_id, SYNTHETIC_PII_PROMPT, max_tokens=48
+            )
+            print(f"  Synthetic-PII probe -> HTTP {probe_status}: {gov.snip(probe_body, 250)}")
+            gov.conclude(
+                ROW_KEY,
+                True,
+                "Guardrail surface exists and accepts configuration (input.pii "
+                "behavior=BLOCK, input.safety=true accepted via PUT ai-gateway; "
+                "restored afterwards). Synthetic-PII probe while enabled -> "
+                f"HTTP {probe_status} ({gov.snip(probe_body, 200)}). No dedicated "
+                "prompt-injection knob in the schema — knobs are "
+                "pii/safety/valid_topics/invalid_keywords.",
+            )
+            return 0
+        _common.fail("Guardrails configuration refused by this endpoint.")
+        gov.conclude(
+            ROW_KEY,
+            False,
+            f"PUT ai-gateway guardrails -> HTTP {put_status} "
+            f"({gov.snip(put_body, 250)}) — no guardrail surface available on "
+            f"this endpoint. ai_gateway keys={sorted(ai_gateway.keys()) if ai_gateway else '(absent)'}",
+        )
+        return 1
+    finally:
+        if mutated:
+            print("  Cleanup: restoring the original ai_gateway config...")
+            restore_status, restore_body = gov.api_request(
+                "PUT",
+                f"/api/2.0/serving-endpoints/{endpoint_name}/ai-gateway",
+                payload=original_gateway,
+            )
+            if restore_status == 200:
+                _common.ok("ai_gateway config restored (guardrails removed).")
+            else:
+                _common.fail(
+                    f"ai_gateway restore FAILED (HTTP {restore_status}): "
+                    f"{gov.snip(restore_body, 150)} — remove the guardrails "
+                    "manually in the serving UI."
+                )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/experiments/coding_agent_inference_unity_ai_gateway/scripts/governance/_gov_common.py
+++ b/experiments/coding_agent_inference_unity_ai_gateway/scripts/governance/_gov_common.py
@@ -1,0 +1,408 @@
+"""Shared plumbing for the governance capability-matrix scripts.
+
+These helpers sit ON TOP of ``scripts/_common.py`` (the experiment's source
+of truth for SSO auth, model-id validation, inference, and results
+recording) — they never replace it. Everything here uses the same
+SSO/OAuth-only token path; zero PATs by construction.
+
+What this module adds:
+
+* a sys.path shim so scripts one level below ``scripts/`` can import
+  ``_common`` (import ``_gov_common`` first, then ``import _common`` works);
+* raw REST calls (``api_request``) against the workspace with the OAuth token;
+* SQL Statements API execution (``sql_exec``) for GRANT/REVOKE/DENY probes
+  and system-table queries;
+* the ``ALLOW_ENDPOINT_MUTATION=1`` safety gate shared by scripts 03-08/10 —
+  every mutation path defaults to dry-run unless explicitly opted in;
+* the second-principal pattern (``TEST_PRINCIPAL`` / ``TEST_PRINCIPAL_PROFILE``)
+  including ``as_profile()`` to run a query authenticated as that principal;
+* ``conclude()`` — the one-and-only ``record_result`` call site per script.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+import requests
+
+# --- sys.path shim: make scripts/ importable from scripts/governance/ ------
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import _common  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Safety gate for anything that mutates workspace state
+# ---------------------------------------------------------------------------
+
+MUTATION_ENV = "ALLOW_ENDPOINT_MUTATION"
+
+
+def mutation_allowed() -> bool:
+    """True only when the operator explicitly opted in to mutations."""
+    return os.environ.get(MUTATION_ENV, "").strip() == "1"
+
+
+def print_mutation_gate() -> None:
+    """Explain the dry-run default for mutation-bearing scripts."""
+    print(f"  {MUTATION_ENV} is not set to 1 — running in DRY-RUN mode.")
+    print("  No grants, denies, permissions, or endpoint configs will be changed.")
+    print(f"  To run the mutation path for real:  {MUTATION_ENV}=1 uv run python <this script>")
+
+
+# ---------------------------------------------------------------------------
+# Second-principal pattern (scripts 03-06)
+# ---------------------------------------------------------------------------
+
+def get_test_principal() -> str | None:
+    """User email or group name that grants/denies target (env TEST_PRINCIPAL)."""
+    value = os.environ.get("TEST_PRINCIPAL", "").strip()
+    return value or None
+
+
+def get_test_principal_profile() -> str | None:
+    """databrickscfg profile authenticated AS the test principal (optional)."""
+    value = os.environ.get("TEST_PRINCIPAL_PROFILE", "").strip()
+    return value or None
+
+
+def print_test_principal_setup() -> None:
+    """Setup guidance when TEST_PRINCIPAL is missing."""
+    print("  TEST_PRINCIPAL is not set — this row needs a second (target) principal.")
+    print("  Setup:")
+    print("    1. Pick (or create) a second workspace user or group with no special grants.")
+    print("    2. export TEST_PRINCIPAL='second.user@example.com'   # or a group name")
+    print("    3. Optional but recommended, to run the query-as-that-user step:")
+    print("       databricks auth login --host <workspace-url> --profile test-principal")
+    print("       (log in AS the second user), then export TEST_PRINCIPAL_PROFILE=test-principal")
+    print(f"    4. Re-run with {MUTATION_ENV}=1 to allow the grant/revoke mutations.")
+
+
+@contextlib.contextmanager
+def as_profile(profile: str):
+    """Temporarily switch _common's SSO token minting to another CLI profile.
+
+    ``_common.get_token()`` shells out to ``bin/get-databricks-token.sh`` on
+    every call and honors DATABRICKS_CONFIG_PROFILE, so swapping the env var
+    is enough to make subsequent calls authenticate as the other principal.
+    """
+    saved = os.environ.get("DATABRICKS_CONFIG_PROFILE")
+    os.environ["DATABRICKS_CONFIG_PROFILE"] = profile
+    try:
+        yield
+    finally:
+        if saved is None:
+            os.environ.pop("DATABRICKS_CONFIG_PROFILE", None)
+        else:
+            os.environ["DATABRICKS_CONFIG_PROFILE"] = saved
+
+
+# ---------------------------------------------------------------------------
+# Raw REST + SQL Statements API (same OAuth token as _common)
+# ---------------------------------------------------------------------------
+
+def api_request(
+    method: str,
+    path: str,
+    payload: dict | None = None,
+    token: str | None = None,
+) -> tuple[int, dict | list | str]:
+    """One workspace REST call. Returns (status, parsed-json-or-text).
+
+    Never raises on non-2xx — governance rows need to observe 403s/404s as
+    data. ``path`` is e.g. ``/api/2.0/serving-endpoints``.
+    """
+    host = _common.get_host()
+    if token is None:
+        token = _common.get_token()
+    resp = requests.request(
+        method.upper(),
+        f"{host}{path}",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+        json=payload,
+        timeout=120,
+    )
+    try:
+        body: dict | list | str = resp.json()
+    except ValueError:
+        body = resp.text
+    return resp.status_code, body
+
+
+_WAREHOUSE_ID: str | None = None
+
+
+def get_warehouse_id() -> str:
+    """Resolve a SQL warehouse for the Statements API.
+
+    Precedence: DATABRICKS_WAREHOUSE_ID env var, else the first RUNNING
+    warehouse, else the first warehouse of any state. Raises RuntimeError
+    with guidance when none exists.
+    """
+    global _WAREHOUSE_ID
+    if _WAREHOUSE_ID:
+        return _WAREHOUSE_ID
+    env_id = os.environ.get("DATABRICKS_WAREHOUSE_ID", "").strip()
+    if env_id:
+        _WAREHOUSE_ID = env_id
+        return env_id
+    status, body = api_request("GET", "/api/2.0/sql/warehouses")
+    warehouses = body.get("warehouses", []) if isinstance(body, dict) else []
+    if status != 200 or not warehouses:
+        raise RuntimeError(
+            "No SQL warehouse available for the SQL Statements API "
+            f"(GET /api/2.0/sql/warehouses -> {status}). Set "
+            "DATABRICKS_WAREHOUSE_ID to a warehouse id and re-run."
+        )
+    # Prefer an already-RUNNING warehouse; else serverless (starts in
+    # seconds); else anything (classic warehouses can take minutes to start).
+    running = [w for w in warehouses if w.get("state") == "RUNNING"]
+    serverless = [w for w in warehouses if w.get("enable_serverless_compute")]
+    _WAREHOUSE_ID = (running or serverless or warehouses)[0]["id"]
+    return _WAREHOUSE_ID
+
+
+def sql_exec(statement: str, token: str | None = None) -> dict:
+    """Run one SQL statement via the Statements API using the OAuth token.
+
+    Returns {"ok": bool, "state": str, "error": str, "columns": [...],
+    "rows": [...]}. SQL-level failures set ok=False with the error message —
+    they never raise, because refused GRANT/DENY syntax is exactly the data
+    these probes exist to capture.
+    """
+    warehouse_id = get_warehouse_id()
+    status, body = api_request(
+        "POST",
+        "/api/2.0/sql/statements",
+        payload={
+            "statement": statement,
+            "warehouse_id": warehouse_id,
+            "wait_timeout": "30s",
+            "on_wait_timeout": "CONTINUE",
+        },
+        token=token,
+    )
+    if status != 200 or not isinstance(body, dict):
+        return {
+            "ok": False,
+            "state": f"HTTP_{status}",
+            "error": snip(body),
+            "columns": [],
+            "rows": [],
+        }
+
+    # Poll while the statement is still PENDING/RUNNING (post wait_timeout).
+    # Generous deadline: a cold (even serverless) warehouse start is included.
+    statement_id = body.get("statement_id")
+    deadline = time.time() + 300
+    while (
+        isinstance(body, dict)
+        and body.get("status", {}).get("state") in ("PENDING", "RUNNING")
+        and time.time() < deadline
+    ):
+        time.sleep(2)
+        status, body = api_request(
+            "GET", f"/api/2.0/sql/statements/{statement_id}", token=token
+        )
+        if status != 200 or not isinstance(body, dict):
+            return {
+                "ok": False,
+                "state": f"HTTP_{status}",
+                "error": snip(body),
+                "columns": [],
+                "rows": [],
+            }
+
+    state = body.get("status", {}).get("state", "UNKNOWN")
+    error = body.get("status", {}).get("error", {}).get("message", "")
+    if state in ("PENDING", "RUNNING"):
+        error = (
+            "statement still {0} after 300s poll deadline (warehouse likely "
+            "still starting) — re-run once a SQL warehouse is RUNNING".format(state)
+        )
+    columns = [
+        c.get("name")
+        for c in body.get("manifest", {}).get("schema", {}).get("columns", [])
+    ]
+    rows = body.get("result", {}).get("data_array", []) or []
+    return {
+        "ok": state == "SUCCEEDED",
+        "state": state,
+        "error": error,
+        "columns": columns,
+        "rows": rows,
+    }
+
+
+def sql_quote_principal(principal: str) -> str:
+    """Backtick-quote a principal for GRANT/REVOKE/DENY SQL."""
+    return "`" + principal.replace("`", "``") + "`"
+
+
+def try_privilege_statements(
+    verb: str, model_id: str, principal: str, token: str | None = None
+) -> tuple[bool, list[tuple[str, dict]]]:
+    """Attempt GRANT/REVOKE/DENY EXECUTE against the model securable.
+
+    The exact securable keyword for foundation-model services is itself part
+    of what's under test (suspected gated behind the account-console
+    "Foundation Model Permissions" Preview/Beta), so we try both spellings —
+    UC registered models surface as securable type FUNCTION in the grants
+    API, while SQL also documents a MODEL keyword. Returns
+    (any_succeeded, [(statement, result), ...]) with verbatim errors kept.
+    """
+    verb = verb.upper()
+    keyword = "FROM" if verb == "REVOKE" else "TO"
+    quoted = sql_quote_principal(principal)
+    attempts: list[tuple[str, dict]] = []
+    for securable in ("MODEL", "FUNCTION"):
+        stmt = f"{verb} EXECUTE ON {securable} {model_id} {keyword} {quoted}"
+        result = sql_exec(stmt, token=token)
+        attempts.append((stmt, result))
+        if result["ok"]:
+            return True, attempts
+    return False, attempts
+
+
+# ---------------------------------------------------------------------------
+# Serving-endpoint helpers
+# ---------------------------------------------------------------------------
+
+def endpoint_tail(model_id: str) -> str:
+    """Map a three-part id to its legacy single-string endpoint name.
+
+    The system.ai registered names drop the `databricks-` prefix that the
+    legacy pay-per-token endpoint names carry (live-tested 2026-07-09:
+    `system.ai.claude-sonnet-4-6` on the gateway route ↔ legacy endpoint
+    `databricks-claude-sonnet-4-6`), so the mapping is tail + prefix.
+    Override with LEGACY_ENDPOINT_NAME if a workspace deviates.
+    """
+    override = os.environ.get("LEGACY_ENDPOINT_NAME", "").strip()
+    if override:
+        return override
+    tail = model_id.split(".")[-1]
+    if not tail.startswith("databricks-"):
+        tail = f"databricks-{tail}"
+    return tail
+
+
+def get_serving_endpoint(name: str, token: str | None = None) -> tuple[int, dict | list | str]:
+    """GET one serving endpoint's full config (includes ai_gateway if set)."""
+    return api_request("GET", f"/api/2.0/serving-endpoints/{name}", token=token)
+
+
+def get_endpoint_id(name: str) -> str | None:
+    """Resolve a serving endpoint's id (needed by the permissions API)."""
+    status, body = get_serving_endpoint(name)
+    if status == 200 and isinstance(body, dict):
+        return body.get("id")
+    return None
+
+
+def principal_acl_field(principal: str) -> str:
+    """Pick the permissions-API field for a principal string.
+
+    Emails -> user_name; UUID-shaped -> service_principal_name; else group_name.
+    """
+    if "@" in principal:
+        return "user_name"
+    if len(principal) == 36 and principal.count("-") == 4:
+        return "service_principal_name"
+    return "group_name"
+
+
+def get_endpoint_acl(endpoint_id: str) -> tuple[int, dict | list | str]:
+    """GET the serving endpoint's permission ACL."""
+    return api_request("GET", f"/api/2.0/permissions/serving-endpoints/{endpoint_id}")
+
+
+def direct_acl_entries(acl_body: dict) -> list[dict]:
+    """Extract the NON-inherited ACL entries in PUT-able form.
+
+    Used to snapshot the original ACL so mutations can be reverted with a
+    full-replace PUT (inherited permissions must not be re-PUT).
+    """
+    entries: list[dict] = []
+    for item in acl_body.get("access_control_list", []):
+        principal_fields = {
+            k: v
+            for k, v in item.items()
+            if k in ("user_name", "group_name", "service_principal_name")
+        }
+        for perm in item.get("all_permissions", []):
+            if not perm.get("inherited"):
+                entries.append(
+                    {**principal_fields, "permission_level": perm.get("permission_level")}
+                )
+    return entries
+
+
+def put_endpoint_acl(endpoint_id: str, entries: list[dict]) -> tuple[int, dict | list | str]:
+    """Full-replace the endpoint's direct ACL (used to restore/revoke)."""
+    return api_request(
+        "PUT",
+        f"/api/2.0/permissions/serving-endpoints/{endpoint_id}",
+        payload={"access_control_list": entries},
+    )
+
+
+def grant_endpoint_can_query(
+    endpoint_id: str, principal: str
+) -> tuple[int, dict | list | str]:
+    """PATCH-add CAN_QUERY on the serving endpoint for the principal."""
+    entry = {principal_acl_field(principal): principal, "permission_level": "CAN_QUERY"}
+    return api_request(
+        "PATCH",
+        f"/api/2.0/permissions/serving-endpoints/{endpoint_id}",
+        payload={"access_control_list": [entry]},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Output / verdict helpers
+# ---------------------------------------------------------------------------
+
+def collect_keys(obj, prefix: str = "") -> list[str]:
+    """Flatten all nested key paths of a JSON object (for config-surface probes)."""
+    keys: list[str] = []
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            path = f"{prefix}.{k}" if prefix else k
+            keys.append(path)
+            keys.extend(collect_keys(v, path))
+    elif isinstance(obj, list):
+        for item in obj:
+            keys.extend(collect_keys(item, prefix + "[]"))
+    return keys
+
+
+def snip(obj, limit: int = 500) -> str:
+    """Render any body/object to a single-line string capped at `limit`."""
+    if isinstance(obj, str):
+        text = obj
+    else:
+        try:
+            text = json.dumps(obj, ensure_ascii=False, sort_keys=True)
+        except (TypeError, ValueError):
+            text = repr(obj)
+    text = " ".join(text.split())
+    return text if len(text) <= limit else text[: limit - 3] + "..."
+
+
+def conclude(row_key: str, passed: bool | None, notes: str) -> None:
+    """Print the verdict line and record the matrix row exactly once."""
+    symbol = "❓" if passed is None else ("✅" if passed else "❌")
+    print(f"\n  VERDICT [{row_key}]: {symbol}")
+    print(f"  NOTES: {notes}")
+    _common.record_result(row_key, passed, notes)
+    print(f"  Recorded to {_common.RESULTS_FILE}")

--- a/experiments/coding_agent_inference_unity_ai_gateway/scripts/verify.py
+++ b/experiments/coding_agent_inference_unity_ai_gateway/scripts/verify.py
@@ -1,0 +1,138 @@
+"""Prove SSO-only auth to Databricks model serving with one real HTTP request.
+
+Flow:
+  1. Mint a short-lived OAuth token by shelling to bin/get-databricks-token.sh
+     (or the .ps1 variant on Windows). Zero PATs — the helper refuses dapi tokens.
+  2. Resolve the workspace host from DATABRICKS_HOST or the CLI profile config.
+  3. POST one tiny chat completion, trying each route in order (next on 404):
+       a. {host}/ai-gateway/mlflow/v1/chat/completions   — Unity AI Gateway,
+          the route that serves three-part system.ai.* identifiers
+       b. {host}/serving-endpoints/chat/completions       — OpenAI-compatible
+       c. {host}/serving-endpoints/{model}/invocations    — legacy per-endpoint
+  4. Assert HTTP 200 and print the model id and route that worked.
+
+Every 404 body is printed — which routes reject three-part identifiers on a
+given workspace is experiment data, not noise.
+
+The model MUST be a three-part Unity Catalog identifier (catalog.schema.model),
+e.g. system.ai.claude-sonnet-4-6. Legacy single-string endpoint
+names are refused.
+"""
+
+import configparser
+import os
+import platform
+import subprocess
+import sys
+from pathlib import Path
+
+import requests
+
+EXPERIMENT_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_MODEL = "system.ai.claude-sonnet-4-6"
+REQUEST_TIMEOUT_SECONDS = 60
+
+
+def fail(message: str) -> "None":
+    print(f"❌ {message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def get_token() -> str:
+    """Mint a short-lived OAuth token via the bin/ credential helper."""
+    if platform.system() == "Windows":
+        helper = EXPERIMENT_ROOT / "bin" / "get-databricks-token.ps1"
+        cmd = ["powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", str(helper)]
+    else:
+        helper = EXPERIMENT_ROOT / "bin" / "get-databricks-token.sh"
+        cmd = ["sh", str(helper)]
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        fail(f"credential helper failed (exit {result.returncode}):\n{result.stderr.strip()}")
+
+    token = result.stdout.strip()
+    if not token:
+        fail("credential helper printed no token.")
+    if token.startswith("dapi"):
+        fail(
+            "credential helper returned what looks like a static PAT (dapi...). "
+            "This experiment is SSO-only — refusing to proceed."
+        )
+    return token
+
+
+def get_host() -> str:
+    """Resolve the workspace host from env, falling back to the CLI profile."""
+    host = os.environ.get("DATABRICKS_HOST", "").strip()
+    if not host:
+        profile = os.environ.get("DATABRICKS_CONFIG_PROFILE", "DEFAULT")
+        cfg_path = Path(os.environ.get("DATABRICKS_CONFIG_FILE", Path.home() / ".databrickscfg"))
+        config = configparser.ConfigParser()
+        config.read(cfg_path)
+        if config.has_option(profile, "host"):
+            host = config.get(profile, "host").strip()
+        if not host:
+            fail(
+                f"could not resolve a workspace host: DATABRICKS_HOST is unset and "
+                f"profile '{profile}' in {cfg_path} has no host. "
+                f"Run: databricks auth login --host https://<your-workspace> --profile {profile}"
+            )
+    if not host.startswith("https://"):
+        host = f"https://{host}"
+    return host.rstrip("/")
+
+
+def get_model() -> str:
+    """Read RPW_MODEL and require a three-part Unity Catalog identifier."""
+    model = os.environ.get("RPW_MODEL", DEFAULT_MODEL).strip()
+    parts = model.split(".")
+    if len(parts) != 3 or not all(parts):
+        fail(
+            f"RPW_MODEL='{model}' is not a three-part Unity Catalog identifier "
+            f"(catalog.schema.model). Legacy single-string endpoint names like "
+            f"'databricks-claude-sonnet-4-6' are refused — use e.g. '{DEFAULT_MODEL}'."
+        )
+    return model
+
+
+def main() -> int:
+    model = get_model()
+    host = get_host()
+    token = get_token()
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+
+    messages = [{"role": "user", "content": "Reply with the single word: ok"}]
+
+    # (url, include model in payload) — next route is tried only on 404.
+    routes = [
+        (f"{host}/ai-gateway/mlflow/v1/chat/completions", True),
+        (f"{host}/serving-endpoints/chat/completions", True),
+        (f"{host}/serving-endpoints/{model}/invocations", False),
+    ]
+
+    response = None
+    url = ""
+    for url, include_model in routes:
+        payload = {"messages": messages, "max_tokens": 16}
+        if include_model:
+            payload["model"] = model
+        print(f"POST {url}  (model={model})")
+        response = requests.post(
+            url, headers=headers, json=payload, timeout=REQUEST_TIMEOUT_SECONDS
+        )
+        if response.status_code != 404:
+            break
+        print(f"  → 404; body: {response.text.strip()}")
+
+    if response.status_code == 200:
+        print(f"✅ HTTP 200 via {url} — SSO OAuth auth verified end-to-end against model '{model}'.")
+        return 0
+
+    print(f"❌ HTTP {response.status_code} from {url}", file=sys.stderr)
+    print(response.text, file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/experiments/coding_agent_inference_unity_ai_gateway/skill/SKILL.md
+++ b/experiments/coding_agent_inference_unity_ai_gateway/skill/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: unity-ai-gateway-coding-agent-setup
+description: >-
+  Point a coding agent (Claude Code, Claude Desktop, Codex CLI, or OpenCode)
+  at Databricks Model Serving / Unity AI Gateway using SSO/OAuth only. Trigger
+  when a user wants their coding agent to run inference through their
+  Databricks workspace — zero PATs, three-part system.ai.<model> Unity Catalog
+  identifiers, proven with a real HTTP 200.
+---
+
+# Unity AI Gateway coding-agent setup
+
+You are driving a customer's setup on their own laptop against their own
+Databricks workspace. Hard rules, no exceptions:
+
+- **SSO/OAuth only. Zero PATs.** Never create, request, store, or accept a
+  static `dapi...` token. If the user offers one, decline: explain that this
+  setup mints short-lived (~1h) OAuth tokens on demand via
+  [`../bin/get-databricks-token.sh`](../bin/get-databricks-token.sh), which is
+  strictly safer and is the only auth path these configs support (the helper
+  itself refuses PATs).
+- **Three-part Unity Catalog model ids** (`system.ai.<model>`, e.g.
+  `system.ai.claude-sonnet-4-6`) — never legacy single-string
+  endpoint names. Whether three-part ids actually resolve is
+  **workspace-dependent** — that is exactly what Step 3 verifies. Do not
+  assume; do not silently downgrade.
+
+Companion script: [`scripts/setup_helper.sh`](scripts/setup_helper.sh)
+(subcommands `preflight`, `materialize`, `verify`).
+Templates + placeholder legend: [`../configs/`](../configs/README.md).
+
+## Step 0 — Preflight
+
+Run `scripts/setup_helper.sh preflight`. It prints a status table:
+Databricks CLI, OAuth state, `ucode` availability, package-registry
+reachability.
+
+- **CLI missing** → have the user install the Databricks CLI, then re-run.
+- **Not OAuth-authenticated** → run
+  `databricks auth login --host https://<workspace-host>` yourself; the human
+  completes browser SSO. Confirm with `databricks auth describe`, then re-run
+  preflight.
+- **Auth type is `pat`** → refuse to proceed on it. Re-authenticate with
+  `databricks auth login` (OAuth) instead.
+
+## Step 1 — Prefer ucode (happy path)
+
+If preflight shows `ucode` available and the target agent is **Claude Code,
+Codex, or OpenCode**: run `ucode <agent>` and go straight to Step 3. Do not
+hand-edit configs when ucode covers the agent.
+
+Fall back to Step 2 only for:
+
+- **Claude Desktop** — not covered by ucode (see
+  [`../configs/claude-desktop.md`](../configs/claude-desktop.md), including
+  its hard limitation: Desktop's chat model cannot be repointed; the escape
+  hatch is an MCP server).
+- **ucode unavailable** on this machine.
+
+## Step 2 — Escape hatch: materialize a template
+
+```sh
+scripts/setup_helper.sh materialize <agent> <workspace-host> <model> [--profile <cli-profile>] [--out <path>]
+```
+
+`<agent>` ∈ `claude-code | claude-desktop | codex | opencode`. This
+substitutes the user's workspace host, CLI profile, a three-part
+`system.ai.<model>` id, and the **absolute path** to
+`../bin/get-databricks-token.sh` (for `apiKeyHelper`-style mechanisms) into
+the matching `../configs/` template. Where to install each result — and which
+mechanisms re-mint tokens vs. capture one at export time — is in
+[`../configs/README.md`](../configs/README.md).
+
+**Legacy names:** `materialize` refuses non-three-part model names. If (and
+only if) Step 3 proves three-part ids do not resolve on this workspace,
+re-run with `--allow-legacy --reason "<why>"`; the output is annotated
+"three-part ids do not resolve on this workspace yet (see experiment README
+row 2)". Say exactly that to the user — record it as a finding, never a
+silent downgrade.
+
+## Step 3 — Verify with a real request
+
+Run `scripts/setup_helper.sh verify` (delegates to `make verify` at the
+experiment root: one real chat completion over SSO OAuth). Interpret:
+
+- **HTTP 200** → done. Auth and model id proven end-to-end (verify tries the
+  `/ai-gateway/mlflow/v1/chat/completions` gateway route first — the only
+  route family that resolves three-part ids; live-tested 2026-07-09).
+- **404 on the three-part id from every route** (the gateway route reports a
+  model-level `NOT_FOUND '<id>' does not exist`, distinct from the classic
+  routes' `ENDPOINT_NOT_FOUND`) → first check the registered name: `system.ai`
+  names drop the `databricks-` prefix of legacy endpoint names (e.g. legacy
+  `databricks-claude-sonnet-4-6` ↔ `system.ai.claude-sonnet-4-6`). If the
+  corrected name still 404s, Unity AI Gateway model services are likely not
+  provisioned on that workspace. Point the user at the experiment
+  [`../README.md`](../README.md) results matrix and the governance checks in
+  [`../scripts/governance/`](../scripts/governance/), then decide together
+  whether to use `--allow-legacy` (Step 2) with the finding recorded.
+- **401/403** → auth triage, in order: token expired (shell-export mechanisms
+  capture one token — re-run the export / restart the agent); wrong profile
+  or host (`databricks auth describe`, check `DATABRICKS_CONFIG_PROFILE`);
+  re-login (`databricks auth login --host <host>`); finally, workspace
+  permissions on the serving endpoint.
+
+## Step 4 — Locked-down package registries
+
+Before any `uv sync` / `npm install`, check preflight's registry probes. If
+the default registries are blocked (common on corporate networks):
+
+1. Ask the user for their org's internal index URLs — do not guess.
+2. Apply generically: `UV_INDEX_URL` / `PIP_INDEX_URL` for Python;
+   `npm config set registry <url>` for Node.
+3. **Warn: never commit proxy-pinned lockfiles to shared repos** — they break
+   for anyone outside that network.

--- a/experiments/coding_agent_inference_unity_ai_gateway/skill/scripts/setup_helper.sh
+++ b/experiments/coding_agent_inference_unity_ai_gateway/skill/scripts/setup_helper.sh
@@ -1,0 +1,280 @@
+#!/usr/bin/env bash
+# setup_helper.sh — mechanical companion for the unity-ai-gateway-coding-agent-setup skill.
+#
+# Subcommands:
+#   preflight
+#       Checks: databricks CLI, OAuth auth state (PATs refused), ucode
+#       availability, package-registry reachability. Prints a status table.
+#       Exits non-zero if a blocking check (CLI / OAuth) fails.
+#
+#   materialize <agent> <workspace-host> <model> [--profile <p>] [--out <path>]
+#                                                [--allow-legacy --reason "<why>"]
+#       Renders the matching ../../configs/ template with placeholders
+#       substituted, to stdout or --out. <model> must be a three-part Unity
+#       Catalog id (catalog.schema.model); legacy single-string names are
+#       refused unless --allow-legacy is passed WITH a mandatory --reason,
+#       which is embedded in the output as an annotation.
+#
+#   verify
+#       Delegates to `make -C <experiment-root> verify` (one real SSO-OAuth
+#       chat completion; HTTP 200 required).
+#
+# SSO/OAuth only — this script never creates, accepts, or embeds a PAT.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+EXPERIMENT_ROOT=$(cd -- "$SCRIPT_DIR/../.." && pwd)
+CONFIGS_DIR="$EXPERIMENT_ROOT/configs"
+
+usage() {
+    cat <<'EOF'
+setup_helper.sh — mechanical companion for the unity-ai-gateway-coding-agent-setup skill.
+
+Subcommands:
+  preflight
+      Checks: databricks CLI, OAuth auth state (PATs refused), ucode
+      availability, package-registry reachability. Prints a status table.
+      Exits non-zero if a blocking check (CLI / OAuth) fails.
+
+  materialize <agent> <workspace-host> <model> [--profile <p>] [--out <path>]
+                                               [--allow-legacy --reason "<why>"]
+      Renders the matching configs/ template with placeholders substituted,
+      to stdout or --out. <agent> is one of: claude-code | claude-desktop |
+      codex | opencode. <model> must be a three-part Unity Catalog id
+      (catalog.schema.model); legacy single-string names are refused unless
+      --allow-legacy is passed WITH a mandatory --reason, which is embedded
+      in the output as an annotation.
+
+  verify
+      Delegates to `make -C <experiment-root> verify` (one real SSO-OAuth
+      chat completion; HTTP 200 required).
+
+SSO/OAuth only — this script never creates, accepts, or embeds a PAT.
+EOF
+}
+
+die() {
+    echo "error: $*" >&2
+    exit 2
+}
+
+# ---------------------------------------------------------------- preflight
+
+row() { # row <check> <status> <detail>
+    printf '%-28s %-8s %s\n' "$1" "$2" "$3"
+}
+
+probe_url() { # probe_url <url> -> 0 reachable / non-zero not
+    # Network-level reachability only: any HTTP response (even 401/404 from an
+    # auth-required index) counts as reachable; DNS/connect/timeout do not.
+    curl -sSL --max-time 5 -o /dev/null "$1" 2>/dev/null
+}
+
+cmd_preflight() {
+    local profile="${DATABRICKS_CONFIG_PROFILE:-DEFAULT}"
+    local blocking_failure=0
+
+    printf '%-28s %-8s %s\n' "CHECK" "STATUS" "DETAIL"
+    printf '%-28s %-8s %s\n' "-----" "------" "------"
+
+    # --- databricks CLI ---
+    local have_cli=0
+    if command -v databricks >/dev/null 2>&1; then
+        have_cli=1
+        local cli_version
+        cli_version=$(databricks --version 2>/dev/null | head -n 1 || true)
+        row "databricks CLI" "OK" "${cli_version:-found} ($(command -v databricks))"
+    else
+        row "databricks CLI" "FAIL" "not on PATH — install the Databricks CLI, then re-run"
+        blocking_failure=1
+    fi
+
+    # --- OAuth auth state ---
+    if [ "$have_cli" -eq 1 ]; then
+        local describe_out auth_type auth_user auth_host
+        if describe_out=$(databricks auth describe -o json 2>/dev/null); then
+            auth_type=$(printf '%s\n' "$describe_out" | sed -n 's/.*"auth_type"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)
+            auth_user=$(printf '%s\n' "$describe_out" | sed -n 's/.*"username"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)
+            auth_host=$(printf '%s\n' "$describe_out" | sed -n 's/.*"host"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)
+            if [ "$auth_type" = "pat" ]; then
+                row "OAuth (profile $profile)" "FAIL" "auth_type=pat — PATs are refused; run: databricks auth login --host <workspace-host>"
+                blocking_failure=1
+            else
+                row "OAuth (profile $profile)" "OK" "auth_type=${auth_type:-unknown} user=${auth_user:-?} host=${auth_host:-?}"
+            fi
+        else
+            row "OAuth (profile $profile)" "FAIL" "not authenticated — run: databricks auth login --host <workspace-host> (human completes browser SSO)"
+            blocking_failure=1
+        fi
+    else
+        row "OAuth (profile $profile)" "SKIP" "requires the databricks CLI"
+    fi
+
+    # --- ucode ---
+    if command -v ucode >/dev/null 2>&1; then
+        row "ucode" "OK" "happy path: ucode <agent> (claude / codex / opencode)"
+    else
+        row "ucode" "MISSING" "fall back to escape-hatch templates in configs/ (see SKILL.md Step 2)"
+    fi
+
+    # --- package registries (generic; honors any already-configured index) ---
+    local pypi_url npm_url
+    pypi_url="${UV_INDEX_URL:-${PIP_INDEX_URL:-https://pypi.org/simple/}}"
+    npm_url=""
+    if command -v npm >/dev/null 2>&1; then
+        npm_url=$(npm config get registry 2>/dev/null || true)
+    fi
+    [ -n "$npm_url" ] && [ "$npm_url" != "undefined" ] || npm_url="https://registry.npmjs.org/"
+
+    if ! command -v curl >/dev/null 2>&1; then
+        row "Python registry" "SKIP" "curl not available to probe"
+        row "npm registry" "SKIP" "curl not available to probe"
+    else
+        if probe_url "$pypi_url"; then
+            row "Python registry" "OK" "$pypi_url reachable"
+        else
+            row "Python registry" "BLOCKED" "$pypi_url unreachable — ask the user for their org's index URL (UV_INDEX_URL / PIP_INDEX_URL)"
+        fi
+        if probe_url "$npm_url"; then
+            row "npm registry" "OK" "$npm_url reachable"
+        else
+            row "npm registry" "BLOCKED" "$npm_url unreachable — ask the user for their org's registry URL (npm config set registry <url>)"
+        fi
+    fi
+
+    if [ "$blocking_failure" -ne 0 ]; then
+        echo >&2
+        echo "preflight: blocking check failed (see FAIL rows above)." >&2
+        return 1
+    fi
+    return 0
+}
+
+# -------------------------------------------------------------- materialize
+
+sed_escape() { # escape a string for use in a sed replacement (delimiter /)
+    printf '%s' "$1" | sed -e 's/[&/\]/\\&/g'
+}
+
+is_three_part_id() { # catalog.schema.model — exactly three non-empty dot parts
+    printf '%s' "$1" | awk -F. 'NF == 3 && $1 != "" && $2 != "" && $3 != "" { ok = 1 } END { exit ok ? 0 : 1 }'
+}
+
+cmd_materialize() {
+    local agent="" host="" model="" out="" reason="" allow_legacy=0
+    local profile="${DATABRICKS_CONFIG_PROFILE:-DEFAULT}"
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --out)          [ $# -ge 2 ] || die "--out requires a path"; out="$2"; shift 2 ;;
+            --profile)      [ $# -ge 2 ] || die "--profile requires a value"; profile="$2"; shift 2 ;;
+            --allow-legacy) allow_legacy=1; shift ;;
+            --reason)       [ $# -ge 2 ] || die "--reason requires a string"; reason="$2"; shift 2 ;;
+            -h|--help)      usage; return 0 ;;
+            -*)             die "unknown flag for materialize: $1" ;;
+            *)
+                if   [ -z "$agent" ]; then agent="$1"
+                elif [ -z "$host"  ]; then host="$1"
+                elif [ -z "$model" ]; then model="$1"
+                else die "unexpected extra argument: $1"
+                fi
+                shift ;;
+        esac
+    done
+
+    [ -n "$agent" ] && [ -n "$host" ] && [ -n "$model" ] \
+        || die "usage: materialize <agent> <workspace-host> <model> [--profile <p>] [--out <path>] [--allow-legacy --reason \"<why>\"]"
+
+    local template kind
+    case "$agent" in
+        claude-code)    template="$CONFIGS_DIR/claude-code.settings.json"; kind=json ;;
+        claude-desktop) template="$CONFIGS_DIR/claude-desktop.mcp.json";   kind=json ;;
+        codex)          template="$CONFIGS_DIR/codex.config.toml";         kind=toml ;;
+        opencode)       template="$CONFIGS_DIR/opencode.json";             kind=json ;;
+        *) die "unknown agent '$agent' (expected: claude-code | claude-desktop | codex | opencode)" ;;
+    esac
+    [ -f "$template" ] || die "template not found: $template"
+
+    # Never a PAT, anywhere — not even smuggled in as an argument.
+    case "$host$model$reason" in
+        *dapi*) die "an argument looks like it contains a static PAT (dapi...). SSO-only — refused." ;;
+    esac
+
+    # Normalize host to a bare hostname (templates carry their own https://).
+    local bare_host
+    bare_host=$(printf '%s' "$host" | sed -e 's|^https\{0,1\}://||' -e 's|/*$||')
+    [ -n "$bare_host" ] || die "workspace host is empty after normalization"
+
+    # Legacy model-name gate.
+    local annotation=""
+    if ! is_three_part_id "$model"; then
+        if [ "$allow_legacy" -ne 1 ]; then
+            die "model '$model' is not a three-part Unity Catalog identifier (catalog.schema.model, e.g. system.ai.claude-sonnet-4-6).
+Legacy single-string endpoint names are refused by default. If 'make verify' proved three-part
+ids do not resolve on this workspace, re-run with: --allow-legacy --reason \"<why>\""
+        fi
+        [ -n "$reason" ] || die "--allow-legacy requires --reason \"<why>\" — the reason is embedded in the output as an annotation"
+        # Keep the annotation safe to embed in JSON string values.
+        local safe_reason
+        safe_reason=$(printf '%s' "$reason" | tr -d '"\\' | tr '\n' ' ')
+        annotation="LEGACY MODEL NAME '$model' ALLOWED — reason: $safe_reason. Three-part ids do not resolve on this workspace yet (see experiment README row 2)."
+    fi
+
+    # Render: substitute every placeholder; retarget the template's example
+    # three-part model id (any system.ai.* occurrence) to the requested model.
+    local rendered
+    rendered=$(sed -E \
+        -e "s/<your-workspace-host>/$(sed_escape "$bare_host")/g" \
+        -e "s/<your-databricks-cli-profile>/$(sed_escape "$profile")/g" \
+        -e "s/<path-to-this-experiment>/$(sed_escape "$EXPERIMENT_ROOT")/g" \
+        -e "s/system\.ai\.[A-Za-z0-9_.-]+/$(sed_escape "$model")/g" \
+        "$template")
+
+    if [ -n "$annotation" ]; then
+        case "$kind" in
+            toml)
+                rendered=$(printf '# %s\n%s\n' "$annotation" "$rendered") ;;
+            json)
+                # JSON has no comments; embed as a top-level marker key.
+                rendered=$(printf '%s\n' "$rendered" | awk -v note="$annotation" '
+                    !done && /\{/ { print; printf "  \"_ALLOW_LEGACY_REASON\": \"%s\",\n", note; done = 1; next }
+                    { print }') ;;
+        esac
+        echo "warning: legacy model name embedded with annotation — record this as a finding, not a silent downgrade." >&2
+    fi
+
+    if [ "$agent" = "claude-desktop" ]; then
+        echo "note: <your-mcp-server-command> is intentionally left for you to fill in — see configs/claude-desktop.md (Desktop's chat model cannot be repointed; MCP is the escape hatch)." >&2
+    fi
+
+    if [ -n "$out" ]; then
+        mkdir -p "$(dirname -- "$out")"
+        printf '%s\n' "$rendered" > "$out"
+        echo "wrote $out (from ${template#"$EXPERIMENT_ROOT"/})" >&2
+    else
+        printf '%s\n' "$rendered"
+    fi
+}
+
+# ------------------------------------------------------------------- verify
+
+cmd_verify() {
+    exec make -C "$EXPERIMENT_ROOT" verify
+}
+
+# --------------------------------------------------------------------- main
+
+main() {
+    [ $# -ge 1 ] || { usage >&2; exit 2; }
+    local cmd="$1"; shift
+    case "$cmd" in
+        preflight)   cmd_preflight "$@" ;;
+        materialize) cmd_materialize "$@" ;;
+        verify)      cmd_verify "$@" ;;
+        -h|--help|help) usage ;;
+        *) die "unknown subcommand '$cmd' (expected: preflight | materialize | verify)" ;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
## What this is

Phase-1 **experiment** (per the scoping doc): establish with hard, live testing which Unity AI Gateway governance capabilities actually work today for coding-agent inference — before building any customer demo. The deliverable is the ✅/❌ **Results Matrix** in `experiments/coding_agent_inference_unity_ai_gateway/README.md`, not a demo.

Ground rules held throughout: SSO/OAuth only (zero PATs, `dapi` refused on sight), three-part `system.ai.*` UC model identifiers, every claim proven with a real HTTP response.

## Headline findings (live-tested 2026-07-09)

- **Three-part ids resolve ONLY on `/ai-gateway/*` routes.** `/serving-endpoints/*` 404s on them and serves legacy single-string names only; `/ai-gateway/mlflow/v1/chat/completions` and `/ai-gateway/anthropic/v1/messages` return 200 for `system.ai.claude-sonnet-4-6`.
- **`system.ai` names drop the `databricks-` prefix** — `system.ai.databricks-claude-sonnet-4-6` does not exist; `system.ai.claude-sonnet-4-6` does.
- **SSO works end-to-end**: `databricks auth login` → short-lived OAuth token → 200. No PAT anywhere.
- **No per-user hard budget cap** on the endpoint (row 8 ❌): alert-style surfaces + per-user *rate* limits only.
- **Per-user usage attribution proven; per-agent unproven** (row 9 ❓): `requester` populated, `usage_context`/`client_request_id` empty in all sampled rows; a marker probe awaits system-table ingestion.
- Rows 3–6 (GRANT/DENY/revoke enforcement) ship as turnkey scripts gated on `TEST_PRINCIPAL` + `ALLOW_ENDPOINT_MUTATION=1`, to be run with and without the Foundation Model Permissions preview.

## What ships

- `bin/get-databricks-token.{sh,ps1,cmd}` — SSO token helper, PAT-refusing
- `make verify` — one real request, gateway route first, every response printed as data
- `configs/` — Claude Code / Claude Desktop / Codex / OpenCode templates pointing at **tested** gateway routes
- `scripts/governance/01–10` — one script per matrix row, idempotent, mutation-gated, recording to `results/matrix_results.json`
- `skill/` — self-service agent skill (preflight → ucode-or-template → verify → locked-down-registry handling)
- `README.md` — Results Matrix + Key Findings, MDM/fleet notes, non-goals

## Verification performed

- `uv sync`, `py_compile` on all Python, `bash -n` on shell helpers, JSON/TOML parse checks on all templates
- Live: `make verify` → 200 via the gateway route; governance rows 01/02/07/08/09 executed against a real workspace; 03–06/10 dry-run paths exercised
- Scan for secrets, internal links, hostnames, and personal names in committed files: clean

This pull request and its description were written by Isaac.