### PR TITLE
experiment: can a UC UDF wrap one privileged action for less-privileged callers?

### DIFF
--- a/experiments/udf_privilege_delegation/.env.example
+++ b/experiments/udf_privilege_delegation/.env.example
@@ -1,0 +1,20 @@
+# Copy to .env (gitignored) or let `make setup` write it for you.
+
+# Databricks CLI profile used for the high-privilege author identity.
+# SSO/OAuth only — a dapi... personal access token is refused by scripts/_common.py.
+DATABRICKS_CONFIG_PROFILE=DEFAULT
+
+# Unity Catalog coordinates for the experiment's schema.
+EXPERIMENT_CATALOG=my_catalog
+EXPERIMENT_SCHEMA=udf_privilege_delegation
+
+# SQL warehouse to run statements on. Leave blank to auto-pick the first
+# serverless warehouse the profile can see.
+EXPERIMENT_WAREHOUSE_ID=
+
+# The low-privilege caller. These three are WRITTEN by
+# scripts/setup/00_create_lowpriv_principal.py — placeholders only here.
+EXPERIMENT_LOWPRIV_DISPLAY_NAME=udf-delegation-lowpriv
+EXPERIMENT_LOWPRIV_SP_ID=0000000000000000
+EXPERIMENT_LOWPRIV_CLIENT_ID=00000000-0000-0000-0000-000000000000
+EXPERIMENT_LOWPRIV_CLIENT_SECRET=replace-me

--- a/experiments/udf_privilege_delegation/.gitignore
+++ b/experiments/udf_privilege_delegation/.gitignore
@@ -1,0 +1,14 @@
+.env
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+.ruff_cache/
+
+# Deliberate deviation from the repo's commit-the-lock convention.
+# This lock was resolved through an internal Databricks PyPI mirror, so every
+# `url = ...` in it points at a host no external consumer can reach — committing
+# it to a public repo would ship a lockfile that cannot be installed from.
+# Regenerate with `uv lock` on a machine resolving against public PyPI and drop
+# this line to bring the experiment in line with the rest of the repo.
+uv.lock

--- a/experiments/udf_privilege_delegation/Makefile
+++ b/experiments/udf_privilege_delegation/Makefile
@@ -1,0 +1,72 @@
+.DEFAULT_GOAL := help
+
+# Config via env vars — sane defaults, overridable, echoed in help.
+export DATABRICKS_CONFIG_PROFILE ?= DEFAULT
+export EXPERIMENT_CATALOG ?= my_catalog
+export EXPERIMENT_SCHEMA ?= udf_privilege_delegation
+export EXPERIMENT_WAREHOUSE_ID ?=
+export EXPERIMENT_LOWPRIV_DISPLAY_NAME ?= udf-delegation-lowpriv
+
+# Credentials for the low-privilege caller are written to .env by `make setup`.
+-include .env
+export
+
+PY := uv run python
+
+.PHONY: help auth-check verify setup matrix row-1 row-2 row-3 row-4 row-5 row-6 row-7 teardown test test-infrastructure lint
+
+help: ## List available targets
+	@echo "Targets:"
+	@grep -E '^[a-zA-Z0-9_-]+:.*?## ' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-20s %s\n", $$1, $$2}'
+	@echo ""
+	@echo "Environment variables:"
+	@echo "  DATABRICKS_CONFIG_PROFILE      CLI profile (default: DEFAULT)"
+	@echo "  EXPERIMENT_CATALOG             Unity Catalog name (default: my_catalog)"
+	@echo "  EXPERIMENT_SCHEMA              UC schema (default: udf_privilege_delegation)"
+	@echo "  EXPERIMENT_WAREHOUSE_ID        SQL warehouse id (default: first serverless warehouse)"
+	@echo "  EXPERIMENT_LOWPRIV_DISPLAY_NAME  Caller service principal (default: udf-delegation-lowpriv)"
+
+auth-check: ## Verify Databricks authentication before anything live
+	databricks auth describe --profile $(DATABRICKS_CONFIG_PROFILE)
+
+verify: auth-check ## Prove auth + connectivity end-to-end with one real request
+	$(PY) scripts/verify.py
+
+setup: verify ## Create the low-privilege caller, the admin-owned objects, and the grants
+	$(PY) scripts/setup/00_create_lowpriv_principal.py
+	$(PY) scripts/setup/01_provision_objects.py
+
+matrix: row-1 row-2 row-3 row-4 row-5 row-6 row-7 ## Run every matrix row and rewrite results/matrix_results.json
+
+row-1: ## SQL UDF — definer vs invoker rights
+	$(PY) scripts/delegation/01_sql_udf_definer_vs_invoker.py
+
+row-2: ## Python UDF — outbound network egress
+	$(PY) scripts/delegation/02_python_udf_network_egress.py
+
+row-3: ## Python UDF — ambient credential context
+	$(PY) scripts/delegation/03_python_udf_credential_context.py
+
+row-4: ## End to end — low-privilege caller creates a service principal
+	$(PY) scripts/delegation/04_end_to_end_create_service_principal.py
+
+row-5: ## SQL surface for identity administration
+	$(PY) scripts/delegation/05_sql_surface_for_identity_admin.py
+
+row-6: ## Function body readability — can a caller with only EXECUTE read the source?
+	$(PY) scripts/delegation/06_function_body_readable_by_caller.py
+
+row-7: ## Author-embedded credential — does the delegated action work then?
+	$(PY) scripts/delegation/07_embedded_credential_end_to_end.py
+
+teardown: ## Remove the schema, the functions, and both service principals
+	$(PY) scripts/setup/99_teardown.py
+
+test: ## Run no-infra tests only (unit + composition)
+	uv run pytest -m "not infrastructure"
+
+test-infrastructure: auth-check ## Run live tests (requires Databricks auth)
+	uv run pytest -m infrastructure
+
+lint: ## Ruff check
+	uv run ruff check scripts tests

--- a/experiments/udf_privilege_delegation/README.md
+++ b/experiments/udf_privilege_delegation/README.md
@@ -1,0 +1,139 @@
+# Can a Unity Catalog UDF wrap one privileged action for less-privileged callers?
+
+**The question.** A high-privilege admin defines a reusable UDF. A lower-privilege
+user is granted permission to invoke it. The user should *not* receive the
+underlying admin privilege directly. Can the function act as a narrowly scoped
+wrapper around a single administrative action — creating a service principal,
+concretely — rather than a broad grant?
+
+**The answer, in one line.** For *data*, yes and it is a real boundary. For
+*administrative actions*, no — not through the function model. It can be forced
+to work by hardcoding a credential in the function body, and that hands the
+credential to every caller in plaintext, so the workaround is worse than the
+grant it replaces.
+
+Run date: **2026-07-28**. One real AWS Databricks workspace, Unity Catalog
+enabled, serverless SQL warehouse on the PRO channel. Author identity: a
+workspace admin. Caller identity: an OAuth M2M service principal that is a plain
+workspace user, holds `USE CATALOG` / `USE SCHEMA` / `EXECUTE` and `CAN_USE` on
+the warehouse, and nothing else. Every row below was produced by a script in
+`scripts/` writing to `results/matrix_results.json`; that file is the source of
+truth and this table is its readable projection.
+
+## Findings matrix
+
+| # | Capability / Question | Claim / Source | Result | Notes |
+|---|---|---|---|---|
+| 1 | Does a UC **SQL** UDF body resolve underlying-object privileges as **definer** (owner) rather than invoker? | [SQL authorized user](https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-authorized-user), [UC UDFs](https://docs.databricks.com/aws/en/udf/unity-catalog) | ✅ | Caller's direct read refused — `[INSUFFICIENT_PERMISSIONS] User does not have SELECT on Table ... SQLSTATE: 42501`. Same caller invoking the admin-owned UDF over the same table got `3`. `EXECUTE` sufficed; no `SELECT` was ever granted. |
+| 2 | Can a UC **Python** UDF make an outbound HTTPS request? | [UC Python UDF limits](https://docs.databricks.com/aws/en/udf/python), [serverless network policies](https://docs.databricks.com/aws/en/security/network/serverless-network-security/network-policies) | ✅ | As the low-privilege caller: `https://example.com` → **HTTP 200**; workspace control plane → **HTTP 401**. A 401 is an authorization answer, so the request completed the round trip. **Environment-dependent** — see caveat below. |
+| 3 | Does a UC Python UDF receive an ambient Databricks credential? | field question | ❌ | The sandbox exports exactly one `DATABRICKS_*` variable, `DATABRICKS_ROOT_VIRTUALENV_ENV`, which authenticates nothing. No token, host, or client id. The SDK imports but `WorkspaceClient()` raises `default auth: cannot configure default credentials`. `dbutils` absent, no active Spark session. Identical for admin and caller. |
+| 4 | End to end: can a low-privilege caller create a service principal through an admin-owned UDF? | the customer's actual proposal | ❌ | Caller invoked the wrapper; the SCIM directory read back as admin afterwards contained no such principal. Failure is capability (rows 2–3), not authorization — the invocation itself was permitted. |
+| 5 | Is there any **SQL surface** for identity administration a definer-rights SQL UDF could wrap? | inferred from row 1 | ❌ | `CREATE SERVICE PRINCIPAL`, `CREATE USER`, `CREATE LOGIN` all `[PARSE_SYNTAX_ERROR] ... SQLSTATE: 42601` for a workspace admin. The grammar does not exist. |
+| 6 | Can a caller holding **only `EXECUTE`** read the function body, and therefore any credential embedded in it? | the obvious workaround to rows 3–5 | ❌ | The caller read the body via **`DESCRIBE FUNCTION EXTENDED`** and via **`information_schema.routines`**. A planted sentinel string was visible through both. (`SHOW CREATE TABLE` was refused — `TABLE_OR_VIEW_NOT_FOUND`.) The caller could still invoke, so it genuinely held only `EXECUTE`. |
+| 7 | Does embedding the author's credential in the body make the delegated action succeed? | the workaround, tested | ✅ | Caller holding only `EXECUTE` invoked the wrapper; SCIM returned **HTTP 201** and the principal was present in the directory on read-back. Works — via a stored secret, not via the function model. Function dropped immediately; token never written to `results/`. |
+
+Status vocabulary: ✅ works as claimed · ❌ does not, with evidence ·
+◑ partially · ❓ could not be isolated.
+
+## Key findings
+
+### The two halves of the pattern never meet
+
+Row 1 is a genuine, useful result and it is worth separating from the rest: a UC
+SQL UDF **is** a privilege boundary. The caller was refused `SELECT` on
+`sensitive_table` and then read it — indirectly, through the shape the author
+chose — with nothing but `EXECUTE`. That is exactly the delegation the question
+describes, and for data access it works.
+
+It does not extend to administrative actions, because of a gap that has nothing
+to do with the privilege model:
+
+- The function type that **carries definer's rights** (SQL) cannot express
+  "create a service principal" — there is no such statement in the dialect
+  (row 5).
+- The function type that **can express it** (Python, via REST) has network reach
+  (row 2) but no identity to spend (row 3). It is anonymous inside the sandbox.
+
+So the honest answer to "does the function model support this kind of delegated
+action" is: **the function model never gets asked.** The Python UDF is not
+denied by Unity Catalog — it simply has no credential to present, and the
+control plane answers `401` like it would to any anonymous caller. Row 4 is the
+consequence, not an independent finding.
+
+### The credential workaround inverts the security property
+
+Rows 6 and 7 are the ones to put in front of a customer, because they are where
+someone determined to make this work ends up.
+
+Embedding the author's token in the function body **does** work (row 7): a caller
+with only `EXECUTE` created a service principal, HTTP 201, verified by reading
+the SCIM directory back as admin. The action really is narrow — the caller can
+pass only a display name.
+
+But the elevation is not coming from the function model. The platform never
+re-authorizes the body as the owner; it replays whatever secret the author left
+in the source. And row 6 shows the caller can read that source: both
+`DESCRIBE FUNCTION EXTENDED` and `information_schema.routines` returned the body
+text, sentinel included, to a principal holding nothing but `EXECUTE`.
+
+The wrapper therefore does not narrow anything. A caller who can invoke it can
+also extract the credential and call the SCIM API directly with the **full**
+admin privilege, not the one action the author intended to expose. That is
+strictly worse than granting the narrow privilege outright, and it fails open —
+silently, whenever someone runs `DESCRIBE`.
+
+It also expires. The embedded token is short-lived, so the wrapper stops working
+at a time unrelated to any change anyone made to it.
+
+### Viability verdict
+
+| Delegation target | Viable via UDF? | Why |
+|---|---|---|
+| Reading data the caller lacks `SELECT` on | **Yes** | Definer's rights, row 1. Sound and supported. |
+| Any administrative action (identity, workspace config, ACLs) | **No** | No SQL surface (row 5); Python sandbox has no identity (row 3). |
+| Same, forced with an embedded credential | **No — actively harmful** | Works (row 7) but discloses the credential to every caller (row 6). |
+
+For the administrative case the primitive to reach for is one that has a real
+run-as identity of its own — a job or Databricks App running as a service
+principal that holds the narrow privilege — rather than a function. That keeps
+the credential outside anything the caller can read. Scoping that alternative is
+outside this experiment; the point here is only that the UDF route is closed.
+
+## Caveats and scope
+
+- **Row 2 is a property of this workspace's egress posture, not of UC.** Databricks
+  documents serverless egress as deny-by-default under a
+  [network policy](https://docs.databricks.com/aws/en/security/network/serverless-network-security/network-policies);
+  this workspace evidently runs a permissive one, which is why `example.com`
+  answered. A workspace with a restrictive policy would see row 2 fail. That
+  makes the overall conclusion *stronger*: even in the most permissive egress
+  posture available, the pattern still fails without an embedded secret.
+- **Row 6 is a negative scoped to the paths probed** — `DESCRIBE FUNCTION EXTENDED`,
+  `SHOW CREATE TABLE`, `information_schema.routines`. Two of the three leaked, so
+  the finding stands regardless, but this is not a claim that those are the only
+  read paths.
+- Rows 1–6 come from a single provisioning run; row 7 re-ran after a teardown fix
+  against the same provisioned objects. Timestamps are in
+  `results/matrix_results.json`.
+- Not tested: Scala/Java UDFs, UDFs on classic (non-serverless) compute,
+  UC Connections or service credentials as an alternative credential source
+  inside the sandbox.
+
+## Running it
+
+```bash
+make                         # list targets
+make verify                  # one real request — proves auth, warehouse, catalog
+make setup                   # low-privilege caller + admin-owned objects + grants
+make matrix                  # all seven rows -> results/matrix_results.json
+make teardown                # remove schema, functions, and both service principals
+```
+
+Configure via env vars (all echoed by `make help`): `DATABRICKS_CONFIG_PROFILE`,
+`EXPERIMENT_CATALOG`, `EXPERIMENT_SCHEMA`, `EXPERIMENT_WAREHOUSE_ID`.
+
+The experiment needs a workspace admin profile (it creates service principals
+and mints their OAuth secrets) and a serverless SQL warehouse. Authentication is
+SSO/OAuth only — `scripts/_common.py` refuses a `dapi…` personal access token on
+sight. Real coordinates are redacted at the results-write boundary, so committed
+evidence carries placeholders only.

--- a/experiments/udf_privilege_delegation/docs/research/2026-07-28-evidence-trail.md
+++ b/experiments/udf_privilege_delegation/docs/research/2026-07-28-evidence-trail.md
@@ -1,0 +1,123 @@
+---
+title: "UDF Privilege Delegation — Evidence Trail and Measurement Traps"
+tags: [unity-catalog, udf, privileges, delegation, methodology]
+status: active
+created: 2026-07-28
+---
+
+# Evidence trail
+
+The README carries the conclusions. This is the raw material behind them, plus
+the three places where the first version of the harness produced a *plausible
+and wrong* answer. All three would have been invisible in a write-up that only
+reported final statuses, which is the argument for keeping the harness itself
+under review rather than only its output.
+
+## Verbatim platform responses
+
+Row 1, caller's direct read (the control that makes the row mean anything):
+
+```
+[INSUFFICIENT_PERMISSIONS] Insufficient privileges:
+User does not have SELECT on Table
+  '<catalog>.udf_privilege_delegation.sensitive_table'. SQLSTATE: 42501
+```
+
+Row 1, same caller through the admin-owned SQL UDF: `3`.
+
+Row 2, from inside `LANGUAGE PYTHON` on a serverless warehouse, as the caller:
+
+```
+https://example.com                       -> {"reached": true, "status": 200}
+<workspace>/api/2.0/preview/scim/v2/Me    -> {"reached": true, "status": 401, "http_error": true}
+```
+
+Row 3, the sandbox describing itself (identical for admin and caller):
+
+```json
+{
+  "databricks_env_vars": ["DATABRICKS_ROOT_VIRTUALENV_ENV"],
+  "credential_env_vars_present": [],
+  "sdk_importable": true,
+  "sdk_default_auth": "ValueError: default auth: cannot configure default credentials",
+  "dbutils_available": false,
+  "spark_session": "none"
+}
+```
+
+Row 5, as a workspace admin:
+
+```
+[PARSE_SYNTAX_ERROR] Syntax error at or near 'SERVICE'. SQLSTATE: 42601 (line 1, pos 7)
+CREATE SERVICE PRINCIPAL `udf-delegation-probe`
+-------^^^
+```
+
+`CREATE USER` and `CREATE LOGIN` fail identically at pos 7.
+
+Row 6, caller holding only `EXECUTE`: the sentinel planted in the function body
+came back through `DESCRIBE FUNCTION EXTENDED` and through
+`information_schema.routines`. `SHOW CREATE TABLE` refused with
+`TABLE_OR_VIEW_NOT_FOUND` — a shape error, not an authorization one.
+
+Row 7, caller holding only `EXECUTE`, function body carrying the author's token:
+`{"outcome": "created", "status": 201}`, confirmed by reading the SCIM directory
+back as the admin.
+
+## Trap 1 — the "low-privilege" client was the admin
+
+The first run reported that the low-privilege service principal authenticated as
+`<the admin's own email>`. The credentials were correct; the SDK never used
+them. The Makefile exports `DATABRICKS_CONFIG_PROFILE`, and the SDK's unified
+auth resolves a config profile ahead of explicitly-passed `client_id` /
+`client_secret`, so the "caller" was the author's own CLI session.
+
+Every row would have passed. The matrix would have read: definer's rights work,
+egress works, credentials are present, delegation succeeds end to end — a
+completely coherent, completely false story, because the experiment would have
+been the admin testing whether the admin can do things.
+
+Fixes: pin `auth_type="oauth-m2m"`, and add `assert_distinct_identities()`, which
+runs `SELECT current_user()` on both clients and aborts if they match. The
+identity claim is now measured, not configured.
+
+## Trap 2 — counting a virtualenv path as a credential
+
+Row 3's first implementation scored "does a credential exist?" as *any*
+environment variable starting with `DATABRICKS_`. The sandbox exports exactly
+one — `DATABRICKS_ROOT_VIRTUALENV_ENV`, a filesystem path — so the row recorded
+**pass**: "the sandbox has a credential."
+
+The fix was to enumerate the variables that could actually authenticate a
+request (`DATABRICKS_TOKEN`, `DATABRICKS_HOST`, `DATABRICKS_CLIENT_ID`, …) and
+report that subset separately. The row flipped to **fail**. Prefix-matching a
+namespace is not the same as detecting the thing the namespace sometimes
+contains.
+
+## Trap 3 — scoring a live 401 as "unreachable"
+
+The egress probe wrapped `urlopen` in a bare `except Exception`, so the control
+plane's `401` — an HTTP response, therefore proof the packet made the round trip
+— was recorded as a connectivity failure. Row 2 would have read "the sandbox can
+reach the public internet but not the workspace," which invites the wrong
+diagnosis entirely (a firewall) instead of the right one (no credential).
+
+`urllib.error.HTTPError` is now caught separately and recorded as
+`reached: true` with the status code. Reachability and authorization are
+different questions and a probe that conflates them answers neither.
+
+## What survived
+
+Rows 1, 5, 6, and 7 were correct on the first run and unchanged by the fixes.
+Rows 2 and 3 changed status. Row 4 was correct throughout but for a reason the
+first harness could not have articulated — it fails because of row 3, and rows
+2 and 3 had to be measured properly before that attribution was earned.
+
+## Environment dependence worth restating
+
+Databricks documents serverless egress as deny-by-default under a
+[network policy](https://docs.databricks.com/aws/en/security/network/serverless-network-security/network-policies).
+Row 2 succeeded here, so this workspace runs a permissive policy. A restrictive
+workspace would fail row 2 and reach the same overall conclusion sooner. Testing
+under the *most* permissive posture available is the stronger test: the pattern
+still fails without an embedded secret.

--- a/experiments/udf_privilege_delegation/pyproject.toml
+++ b/experiments/udf_privilege_delegation/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "udf-privilege-delegation"
+version = "0.1.0"
+description = "Experiment: can a Unity Catalog UDF act as a narrowly scoped privilege wrapper for one administrative action?"
+requires-python = ">=3.11"
+dependencies = ["databricks-sdk>=0.40.0"]
+
+[dependency-groups]
+dev = ["pytest>=8.0.0", "ruff>=0.8.0"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-v --tb=short"
+markers = [
+    "infrastructure: Tests requiring live Databricks infrastructure",
+]
+
+[tool.ruff]
+line-length = 100

--- a/experiments/udf_privilege_delegation/results/matrix_results.json
+++ b/experiments/udf_privilege_delegation/results/matrix_results.json
@@ -1,0 +1,248 @@
+{
+  "environment": {
+    "author_identity": "workspace admin",
+    "caller_identity": "OAuth M2M service principal, workspace user (non-admin)",
+    "cloud": "AWS",
+    "compute": "serverless SQL warehouse (PRO channel)",
+    "unity_catalog": "enabled",
+    "workspace": "one real Databricks workspace (host redacted)"
+  },
+  "rows": {
+    "1": {
+      "evidence": {
+        "control_direct_read": {
+          "error": "[INSUFFICIENT_PERMISSIONS] Insufficient privileges: User does not have SELECT on Table 'my_catalog.udf_privilege_delegation.sensitive_table'. SQLSTATE: 42501",
+          "error_code": "ServiceErrorCode.BAD_REQUEST",
+          "scalar": null,
+          "succeeded": false
+        },
+        "function_invocation": {
+          "error": null,
+          "error_code": null,
+          "scalar": "3",
+          "succeeded": true
+        }
+      },
+      "finding": "Definer's rights. The caller was denied a direct read of sensitive_table but successfully invoked an admin-owned SQL UDF whose body reads it, receiving 3. A SQL UDF is therefore a genuine privilege boundary for data access: EXECUTE on the function is sufficient and the caller never gains the underlying SELECT.",
+      "question": "Does a UC SQL UDF body run with definer (owner) privileges on objects the caller cannot access?",
+      "recorded_at": "2026-07-28T21:55:40+00:00",
+      "status": "pass"
+    },
+    "2": {
+      "evidence": {
+        "as_admin": {
+          "public_internet": {
+            "invocation": {
+              "error": null,
+              "error_code": null,
+              "scalar": "{\"reached\": true, \"status\": 200}",
+              "succeeded": true
+            },
+            "udf_report": {
+              "reached": true,
+              "status": 200
+            }
+          },
+          "workspace_control_plane": {
+            "invocation": {
+              "error": null,
+              "error_code": null,
+              "scalar": "{\"reached\": true, \"status\": 401, \"http_error\": true}",
+              "succeeded": true
+            },
+            "udf_report": {
+              "http_error": true,
+              "reached": true,
+              "status": 401
+            }
+          }
+        },
+        "as_lowpriv_caller": {
+          "public_internet": {
+            "invocation": {
+              "error": null,
+              "error_code": null,
+              "scalar": "{\"reached\": true, \"status\": 200}",
+              "succeeded": true
+            },
+            "udf_report": {
+              "reached": true,
+              "status": 200
+            }
+          },
+          "workspace_control_plane": {
+            "invocation": {
+              "error": null,
+              "error_code": null,
+              "scalar": "{\"reached\": true, \"status\": 401, \"http_error\": true}",
+              "succeeded": true
+            },
+            "udf_report": {
+              "http_error": true,
+              "reached": true,
+              "status": 401
+            }
+          }
+        }
+      },
+      "finding": "The UC Python UDF sandbox has outbound network access. As the low-privilege caller: workspace_control_plane -> HTTP 401, public_internet -> HTTP 200. A REST-based administrative action is therefore mechanically reachable from inside a function body \u2014 egress is not the constraint. Whether the request can be *authenticated* is row 3.",
+      "question": "Can a UC Python UDF make an outbound HTTPS request (the prerequisite for any REST-based admin action)?",
+      "recorded_at": "2026-07-28T21:55:48+00:00",
+      "status": "pass"
+    },
+    "3": {
+      "evidence": {
+        "as_admin": {
+          "invocation": {
+            "error": null,
+            "error_code": null,
+            "scalar": "{\"databricks_env_vars\": [\"DATABRICKS_ROOT_VIRTUALENV_ENV\"], \"credential_env_vars_present\": [], \"sdk_importable\": true, \"sdk_default_auth\": \"ValueError: default auth: cannot configure default credentials, please check https://docs.databricks.com/en/dev-tools/auth.html#databricks-client-unified-authentication to configure credentials for your preferred\", \"dbutils_available\": false, \"spark_session\": \"none\"}",
+            "succeeded": true
+          },
+          "udf_report": {
+            "credential_env_vars_present": [],
+            "databricks_env_vars": [
+              "DATABRICKS_ROOT_VIRTUALENV_ENV"
+            ],
+            "dbutils_available": false,
+            "sdk_default_auth": "ValueError: default auth: cannot configure default credentials, please check https://docs.databricks.com/en/dev-tools/auth.html#databricks-client-unified-authentication to configure credentials for your preferred",
+            "sdk_importable": true,
+            "spark_session": "none"
+          }
+        },
+        "as_lowpriv_caller": {
+          "invocation": {
+            "error": null,
+            "error_code": null,
+            "scalar": "{\"databricks_env_vars\": [\"DATABRICKS_ROOT_VIRTUALENV_ENV\"], \"credential_env_vars_present\": [], \"sdk_importable\": true, \"sdk_default_auth\": \"ValueError: default auth: cannot configure default credentials, please check https://docs.databricks.com/en/dev-tools/auth.html#databricks-client-unified-authentication to configure credentials for your preferred\", \"dbutils_available\": false, \"spark_session\": \"none\"}",
+            "succeeded": true
+          },
+          "udf_report": {
+            "credential_env_vars_present": [],
+            "databricks_env_vars": [
+              "DATABRICKS_ROOT_VIRTUALENV_ENV"
+            ],
+            "dbutils_available": false,
+            "sdk_default_auth": "ValueError: default auth: cannot configure default credentials, please check https://docs.databricks.com/en/dev-tools/auth.html#databricks-client-unified-authentication to configure credentials for your preferred",
+            "sdk_importable": true,
+            "spark_session": "none"
+          }
+        }
+      },
+      "finding": "No ambient credential. The UC Python UDF sandbox exposed no DATABRICKS_* environment variables and the SDK could not construct a default-auth client, for either identity. A function body therefore has nothing to authenticate as \u2014 it cannot act on the owner's behalf even in principle. Any credential would have to be passed in explicitly by the caller, which inverts the pattern: the caller would need to already hold the privileged credential.",
+      "question": "Does a UC Python UDF receive an ambient Databricks credential it could use to act as the function owner?",
+      "recorded_at": "2026-07-28T21:55:57+00:00",
+      "status": "fail"
+    },
+    "4": {
+      "evidence": {
+        "directory_contains_target_after_call": false,
+        "invocation": {
+          "error": null,
+          "error_code": null,
+          "scalar": "{\"had_ambient_token\": false, \"had_ambient_host\": false, \"outcome\": \"no ambient credential in UDF sandbox\"}",
+          "succeeded": true
+        },
+        "udf_report": {
+          "had_ambient_host": false,
+          "had_ambient_token": false,
+          "outcome": "no ambient credential in UDF sandbox"
+        }
+      },
+      "finding": "End-to-end delegation did not work. The caller could invoke the admin-owned function, but no service principal was created \u2014 the function body could not perform the administrative action. The failure is a capability failure inside the sandbox (see rows 2 and 3), not an authorization failure on the function itself.",
+      "question": "Can a low-privilege caller create a service principal by invoking an admin-owned UDF wrapper?",
+      "recorded_at": "2026-07-28T21:56:02+00:00",
+      "status": "fail"
+    },
+    "5": {
+      "evidence": {
+        "create_login": {
+          "outcome": {
+            "error": "[PARSE_SYNTAX_ERROR] Syntax error at or near 'LOGIN'. SQLSTATE: 42601 (line 1, pos 7) == SQL == CREATE LOGIN `udf-delegation-probe` -------^^^",
+            "error_code": "ServiceErrorCode.BAD_REQUEST",
+            "scalar": null,
+            "succeeded": false
+          },
+          "statement": "CREATE LOGIN `udf-delegation-probe`"
+        },
+        "create_service_principal": {
+          "outcome": {
+            "error": "[PARSE_SYNTAX_ERROR] Syntax error at or near 'SERVICE'. SQLSTATE: 42601 (line 1, pos 7) == SQL == CREATE SERVICE PRINCIPAL `udf-delegation-probe` -------^^^",
+            "error_code": "ServiceErrorCode.BAD_REQUEST",
+            "scalar": null,
+            "succeeded": false
+          },
+          "statement": "CREATE SERVICE PRINCIPAL `udf-delegation-probe`"
+        },
+        "create_user": {
+          "outcome": {
+            "error": "[PARSE_SYNTAX_ERROR] Syntax error at or near 'USER'. SQLSTATE: 42601 (line 1, pos 7) == SQL == CREATE USER `udf-delegation-probe` -------^^^",
+            "error_code": "ServiceErrorCode.BAD_REQUEST",
+            "scalar": null,
+            "succeeded": false
+          },
+          "statement": "CREATE USER `udf-delegation-probe`"
+        }
+      },
+      "finding": "No SQL surface. Every identity-administration statement was rejected by the parser even for a workspace admin, so principal creation is reachable only over the SCIM REST API. The one function type that carries definer's rights (SQL UDFs, row 1) therefore cannot express the action, and the one that could express it (Python UDFs) has neither egress nor a credential (rows 2-3). The two halves of the pattern never meet.",
+      "question": "Does any SQL surface exist for creating a principal, such that a definer-rights SQL UDF could wrap it?",
+      "recorded_at": "2026-07-28T21:56:05+00:00",
+      "status": "fail"
+    },
+    "6": {
+      "evidence": {
+        "describe_function_extended": {
+          "error": null,
+          "error_code": null,
+          "sentinel_visible_to_caller": true,
+          "statement": "DESCRIBE FUNCTION EXTENDED `my_catalog`.`udf_privilege_delegation`.f_py_with_embedded_sentinel",
+          "succeeded": true
+        },
+        "information_schema_routines": {
+          "error": null,
+          "error_code": null,
+          "sentinel_visible_to_caller": true,
+          "statement": "SELECT routine_definition FROM `my_catalog`.information_schema.routines WHERE routine_schema = 'udf_privilege_delegation' AND routine_name = 'f_py_with_embedded_sentinel'",
+          "succeeded": true
+        },
+        "invocation_control": {
+          "error": null,
+          "error_code": null,
+          "scalar": "ran",
+          "succeeded": true
+        },
+        "show_create_table": {
+          "error": "[TABLE_OR_VIEW_NOT_FOUND] The table or view `my_catalog`.`udf_privilege_delegation`.`f_py_with_embedded_sentinel` cannot be found. Verify the spelling and correctness of the schema and catalog.\nSearch path: [`system`.`session`, `my_catalog`.`default`].\nIf you did not qualify the name with a schema, verify the current_schema() output, or qualify the name with the correct schema and catalog.\nTo tolerate the error on drop use DROP VIEW IF EXISTS or DROP TABLE IF EXISTS. SQLSTATE: 42P01; line 1 pos 18",
+          "error_code": "ServiceErrorCode.BAD_REQUEST",
+          "sentinel_visible_to_caller": false,
+          "statement": "SHOW CREATE TABLE `my_catalog`.`udf_privilege_delegation`.f_py_with_embedded_sentinel",
+          "succeeded": false
+        }
+      },
+      "finding": "The function body is readable by a caller holding only EXECUTE, via describe_function_extended, information_schema_routines. A credential hardcoded into the body is therefore disclosed to exactly the population the wrapper was meant to keep it from \u2014 the workaround is not a delegation boundary, it is a credential handout with extra steps.",
+      "question": "Can a caller holding only EXECUTE read the function body, and therefore any credential embedded in it?",
+      "recorded_at": "2026-07-28T21:56:14+00:00",
+      "status": "fail"
+    },
+    "7": {
+      "evidence": {
+        "credential_source": "author's short-lived OAuth access token, embedded in the body",
+        "directory_contains_target_after_call": true,
+        "invocation": {
+          "error": null,
+          "error_code": null,
+          "scalar": "{\"outcome\": \"created\", \"status\": 201}",
+          "succeeded": true
+        },
+        "udf_report": {
+          "outcome": "created",
+          "status": 201
+        }
+      },
+      "finding": "It works, by embedding a credential. A caller holding only EXECUTE created a service principal through an admin-authored Python UDF whose body carries the author's token. The action is genuinely delegated and genuinely narrow \u2014 the caller can pass only a display name. But the elevation comes from a stored secret, not from the function model: the platform never re-authorizes the body as the owner, it simply replays whatever credential the author left in the source. Row 6 decides whether that secret stays hidden from the caller, and the token expires, so the wrapper silently stops working when it does.",
+      "question": "Does embedding the author's credential in the function body make the delegated admin action succeed for a low-privilege caller?",
+      "recorded_at": "2026-07-28T21:56:41+00:00",
+      "status": "pass"
+    }
+  }
+}

--- a/experiments/udf_privilege_delegation/scripts/README.md
+++ b/experiments/udf_privilege_delegation/scripts/README.md
@@ -1,0 +1,65 @@
+# scripts/
+
+Every ✅/❌ in the README matrix is produced here. One numbered script per matrix
+row; the number ties script → row → entry in `results/matrix_results.json`.
+
+## Prerequisites
+
+- A Databricks CLI profile for a **workspace admin** — the setup scripts create
+  service principals and mint their OAuth secrets. SSO/OAuth only; `_common.py`
+  exits if `DATABRICKS_TOKEN` looks like a `dapi…` personal access token.
+- A **serverless** SQL warehouse. UC Python UDFs do not run on classic warehouses.
+- A Unity Catalog catalog the profile can create schemas in.
+
+## Shared modules
+
+| File | Purpose |
+|---|---|
+| `_common.py` | Auth (`admin_client`, `lowpriv_client`), `.env` loading, SQL execution, results writing, redaction. |
+| `delegation/_delegation_common.py` | Function invocation and JSON decoding for the matrix rows. |
+
+Three things in `_common.py` are load-bearing and easy to break:
+
+- **`lowpriv_client()` pins `auth_type="oauth-m2m"`.** The Makefile exports
+  `DATABRICKS_CONFIG_PROFILE`, and without the pin the SDK's unified auth
+  resolves the CLI profile first and silently returns the *admin* identity —
+  turning every row into a self-test that always passes.
+- **`assert_distinct_identities()` is called by every row that uses both
+  identities.** It runs `SELECT current_user()` on each client and refuses to
+  continue if they match. Configuration is not trusted; the warehouse is asked.
+- **`write_result()` redacts.** Catalog name, workspace host, caller application
+  id, and anything email-shaped are replaced with placeholders before anything
+  is written, because raw platform error strings are exactly where real
+  coordinates hide and `results/` is committed to a public repo.
+
+## Setup and teardown
+
+| Script | What it does |
+|---|---|
+| `verify.py` | One real request (`SELECT current_user()`, then `SHOW SCHEMAS`) to prove profile + warehouse + catalog before any matrix work. |
+| `setup/00_create_lowpriv_principal.py` | Creates the caller service principal, mints a workspace OAuth secret, grants `CAN_USE` on the warehouse, asserts it is not in `admins`, writes the gitignored `.env`, and proves it authenticates as itself. |
+| `setup/01_provision_objects.py` | Creates the schema, `sensitive_table`, the four probe functions, and grants the caller `USE CATALOG` / `USE SCHEMA` / `EXECUTE` — then asserts via `SHOW GRANTS` that the caller holds *nothing* on `sensitive_table`. |
+| `setup/99_teardown.py` | Drops the schema cascade and deletes both target principals and the caller. Run it before re-running row 4 or row 7 — both refuse to produce a result if their target principal already exists. |
+
+## Matrix rows
+
+| Script | Row | Question |
+|---|---|---|
+| `delegation/01_sql_udf_definer_vs_invoker.py` | 1 | Does a SQL UDF body run with the owner's privileges? Asserts the control (direct read denied) before trusting the wrapped read. |
+| `delegation/02_python_udf_network_egress.py` | 2 | Can the Python sandbox reach the network? Probes the workspace control plane and a public endpoint, as both identities. |
+| `delegation/03_python_udf_credential_context.py` | 3 | Does the sandbox hold a credential? Asks the sandbox to describe its own environment. |
+| `delegation/04_end_to_end_create_service_principal.py` | 4 | Does the whole pattern work? Verdict is the SCIM directory read back as admin, not the function's return value. |
+| `delegation/05_sql_surface_for_identity_admin.py` | 5 | Is identity administration expressible in SQL at all? Probed as admin — if the grammar is absent for an admin it is absent for everyone. |
+| `delegation/06_function_body_readable_by_caller.py` | 6 | Can a caller with only `EXECUTE` read the body? Plants a sentinel (never a real secret) and tries three read paths. |
+| `delegation/07_embedded_credential_end_to_end.py` | 7 | Does an author-embedded credential make it work? Uses the author's short-lived OAuth token, never logs the DDL, and drops the function in a `finally` block. |
+
+## Reading the output
+
+Failure output is data. `INSUFFICIENT_PERMISSIONS` (row 1's control),
+`PARSE_SYNTAX_ERROR` (row 5), and `HTTP 401` (row 2) are each the finding for
+their row — *which* thing refused and *how* is the result, so scripts print the
+rejected error body rather than swallowing it.
+
+Scripts are idempotent (`CREATE OR REPLACE` throughout) except where a
+pre-existing target would make a result meaningless: rows 4 and 7 check the SCIM
+directory first and record `inconclusive` rather than a false pass.

--- a/experiments/udf_privilege_delegation/scripts/_common.py
+++ b/experiments/udf_privilege_delegation/scripts/_common.py
@@ -1,0 +1,336 @@
+"""Shared helpers: auth, output style, SQL execution, results writing.
+
+Every live claim in this experiment's findings matrix is produced by a script
+that goes through this module, so auth handling and evidence capture stay
+uniform.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.sql import ExecuteStatementRequestOnWaitTimeout, StatementState
+
+EXPERIMENT_ROOT = Path(__file__).resolve().parent.parent
+RESULTS_PATH = EXPERIMENT_ROOT / "results" / "matrix_results.json"
+
+
+def _load_dotenv() -> None:
+    """Load the gitignored .env written by scripts/setup/00_*.py.
+
+    Make's `-include .env` is evaluated when the Makefile is parsed, which is
+    before `make setup` has written the file — so the setup and matrix targets
+    would not see the caller credentials in the same invocation. Loading here
+    makes each script self-sufficient.
+    """
+    env_path = EXPERIMENT_ROOT / ".env"
+    if not env_path.exists():
+        return
+    for line in env_path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        os.environ[key.strip()] = value.strip()
+
+
+_load_dotenv()
+
+PROFILE = os.environ.get("DATABRICKS_CONFIG_PROFILE", "DEFAULT")
+CATALOG = os.environ.get("EXPERIMENT_CATALOG", "my_catalog")
+SCHEMA = os.environ.get("EXPERIMENT_SCHEMA", "udf_privilege_delegation")
+WAREHOUSE_ID = os.environ.get("EXPERIMENT_WAREHOUSE_ID", "")
+
+FQ_SCHEMA = f"`{CATALOG}`.`{SCHEMA}`"
+
+# The low-privilege caller identity, populated by scripts/setup/00_*.py.
+LOWPRIV_DISPLAY_NAME = os.environ.get(
+    "EXPERIMENT_LOWPRIV_DISPLAY_NAME", "udf-delegation-lowpriv"
+)
+
+
+# --------------------------------------------------------------------------
+# output
+# --------------------------------------------------------------------------
+
+
+def section(title: str) -> None:
+    print(f"\n{'=' * 72}\n{title}\n{'=' * 72}")
+
+
+def step(msg: str) -> None:
+    print(f"  ->  {msg}")
+
+
+def ok(msg: str) -> None:
+    print(f"  OK  {msg}")
+
+
+def fail(msg: str) -> None:
+    print(f"  !!  {msg}")
+
+
+def info(msg: str) -> None:
+    print(f"      {msg}")
+
+
+# --------------------------------------------------------------------------
+# auth
+# --------------------------------------------------------------------------
+
+
+def _refuse_pat(value: str | None, where: str) -> None:
+    """This repo is public and SSO/OAuth-only. Personal access tokens are a
+    footgun that ends up in shell history and result artifacts."""
+    if value and value.startswith("dapi"):
+        raise SystemExit(
+            f"Refusing to run: a personal access token was supplied via {where}. "
+            "This experiment is OAuth/SSO only — use a Databricks CLI profile."
+        )
+
+
+def admin_client() -> WorkspaceClient:
+    """The high-privilege author identity (a workspace admin, via SSO profile)."""
+    _refuse_pat(os.environ.get("DATABRICKS_TOKEN"), "DATABRICKS_TOKEN")
+    return WorkspaceClient(profile=PROFILE)
+
+
+def lowpriv_client() -> WorkspaceClient:
+    """The low-privilege caller identity — an OAuth M2M service principal that
+    holds nothing but USE CATALOG / USE SCHEMA / EXECUTE.
+
+    Credentials come from the gitignored .env written by
+    scripts/setup/00_create_lowpriv_principal.py.
+    """
+    client_id = os.environ.get("EXPERIMENT_LOWPRIV_CLIENT_ID")
+    client_secret = os.environ.get("EXPERIMENT_LOWPRIV_CLIENT_SECRET")
+    if not client_id or not client_secret:
+        raise SystemExit(
+            "EXPERIMENT_LOWPRIV_CLIENT_ID / _CLIENT_SECRET are unset. "
+            "Run `make setup` first — it creates the low-privilege service "
+            "principal and writes .env."
+        )
+    # auth_type is pinned: DATABRICKS_CONFIG_PROFILE is exported by the Makefile,
+    # and without pinning, the SDK's unified auth resolves the CLI profile first
+    # and silently hands back the *admin* identity — which would make every row
+    # of this matrix a self-test.
+    return WorkspaceClient(
+        host=admin_client().config.host,
+        client_id=client_id,
+        client_secret=client_secret,
+        auth_type="oauth-m2m",
+    )
+
+
+def assert_distinct_identities(admin: WorkspaceClient, caller: WorkspaceClient) -> tuple[str, str]:
+    """Refuse to produce evidence unless the two clients really are two identities.
+
+    The entire experiment is worthless if the "low-privilege caller" is actually
+    the admin's session, so this is checked against the live warehouse rather
+    than assumed from configuration.
+    """
+    admin_who = run_sql(admin, "SELECT current_user()").scalar
+    caller_who = run_sql(caller, "SELECT current_user()").scalar
+    if not caller_who or admin_who == caller_who:
+        raise SystemExit(
+            "Identity check failed: the low-privilege client resolved to "
+            f"{caller_who!r}, the same identity as the admin client. Every matrix "
+            "row would be a self-test. Check .env and the oauth-m2m credentials."
+        )
+    return str(admin_who), str(caller_who)
+
+
+def warehouse_id(w: WorkspaceClient) -> str:
+    """Resolve the SQL warehouse to run statements on."""
+    if WAREHOUSE_ID:
+        return WAREHOUSE_ID
+    for wh in w.warehouses.list():
+        if wh.enable_serverless_compute and wh.id:
+            return wh.id
+    raise SystemExit(
+        "No serverless SQL warehouse found. Set EXPERIMENT_WAREHOUSE_ID."
+    )
+
+
+# --------------------------------------------------------------------------
+# sql
+# --------------------------------------------------------------------------
+
+
+class SqlOutcome:
+    """The outcome of one statement — success rows, or the platform's refusal.
+
+    Failure output is data in this experiment: *which* error the platform
+    raises (PERMISSION_DENIED vs UNAUTHORIZED_ACCESS vs a sandbox error)
+    is often the finding itself.
+    """
+
+    def __init__(
+        self,
+        succeeded: bool,
+        rows: list[list[Any]] | None = None,
+        error: str | None = None,
+        error_code: str | None = None,
+    ) -> None:
+        self.succeeded = succeeded
+        self.rows = rows or []
+        self.error = error
+        self.error_code = error_code
+
+    @property
+    def scalar(self) -> Any:
+        return self.rows[0][0] if self.rows and self.rows[0] else None
+
+    def summary(self) -> dict[str, Any]:
+        return {
+            "succeeded": self.succeeded,
+            "scalar": self.scalar,
+            "error_code": self.error_code,
+            "error": _truncate(self.error) if self.error else None,
+        }
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return f"SqlOutcome(succeeded={self.succeeded}, scalar={self.scalar!r})"
+
+
+def _truncate(text: str, limit: int = 600) -> str:
+    text = " ".join(text.split())
+    return text if len(text) <= limit else text[:limit] + " ...[truncated]"
+
+
+def run_sql(w: WorkspaceClient, sql: str, *, wh: str | None = None) -> SqlOutcome:
+    """Execute one statement and capture success rows or the refusal."""
+    resp = w.statement_execution.execute_statement(
+        statement=sql,
+        warehouse_id=wh or warehouse_id(w),
+        wait_timeout="50s",
+        on_wait_timeout=ExecuteStatementRequestOnWaitTimeout.CANCEL,
+    )
+    status = resp.status
+    if status and status.state == StatementState.SUCCEEDED:
+        rows = []
+        if resp.result and resp.result.data_array:
+            rows = [list(r) for r in resp.result.data_array]
+        return SqlOutcome(True, rows=rows)
+
+    err = status.error if status else None
+    return SqlOutcome(
+        False,
+        error=err.message if err and err.message else str(status),
+        error_code=str(err.error_code) if err and err.error_code else None,
+    )
+
+
+def run_sql_or_die(w: WorkspaceClient, sql: str, *, wh: str | None = None) -> SqlOutcome:
+    outcome = run_sql(w, sql, wh=wh)
+    if not outcome.succeeded:
+        fail(f"setup statement failed: {outcome.error_code}: {outcome.error}")
+        info(f"statement: {_truncate(sql, 300)}")
+        sys.exit(1)
+    return outcome
+
+
+# --------------------------------------------------------------------------
+# results
+# --------------------------------------------------------------------------
+
+VALID_STATUS = {"pass", "fail", "partial", "inconclusive"}
+
+# results/ is committed to a public repo, and the most useful evidence — raw
+# platform error strings — is exactly where real coordinates hide. Redaction
+# happens at the write boundary so no individual script can forget it.
+PLACEHOLDER_CATALOG = "my_catalog"
+PLACEHOLDER_HOST = "https://my-workspace.cloud.databricks.com"
+PLACEHOLDER_AUTHOR = "author@example.com"
+PLACEHOLDER_CALLER = "00000000-0000-0000-0000-000000000000"
+
+
+def _redaction_map() -> dict[str, str]:
+    mapping = {CATALOG: PLACEHOLDER_CATALOG}
+    caller_id = os.environ.get("EXPERIMENT_LOWPRIV_CLIENT_ID")
+    if caller_id:
+        mapping[caller_id] = PLACEHOLDER_CALLER
+    try:
+        cfg = admin_client().config
+        if cfg.host:
+            mapping[cfg.host.rstrip("/")] = PLACEHOLDER_HOST
+        # bare hostname, for error strings that omit the scheme
+        if cfg.hostname:
+            mapping[cfg.hostname] = PLACEHOLDER_HOST.removeprefix("https://")
+    except Exception:  # pragma: no cover - redaction must never break a run
+        pass
+    return mapping
+
+
+_EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+
+
+def redact(blob: str) -> str:
+    for real, placeholder in _redaction_map().items():
+        if real:
+            blob = blob.replace(real, placeholder)
+    return _EMAIL_RE.sub(PLACEHOLDER_AUTHOR, blob)
+
+
+def write_result(
+    row_id: str,
+    *,
+    question: str,
+    status: str,
+    finding: str,
+    evidence: dict[str, Any],
+) -> None:
+    """Append/overwrite one matrix row in results/matrix_results.json.
+
+    ``status`` maps to the README matrix vocabulary:
+      pass -> works as claimed, fail -> does not, partial -> partially,
+      inconclusive -> could not be isolated (``finding`` must say why).
+    """
+    if status not in VALID_STATUS:
+        raise ValueError(f"status must be one of {sorted(VALID_STATUS)}, got {status!r}")
+
+    RESULTS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    if RESULTS_PATH.exists():
+        payload = json.loads(RESULTS_PATH.read_text())
+    else:
+        payload = {"rows": {}}
+
+    payload["rows"][row_id] = json.loads(
+        redact(
+            json.dumps(
+                {
+                    "question": question,
+                    "status": status,
+                    "finding": finding,
+                    "evidence": evidence,
+                    "recorded_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+                }
+            )
+        )
+    )
+    payload["environment"] = environment_shape()
+    RESULTS_PATH.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    ok(f"recorded row {row_id}: {status}")
+
+
+def environment_shape() -> dict[str, str]:
+    """Results are claims about a moment — record the shape of the moment.
+
+    Deliberately records no workspace host, account id, or user: this repo is
+    public.
+    """
+    return {
+        "cloud": "AWS",
+        "workspace": "one real Databricks workspace (host redacted)",
+        "compute": "serverless SQL warehouse (PRO channel)",
+        "unity_catalog": "enabled",
+        "caller_identity": "OAuth M2M service principal, workspace user (non-admin)",
+        "author_identity": "workspace admin",
+    }

--- a/experiments/udf_privilege_delegation/scripts/delegation/01_sql_udf_definer_vs_invoker.py
+++ b/experiments/udf_privilege_delegation/scripts/delegation/01_sql_udf_definer_vs_invoker.py
@@ -1,0 +1,115 @@
+"""Row 1 — does a UC SQL UDF body resolve underlying privileges as definer or invoker?
+
+This is the load-bearing question for the whole pattern. If the function body
+runs with the *owner's* privileges, an admin-authored function is a real
+privilege boundary and narrow delegation is possible. If it runs with the
+*caller's*, a function can never grant access the caller does not already have.
+
+Design: the caller holds EXECUTE on f_sql_read_sensitive and no privilege at
+all on the table its body reads. Two statements, run as the caller:
+
+  A. direct  SELECT count(*) FROM sensitive_table   -- must fail (control)
+  B. wrapped SELECT f_sql_read_sensitive()          -- the actual question
+
+A must fail for B to mean anything, so A is asserted, not assumed.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from _common import (  # noqa: E402
+    FQ_SCHEMA,
+    admin_client,
+    assert_distinct_identities,
+    fail,
+    info,
+    lowpriv_client,
+    ok,
+    run_sql,
+    section,
+    step,
+    write_result,
+)
+
+ROW = "1"
+QUESTION = "Does a UC SQL UDF body run with definer (owner) privileges on objects the caller cannot access?"
+
+
+def main() -> int:
+    section(f"row {ROW}: SQL UDF — definer vs invoker rights")
+    lw = lowpriv_client()
+    admin_who, caller_who = assert_distinct_identities(admin_client(), lw)
+    info(f"author={admin_who}  caller={caller_who}")
+
+    step("control A: caller reads sensitive_table directly (expected: denied)")
+    direct = run_sql(lw, f"SELECT count(*) FROM {FQ_SCHEMA}.sensitive_table")
+    if direct.succeeded:
+        fail(
+            "the caller CAN read sensitive_table directly — the scenario is not "
+            "set up correctly and rows 1-2 would be meaningless"
+        )
+        write_result(
+            ROW,
+            question=QUESTION,
+            status="inconclusive",
+            finding=(
+                "Could not isolate the question: the low-privilege caller already had "
+                "read access to the underlying table, so a successful call through the "
+                "function would not have demonstrated definer's rights. Re-provision "
+                "with setup/01 and confirm SHOW GRANTS returns nothing."
+            ),
+            evidence={"control_direct_read": direct.summary()},
+        )
+        return 1
+    ok(f"denied as required: {direct.error_code}")
+    info(f"error: {direct.error}")
+
+    step("B: caller invokes the admin-owned SQL UDF that reads the same table")
+    wrapped = run_sql(lw, f"SELECT {FQ_SCHEMA}.f_sql_read_sensitive()")
+
+    evidence = {
+        "control_direct_read": direct.summary(),
+        "function_invocation": wrapped.summary(),
+    }
+
+    if wrapped.succeeded:
+        ok(f"function returned {wrapped.scalar} — the body read a table the caller cannot")
+        write_result(
+            ROW,
+            question=QUESTION,
+            status="pass",
+            finding=(
+                "Definer's rights. The caller was denied a direct read of "
+                "sensitive_table but successfully invoked an admin-owned SQL UDF "
+                f"whose body reads it, receiving {wrapped.scalar}. A SQL UDF is "
+                "therefore a genuine privilege boundary for data access: EXECUTE on "
+                "the function is sufficient and the caller never gains the "
+                "underlying SELECT."
+            ),
+            evidence=evidence,
+        )
+    else:
+        fail(f"function invocation also denied: {wrapped.error_code}")
+        info(f"error: {wrapped.error}")
+        write_result(
+            ROW,
+            question=QUESTION,
+            status="fail",
+            finding=(
+                "Invoker's rights. The caller holds EXECUTE on the function but the "
+                "invocation was refused with "
+                f"{wrapped.error_code}, meaning the body's object references are "
+                "authorized against the caller, not the owner. A SQL UDF cannot "
+                "elevate access to objects the caller lacks."
+            ),
+            evidence=evidence,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/udf_privilege_delegation/scripts/delegation/02_python_udf_network_egress.py
+++ b/experiments/udf_privilege_delegation/scripts/delegation/02_python_udf_network_egress.py
@@ -1,0 +1,137 @@
+"""Row 2 — can a UC Python UDF make an outbound HTTPS request?
+
+Creating a service principal is a SCIM REST operation. If the Python UDF
+sandbox has no network egress, then no UDF can perform that action regardless
+of who owns the function or how the privilege model resolves — the pattern is
+blocked on capability, not on authorization.
+
+Two targets are probed so a failure can be attributed:
+  - the workspace's own control plane (same-origin, most likely to be allowed)
+  - a public internet endpoint (broadest egress)
+
+This row is a capability question, not an authorization question, so it is run
+as BOTH identities: if the admin cannot reach the network either, the sandbox
+is the constraint rather than the caller's privileges.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from _delegation_common import call_function, decode_json_scalar  # noqa: E402
+
+from _common import (  # noqa: E402
+    admin_client,
+    assert_distinct_identities,
+    fail,
+    info,
+    lowpriv_client,
+    ok,
+    section,
+    step,
+    write_result,
+)
+
+ROW = "2"
+QUESTION = "Can a UC Python UDF make an outbound HTTPS request (the prerequisite for any REST-based admin action)?"
+
+
+def probe(w, label: str) -> dict:
+    results = {}
+    host = w.config.host.rstrip("/")
+    targets = {
+        "workspace_control_plane": f"{host}/api/2.0/preview/scim/v2/Me",
+        "public_internet": "https://example.com",
+    }
+    for name, url in targets.items():
+        step(f"[{label}] f_py_egress -> {name}")
+        outcome = call_function(w, "f_py_egress", url)
+        decoded = decode_json_scalar(outcome)
+        results[name] = {"invocation": outcome.summary(), "udf_report": decoded}
+        if not outcome.succeeded:
+            fail(f"invocation itself failed: {outcome.error_code}")
+            info(f"error: {outcome.error}")
+        elif decoded.get("reached"):
+            ok(f"reached {name} (HTTP {decoded.get('status')})")
+        else:
+            fail(f"{name} unreachable: {decoded.get('error_type')}: {decoded.get('error')}")
+    return results
+
+
+def main() -> int:
+    section(f"row {ROW}: UC Python UDF — network egress")
+
+    admin_w, caller_w = admin_client(), lowpriv_client()
+    admin_who, caller_who = assert_distinct_identities(admin_w, caller_w)
+    info(f"author={admin_who}  caller={caller_who}")
+
+    admin = probe(admin_w, "admin")
+    caller = probe(caller_w, "low-priv caller")
+
+    evidence = {"as_admin": admin, "as_lowpriv_caller": caller}
+
+    def reached(res: dict) -> bool:
+        return any(v["udf_report"].get("reached") for v in res.values())
+
+    invocable = all(
+        v["invocation"]["succeeded"] for v in list(admin.values()) + list(caller.values())
+    )
+
+    if not invocable:
+        write_result(
+            ROW,
+            question=QUESTION,
+            status="inconclusive",
+            finding=(
+                "Could not isolate egress: at least one f_py_egress invocation failed "
+                "before the UDF body ran, so the sandbox's network behaviour was never "
+                "exercised. See evidence.invocation error codes."
+            ),
+            evidence=evidence,
+        )
+        return 0
+
+    if reached(admin) or reached(caller):
+        detail = ", ".join(
+            f"{target} -> HTTP {res['udf_report'].get('status')}"
+            if res["udf_report"].get("reached")
+            else f"{target} -> unreachable ({res['udf_report'].get('error_type')})"
+            for target, res in caller.items()
+        )
+        write_result(
+            ROW,
+            question=QUESTION,
+            status="pass",
+            finding=(
+                "The UC Python UDF sandbox has outbound network access. As the "
+                f"low-privilege caller: {detail}. A REST-based administrative action "
+                "is therefore mechanically reachable from inside a function body — "
+                "egress is not the constraint. Whether the request can be "
+                "*authenticated* is row 3."
+            ),
+            evidence=evidence,
+        )
+    else:
+        write_result(
+            ROW,
+            question=QUESTION,
+            status="fail",
+            finding=(
+                "No egress. Every outbound HTTPS request from inside the UC Python "
+                "UDF sandbox failed, for both the owning admin and the low-privilege "
+                "caller, against both the workspace control plane and the public "
+                "internet. Because creating a service principal has no SQL surface "
+                "and can only be done over REST, this blocks the wrapper pattern for "
+                "that action on capability grounds — before authorization is even "
+                "considered."
+            ),
+            evidence=evidence,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/udf_privilege_delegation/scripts/delegation/03_python_udf_credential_context.py
+++ b/experiments/udf_privilege_delegation/scripts/delegation/03_python_udf_credential_context.py
@@ -1,0 +1,121 @@
+"""Row 3 — does a UC Python UDF receive an ambient Databricks credential?
+
+Even with egress, a wrapper function needs *something to authenticate with*.
+The delegation pattern only works if the function body can act as the owner —
+which requires the sandbox to hand it an owner-scoped credential.
+
+This asks the sandbox to describe itself: which DATABRICKS_* environment
+variables exist, whether the SDK can construct a default-auth client, whether
+dbutils or an active Spark session are reachable.
+
+Run as both identities: a credential that appears only for the admin would
+still not help, because the function must work when the *caller* invokes it.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from _delegation_common import call_function, decode_json_scalar  # noqa: E402
+
+from _common import (  # noqa: E402
+    admin_client,
+    assert_distinct_identities,
+    fail,
+    info,
+    lowpriv_client,
+    ok,
+    section,
+    step,
+    write_result,
+)
+
+ROW = "3"
+QUESTION = "Does a UC Python UDF receive an ambient Databricks credential it could use to act as the function owner?"
+
+
+def probe(w, label: str) -> dict:
+    step(f"[{label}] f_py_credential_probe()")
+    outcome = call_function(w, "f_py_credential_probe")
+    decoded = decode_json_scalar(outcome)
+    if outcome.succeeded:
+        ok(f"[{label}] sandbox reported: {decoded}")
+    else:
+        fail(f"[{label}] invocation failed: {outcome.error_code}")
+        info(f"error: {outcome.error}")
+    return {"invocation": outcome.summary(), "udf_report": decoded}
+
+
+def main() -> int:
+    section(f"row {ROW}: UC Python UDF — credential context")
+
+    admin_w, caller_w = admin_client(), lowpriv_client()
+    admin_who, caller_who = assert_distinct_identities(admin_w, caller_w)
+    info(f"author={admin_who}  caller={caller_who}")
+
+    admin = probe(admin_w, "admin")
+    caller = probe(caller_w, "low-priv caller")
+    evidence = {"as_admin": admin, "as_lowpriv_caller": caller}
+
+    if not (admin["invocation"]["succeeded"] and caller["invocation"]["succeeded"]):
+        write_result(
+            ROW,
+            question=QUESTION,
+            status="inconclusive",
+            finding=(
+                "Could not isolate the credential context: the probe function failed "
+                "to execute for at least one identity, so the sandbox never reported "
+                "its environment."
+            ),
+            evidence=evidence,
+        )
+        return 0
+
+    def has_credential(res: dict) -> bool:
+        # Only credential-bearing variables count. The sandbox exports unrelated
+        # DATABRICKS_* bookkeeping (e.g. DATABRICKS_ROOT_VIRTUALENV_ENV), and
+        # treating any DATABRICKS_* prefix as proof of a credential would score
+        # this row "pass" on a variable that cannot authenticate anything.
+        report = res["udf_report"]
+        creds = report.get("credential_env_vars_present") or []
+        sdk_ok = report.get("sdk_default_auth") == "constructed"
+        return bool(creds) or sdk_ok
+
+    if has_credential(caller):
+        write_result(
+            ROW,
+            question=QUESTION,
+            status="pass",
+            finding=(
+                "The sandbox exposed a usable Databricks credential when the "
+                "low-privilege caller invoked the function. See evidence for exactly "
+                "which variables or auth path were available and whose identity they "
+                "resolve to — an owner-scoped credential enables delegation, a "
+                "caller-scoped one does not."
+            ),
+            evidence=evidence,
+        )
+    else:
+        write_result(
+            ROW,
+            question=QUESTION,
+            status="fail",
+            finding=(
+                "No ambient credential. The UC Python UDF sandbox exposed no "
+                "DATABRICKS_* environment variables and the SDK could not construct a "
+                "default-auth client, for either identity. A function body therefore "
+                "has nothing to authenticate as — it cannot act on the owner's behalf "
+                "even in principle. Any credential would have to be passed in "
+                "explicitly by the caller, which inverts the pattern: the caller would "
+                "need to already hold the privileged credential."
+            ),
+            evidence=evidence,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/udf_privilege_delegation/scripts/delegation/04_end_to_end_create_service_principal.py
+++ b/experiments/udf_privilege_delegation/scripts/delegation/04_end_to_end_create_service_principal.py
@@ -1,0 +1,117 @@
+"""Row 4 — end to end: does the low-privilege caller actually create a service principal?
+
+The rows above test the mechanism in pieces. This one asks the question the way
+a customer would: an admin publishes f_py_create_sp, a low-privilege user is
+granted EXECUTE on it and nothing else, the user calls it — does a service
+principal exist afterwards?
+
+The verdict is not the function's return value. It is the workspace SCIM
+directory, read back by the admin: an actual principal, or nothing.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from _delegation_common import call_function, decode_json_scalar  # noqa: E402
+
+from _common import (  # noqa: E402
+    admin_client,
+    assert_distinct_identities,
+    fail,
+    info,
+    lowpriv_client,
+    ok,
+    section,
+    step,
+    write_result,
+)
+
+ROW = "4"
+QUESTION = "Can a low-privilege caller create a service principal by invoking an admin-owned UDF wrapper?"
+
+TARGET_NAME = "udf-delegation-target-sp"
+
+
+def directory_contains(w, display_name: str) -> bool:
+    return any(w.service_principals.list(filter=f'displayName eq "{display_name}"'))
+
+
+def main() -> int:
+    section(f"row {ROW}: end-to-end delegated service principal creation")
+    admin = admin_client()
+    caller = lowpriv_client()
+    admin_who, caller_who = assert_distinct_identities(admin, caller)
+    info(f"author={admin_who}  caller={caller_who}")
+
+    step(f"pre-check: is {TARGET_NAME!r} already in the directory?")
+    if directory_contains(admin, TARGET_NAME):
+        fail("target already exists — run `make teardown` first so the result is meaningful")
+        write_result(
+            ROW,
+            question=QUESTION,
+            status="inconclusive",
+            finding=(
+                f"Could not isolate the result: a service principal named "
+                f"{TARGET_NAME!r} already existed before the call, so its presence "
+                "afterwards would prove nothing. Tear down and re-run."
+            ),
+            evidence={"precheck": "target already present"},
+        )
+        return 1
+    ok("directory is clean")
+
+    step("low-privilege caller invokes the admin-owned wrapper")
+    outcome = call_function(caller, "f_py_create_sp", TARGET_NAME)
+    decoded = decode_json_scalar(outcome)
+    if outcome.succeeded:
+        info(f"function returned: {decoded}")
+    else:
+        fail(f"invocation failed: {outcome.error_code}")
+        info(f"error: {outcome.error}")
+
+    step("verdict: reading the SCIM directory back as admin")
+    created = directory_contains(admin, TARGET_NAME)
+
+    evidence = {
+        "invocation": outcome.summary(),
+        "udf_report": decoded,
+        "directory_contains_target_after_call": created,
+    }
+
+    if created:
+        ok(f"{TARGET_NAME} exists — delegation succeeded")
+        write_result(
+            ROW,
+            question=QUESTION,
+            status="pass",
+            finding=(
+                "End-to-end delegation worked: a caller holding only EXECUTE on the "
+                "function caused a service principal to be created, without holding "
+                "any identity-management privilege directly."
+            ),
+            evidence=evidence,
+        )
+    else:
+        fail(f"{TARGET_NAME} was not created")
+        write_result(
+            ROW,
+            question=QUESTION,
+            status="fail",
+            finding=(
+                "End-to-end delegation did not work. The caller could invoke the "
+                "admin-owned function, but no service principal was created — the "
+                "function body could not perform the administrative action. The "
+                "failure is a capability failure inside the sandbox (see rows 2 and "
+                "3), not an authorization failure on the function itself."
+            ),
+            evidence=evidence,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/udf_privilege_delegation/scripts/delegation/05_sql_surface_for_identity_admin.py
+++ b/experiments/udf_privilege_delegation/scripts/delegation/05_sql_surface_for_identity_admin.py
@@ -1,0 +1,91 @@
+"""Row 5 — is there any SQL surface for identity administration a UDF could call?
+
+Rows 2-4 fail through the network path. This row checks the other possible
+path: if creating a principal were expressible in SQL, a SQL UDF (which row 1
+shows *does* carry definer's rights) could wrap it and the pattern would work
+without any egress at all.
+
+So: does the SQL dialect accept identity-administration DDL? Probed as the
+admin, because if the grammar does not exist for an admin it does not exist for
+anyone. A PARSE_SYNTAX_ERROR is the finding — it means the operation lives
+outside SQL entirely.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from _common import (  # noqa: E402
+    admin_client,
+    fail,
+    info,
+    ok,
+    run_sql,
+    section,
+    step,
+    write_result,
+)
+
+ROW = "5"
+QUESTION = "Does any SQL surface exist for creating a principal, such that a definer-rights SQL UDF could wrap it?"
+
+CANDIDATES = {
+    "create_service_principal": "CREATE SERVICE PRINCIPAL `udf-delegation-probe`",
+    "create_user": "CREATE USER `udf-delegation-probe`",
+    "create_login": "CREATE LOGIN `udf-delegation-probe`",
+}
+
+
+def main() -> int:
+    section(f"row {ROW}: SQL surface for identity administration")
+    w = admin_client()
+
+    evidence = {}
+    any_accepted = False
+    for name, stmt in CANDIDATES.items():
+        step(f"probing: {stmt}")
+        outcome = run_sql(w, stmt)
+        evidence[name] = {"statement": stmt, "outcome": outcome.summary()}
+        if outcome.succeeded:
+            any_accepted = True
+            ok("accepted by the SQL parser")
+        else:
+            fail(f"rejected: {outcome.error_code}")
+            info(f"error: {outcome.error}")
+
+    if any_accepted:
+        write_result(
+            ROW,
+            question=QUESTION,
+            status="pass",
+            finding=(
+                "At least one identity-administration statement is expressible in "
+                "SQL, so a definer-rights SQL UDF could wrap it. See evidence for "
+                "which grammar was accepted."
+            ),
+            evidence=evidence,
+        )
+    else:
+        write_result(
+            ROW,
+            question=QUESTION,
+            status="fail",
+            finding=(
+                "No SQL surface. Every identity-administration statement was rejected "
+                "by the parser even for a workspace admin, so principal creation is "
+                "reachable only over the SCIM REST API. The one function type that "
+                "carries definer's rights (SQL UDFs, row 1) therefore cannot express "
+                "the action, and the one that could express it (Python UDFs) has "
+                "neither egress nor a credential (rows 2-3). The two halves of the "
+                "pattern never meet."
+            ),
+            evidence=evidence,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/udf_privilege_delegation/scripts/delegation/06_function_body_readable_by_caller.py
+++ b/experiments/udf_privilege_delegation/scripts/delegation/06_function_body_readable_by_caller.py
@@ -1,0 +1,158 @@
+"""Row 6 — can a caller holding only EXECUTE read the function's body?
+
+Rows 2-4 show the sandbox has network reach but no identity. The obvious next
+move for anyone determined to make the pattern work is for the author to
+hardcode a credential into the function body. That only stays a *delegation* if
+the body is opaque to the caller: if EXECUTE also confers the ability to read
+the source, the "wrapper" hands every caller the admin credential in plaintext
+and is strictly worse than granting the privilege directly.
+
+A sentinel string stands in for the credential here — the question is whether
+the body is readable, and a real token is not needed to answer it (and must not
+be written into a public repo's evidence).
+
+Every plausible read path the caller could try is probed, because "DESCRIBE was
+blocked" would not be a finding if information_schema still exposed the text.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from _common import (  # noqa: E402
+    CATALOG,
+    FQ_SCHEMA,
+    SCHEMA,
+    admin_client,
+    assert_distinct_identities,
+    fail,
+    info,
+    lowpriv_client,
+    ok,
+    run_sql,
+    run_sql_or_die,
+    section,
+    step,
+    write_result,
+)
+
+ROW = "6"
+QUESTION = "Can a caller holding only EXECUTE read the function body, and therefore any credential embedded in it?"
+
+SENTINEL = "SENTINEL-NOT-A-REAL-SECRET-9f3a2c"
+FN = "f_py_with_embedded_sentinel"
+
+
+def main() -> int:
+    section(f"row {ROW}: function body readability")
+    admin = admin_client()
+    caller = lowpriv_client()
+    admin_who, caller_who = assert_distinct_identities(admin, caller)
+    info(f"author={admin_who}  caller={caller_who}")
+
+    step(f"admin creates {FN} with a sentinel embedded in the body")
+    run_sql_or_die(
+        admin,
+        f"""
+CREATE OR REPLACE FUNCTION {FQ_SCHEMA}.{FN}()
+RETURNS STRING
+LANGUAGE PYTHON
+COMMENT 'Body contains a sentinel standing in for a hardcoded credential.'
+AS $$
+embedded = "{SENTINEL}"
+return "ran"
+$$
+""",
+    )
+    run_sql_or_die(admin, f"GRANT EXECUTE ON FUNCTION {FQ_SCHEMA}.{FN} TO `{caller_who}`")
+    ok("function created; caller granted EXECUTE only")
+
+    read_paths = {
+        "describe_function_extended": f"DESCRIBE FUNCTION EXTENDED {FQ_SCHEMA}.{FN}",
+        "show_create_table": f"SHOW CREATE TABLE {FQ_SCHEMA}.{FN}",
+        "information_schema_routines": (
+            "SELECT routine_definition FROM "
+            f"`{CATALOG}`.information_schema.routines "
+            f"WHERE routine_schema = '{SCHEMA}' AND routine_name = '{FN}'"
+        ),
+    }
+
+    evidence = {}
+    leaked_via = []
+    for name, stmt in read_paths.items():
+        step(f"caller attempts: {name}")
+        outcome = run_sql(caller, stmt)
+        blob = " ".join(" ".join(str(c) for c in row) for row in outcome.rows)
+        leaked = SENTINEL in blob
+        evidence[name] = {
+            "statement": stmt,
+            "succeeded": outcome.succeeded,
+            "error_code": outcome.error_code,
+            "error": outcome.error,
+            "sentinel_visible_to_caller": leaked,
+        }
+        if leaked:
+            leaked_via.append(name)
+            fail("sentinel is visible to the caller through this path")
+        elif outcome.succeeded:
+            ok("statement allowed, but the body text was not exposed")
+        else:
+            ok(f"refused: {outcome.error_code}")
+
+    step("confirming the caller can still invoke it (EXECUTE really is held)")
+    invoked = run_sql(caller, f"SELECT {FQ_SCHEMA}.{FN}()")
+    evidence["invocation_control"] = invoked.summary()
+    if invoked.succeeded:
+        ok(f"invocation returned {invoked.scalar!r}")
+    else:
+        fail(f"caller cannot invoke: {invoked.error_code}")
+
+    if leaked_via:
+        write_result(
+            ROW,
+            question=QUESTION,
+            status="fail",
+            finding=(
+                "The function body is readable by a caller holding only EXECUTE, via "
+                f"{', '.join(leaked_via)}. A credential hardcoded into the body is "
+                "therefore disclosed to exactly the population the wrapper was meant "
+                "to keep it from — the workaround is not a delegation boundary, it is "
+                "a credential handout with extra steps."
+            ),
+            evidence=evidence,
+        )
+    elif not invoked.succeeded:
+        write_result(
+            ROW,
+            question=QUESTION,
+            status="inconclusive",
+            finding=(
+                "Could not isolate the question: the caller could not invoke the "
+                "function, so it is not established that it held EXECUTE at the time "
+                "the read paths were probed."
+            ),
+            evidence=evidence,
+        )
+    else:
+        write_result(
+            ROW,
+            question=QUESTION,
+            status="pass",
+            finding=(
+                "The body is opaque to the caller. EXECUTE permitted invocation but "
+                "none of the probed read paths (DESCRIBE FUNCTION EXTENDED, SHOW "
+                "CREATE TABLE, information_schema.routines) exposed the sentinel, so "
+                "a credential embedded in the body is not disclosed to callers by "
+                "these paths. Note this is a negative over the paths actually "
+                "probed — it is not a proof that no read path exists."
+            ),
+            evidence=evidence,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/udf_privilege_delegation/scripts/delegation/07_embedded_credential_end_to_end.py
+++ b/experiments/udf_privilege_delegation/scripts/delegation/07_embedded_credential_end_to_end.py
@@ -1,0 +1,189 @@
+"""Row 7 — does an author-embedded credential make the delegated action work?
+
+Rows 2-4 establish that the sandbox can reach the network but has no identity
+of its own. This row closes the loop on the only remaining construction: the
+author embeds their own credential in the function body, so the body
+authenticates as the author no matter who invokes it.
+
+If this works, the honest answer to "can a UDF wrap one admin action?" is
+"mechanically yes, by hardcoding a credential" — and row 6 decides whether that
+is a security boundary or a leak.
+
+Credential hygiene, because this repo is public:
+  - the token is fetched at runtime from the caller's own OAuth session and is
+    short-lived; it is never a PAT
+  - the function DDL containing it is never printed and never written to
+    results/
+  - the function is dropped at the end of this script, pass or fail
+Nothing in the committed evidence contains the token — only booleans, HTTP
+status codes, and the SCIM directory verdict.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from _delegation_common import call_function, decode_json_scalar  # noqa: E402
+
+from _common import (  # noqa: E402
+    FQ_SCHEMA,
+    admin_client,
+    assert_distinct_identities,
+    fail,
+    info,
+    lowpriv_client,
+    ok,
+    run_sql,
+    run_sql_or_die,
+    section,
+    step,
+    write_result,
+)
+
+ROW = "7"
+QUESTION = "Does embedding the author's credential in the function body make the delegated admin action succeed for a low-privilege caller?"
+
+FN = "f_py_create_sp_embedded"
+TARGET_NAME = "udf-delegation-target-sp-embedded"
+
+
+def author_bearer_token(w) -> str:
+    """The author's own short-lived OAuth access token."""
+    headers = w.config.authenticate()
+    auth = headers.get("Authorization", "")
+    if not auth.startswith("Bearer "):
+        raise SystemExit(
+            "Could not obtain a bearer token for the author identity; this row "
+            "requires an OAuth session."
+        )
+    return auth[len("Bearer ") :]
+
+
+def directory_contains(w, display_name: str) -> bool:
+    return any(w.service_principals.list(filter=f'displayName eq "{display_name}"'))
+
+
+def build_ddl(host: str, token: str) -> str:
+    """Never printed, never logged, never written to results/."""
+    return f"""
+CREATE OR REPLACE FUNCTION {FQ_SCHEMA}.{FN}(name STRING)
+RETURNS STRING
+LANGUAGE PYTHON
+COMMENT 'Author-embedded credential. Dropped at the end of row 7.'
+AS $$
+import json, urllib.request, urllib.error
+HOST = "{host}"
+TOKEN = "{token}"
+body = json.dumps({{
+    "schemas": ["urn:ietf:params:scim:schemas:core:2.0:ServicePrincipal"],
+    "displayName": name,
+    "active": True,
+}}).encode()
+req = urllib.request.Request(
+    HOST.rstrip("/") + "/api/2.0/preview/scim/v2/ServicePrincipals",
+    data=body, method="POST",
+    headers={{"Authorization": "Bearer " + TOKEN, "Content-Type": "application/json"}},
+)
+try:
+    with urllib.request.urlopen(req, timeout=20) as resp:
+        return json.dumps({{"outcome": "created", "status": resp.status}})
+except urllib.error.HTTPError as exc:
+    return json.dumps({{"outcome": "http_error", "status": exc.code}})
+except Exception as exc:
+    return json.dumps({{"outcome": "failed", "error_type": type(exc).__name__}})
+$$
+"""
+
+
+def main() -> int:
+    section(f"row {ROW}: author-embedded credential, end to end")
+    admin = admin_client()
+    caller = lowpriv_client()
+    admin_who, caller_who = assert_distinct_identities(admin, caller)
+    info(f"author={admin_who}  caller={caller_who}")
+
+    step("pre-check: target must not already exist")
+    if directory_contains(admin, TARGET_NAME):
+        fail("target already exists — run `make teardown` first")
+        write_result(
+            ROW,
+            question=QUESTION,
+            status="inconclusive",
+            finding=(
+                f"Could not isolate the result: {TARGET_NAME!r} already existed "
+                "before the call."
+            ),
+            evidence={"precheck": "target already present"},
+        )
+        return 1
+    ok("directory is clean")
+
+    try:
+        step("author creates the wrapper with their own short-lived token embedded")
+        run_sql_or_die(admin, build_ddl(admin.config.host, author_bearer_token(admin)))
+        run_sql_or_die(
+            admin, f"GRANT EXECUTE ON FUNCTION {FQ_SCHEMA}.{FN} TO `{caller_who}`"
+        )
+        ok("wrapper created; caller granted EXECUTE only (DDL deliberately not logged)")
+
+        step("low-privilege caller invokes the wrapper")
+        outcome = call_function(caller, FN, TARGET_NAME)
+        decoded = decode_json_scalar(outcome)
+        info(f"function returned: {decoded}")
+
+        step("verdict: reading the SCIM directory back as admin")
+        created = directory_contains(admin, TARGET_NAME)
+
+        evidence = {
+            "invocation": outcome.summary(),
+            "udf_report": decoded,
+            "directory_contains_target_after_call": created,
+            "credential_source": "author's short-lived OAuth access token, embedded in the body",
+        }
+
+        if created:
+            ok(f"{TARGET_NAME} exists — the caller performed an admin action")
+            write_result(
+                ROW,
+                question=QUESTION,
+                status="pass",
+                finding=(
+                    "It works, by embedding a credential. A caller holding only "
+                    "EXECUTE created a service principal through an admin-authored "
+                    "Python UDF whose body carries the author's token. The action is "
+                    "genuinely delegated and genuinely narrow — the caller can pass "
+                    "only a display name. But the elevation comes from a stored "
+                    "secret, not from the function model: the platform never "
+                    "re-authorizes the body as the owner, it simply replays whatever "
+                    "credential the author left in the source. Row 6 decides whether "
+                    "that secret stays hidden from the caller, and the token expires, "
+                    "so the wrapper silently stops working when it does."
+                ),
+                evidence=evidence,
+            )
+        else:
+            fail(f"{TARGET_NAME} was not created")
+            write_result(
+                ROW,
+                question=QUESTION,
+                status="fail",
+                finding=(
+                    "Even with the author's credential embedded in the body, the "
+                    "delegated action did not complete. See evidence.udf_report for "
+                    "the status the control plane returned."
+                ),
+                evidence=evidence,
+            )
+    finally:
+        step("dropping the function so no credential is left in the metastore")
+        dropped = run_sql(admin, f"DROP FUNCTION IF EXISTS {FQ_SCHEMA}.{FN}")
+        ok("function dropped") if dropped.succeeded else fail(f"drop failed: {dropped.error}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/udf_privilege_delegation/scripts/delegation/_delegation_common.py
+++ b/experiments/udf_privilege_delegation/scripts/delegation/_delegation_common.py
@@ -1,0 +1,29 @@
+"""Helpers shared by the delegation matrix scripts."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from _common import FQ_SCHEMA, SqlOutcome, run_sql  # noqa: E402
+
+
+def call_function(w, fn: str, *args: str) -> SqlOutcome:
+    """Invoke a function in the experiment schema with string literal args."""
+    rendered = ", ".join("'" + a.replace("'", "''") + "'" for a in args)
+    return run_sql(w, f"SELECT {FQ_SCHEMA}.{fn}({rendered})")
+
+
+def decode_json_scalar(outcome: SqlOutcome) -> dict[str, Any]:
+    """UDFs return JSON strings so the sandbox's own view of the world survives
+    the trip back. Decode it, or explain why it could not be decoded."""
+    if not outcome.succeeded:
+        return {"_undecodable": "statement failed", "_error": outcome.error}
+    try:
+        return json.loads(outcome.scalar)
+    except (TypeError, ValueError) as exc:
+        return {"_undecodable": str(exc), "_raw": str(outcome.scalar)[:400]}

--- a/experiments/udf_privilege_delegation/scripts/setup/00_create_lowpriv_principal.py
+++ b/experiments/udf_privilege_delegation/scripts/setup/00_create_lowpriv_principal.py
@@ -1,0 +1,115 @@
+"""Create the low-privilege caller identity.
+
+The whole experiment turns on the caller being *genuinely* less privileged than
+the function author. Running the matrix as the admin who owns the functions
+would prove nothing, so this script provisions a throwaway OAuth M2M service
+principal that holds no workspace entitlements and no Unity Catalog grants
+beyond what 01_provision_objects.py gives it.
+
+Writes EXPERIMENT_LOWPRIV_CLIENT_ID / _CLIENT_SECRET into the gitignored .env.
+
+Idempotent: re-running reuses the existing service principal and mints a fresh
+secret.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from databricks.sdk.service import iam  # noqa: E402
+
+from _common import (  # noqa: E402
+    EXPERIMENT_ROOT,
+    LOWPRIV_DISPLAY_NAME,
+    admin_client,
+    info,
+    ok,
+    section,
+    step,
+)
+
+ENV_PATH = EXPERIMENT_ROOT / ".env"
+
+
+def find_or_create_sp(w) -> iam.ServicePrincipal:
+    for sp in w.service_principals.list(
+        filter=f'displayName eq "{LOWPRIV_DISPLAY_NAME}"'
+    ):
+        info(f"reusing existing service principal (application_id={sp.application_id})")
+        return sp
+
+    step(f"creating service principal {LOWPRIV_DISPLAY_NAME!r}")
+    # No entitlements: not allowed cluster creation, not a workspace admin.
+    # It can authenticate and reach SQL, nothing more.
+    return w.service_principals.create(
+        display_name=LOWPRIV_DISPLAY_NAME,
+        active=True,
+        entitlements=[iam.ComplexValue(value="workspace-access")],
+    )
+
+
+def main() -> int:
+    section("setup: low-privilege caller identity")
+    w = admin_client()
+
+    sp = find_or_create_sp(w)
+    ok(f"service principal id={sp.id} application_id={sp.application_id}")
+
+    step("minting a workspace-level OAuth secret for the service principal")
+    secret = w.service_principal_secrets_proxy.create(service_principal_id=int(sp.id))
+    ok(f"secret created (id={secret.id})")
+
+    step("confirming the identity is NOT a workspace admin")
+    admin_members = []
+    for group in w.groups.list(filter='displayName eq "admins"'):
+        admin_members = [m.value for m in (group.members or [])]
+    if sp.id in admin_members:
+        raise SystemExit(
+            "The low-privilege service principal is in the admins group. "
+            "That would invalidate every row of the matrix — remove it and re-run."
+        )
+    ok("caller is a plain workspace user, not an admin")
+
+    step(f"writing credentials to {ENV_PATH.relative_to(EXPERIMENT_ROOT)} (gitignored)")
+    ENV_PATH.write_text(
+        "# Written by scripts/setup/00_create_lowpriv_principal.py — do not commit.\n"
+        f"EXPERIMENT_LOWPRIV_SP_ID={sp.id}\n"
+        f"EXPERIMENT_LOWPRIV_CLIENT_ID={sp.application_id}\n"
+        f"EXPERIMENT_LOWPRIV_CLIENT_SECRET={secret.secret}\n"
+    )
+    ok("credentials written")
+
+    step("granting the caller CAN_USE on the warehouse so it can issue statements at all")
+    from databricks.sdk.service import sql as sqlservice
+
+    from _common import warehouse_id
+
+    wh = warehouse_id(w)
+    w.warehouses.update_permissions(
+        warehouse_id=wh,
+        access_control_list=[
+            sqlservice.WarehouseAccessControlRequest(
+                service_principal_name=sp.application_id,
+                permission_level=sqlservice.WarehousePermissionLevel.CAN_USE,
+            )
+        ],
+    )
+    ok(f"warehouse {wh} CAN_USE granted (compute access only — no data privileges)")
+
+    step("proving the low-privilege identity authenticates as ITSELF, not as the admin")
+    import os
+
+    from _common import assert_distinct_identities, lowpriv_client
+
+    os.environ["EXPERIMENT_LOWPRIV_CLIENT_ID"] = sp.application_id or ""
+    os.environ["EXPERIMENT_LOWPRIV_CLIENT_SECRET"] = secret.secret or ""
+    admin_who, caller_who = assert_distinct_identities(w, lowpriv_client())
+    ok(f"admin={admin_who}  caller={caller_who}  (distinct)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/udf_privilege_delegation/scripts/setup/01_provision_objects.py
+++ b/experiments/udf_privilege_delegation/scripts/setup/01_provision_objects.py
@@ -1,0 +1,229 @@
+"""Provision the scenario: admin-owned objects, low-privilege caller grants.
+
+Creates, as the high-privilege author:
+
+  sensitive_table            a table the caller is deliberately NOT granted on
+  f_sql_read_sensitive()     SQL UDF whose body reads sensitive_table
+  f_py_read_sensitive()      Python UDF that reads nothing (see note below)
+  f_py_egress(url)           Python UDF that attempts one outbound HTTPS request
+  f_py_credential_probe()    Python UDF that reports its own execution context
+  f_py_create_sp(name)       Python UDF that attempts a SCIM create-SP call
+
+and grants the low-privilege caller USE CATALOG / USE SCHEMA / EXECUTE — and
+nothing else. In particular it is never granted SELECT on sensitive_table, so
+any successful read through a function is evidence of definer's rights.
+
+Note on f_py_read_sensitive: Unity Catalog Python UDFs cannot open a Spark
+session or issue SQL from inside the sandbox, so the Python-side privilege
+question is answered by the egress and credential probes rather than by a table
+read. That constraint is itself recorded as a matrix finding.
+
+Idempotent: CREATE OR REPLACE throughout.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from _common import (  # noqa: E402
+    CATALOG,
+    FQ_SCHEMA,
+    LOWPRIV_DISPLAY_NAME,
+    admin_client,
+    info,
+    ok,
+    run_sql_or_die,
+    section,
+    step,
+    warehouse_id,
+)
+
+# The caller is referenced in GRANT statements by application id.
+import os  # noqa: E402
+
+LOWPRIV_APP_ID = os.environ.get("EXPERIMENT_LOWPRIV_CLIENT_ID", "")
+
+
+PY_EGRESS = """
+import json, urllib.request, urllib.error
+try:
+    req = urllib.request.Request(url, headers={"User-Agent": "uc-python-udf-probe"})
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        return json.dumps({"reached": True, "status": resp.status})
+except urllib.error.HTTPError as exc:
+    # An HTTP status back from the origin means the packet made the round trip.
+    # 401/403 is an authorization answer, not a connectivity failure — conflating
+    # the two would understate the sandbox's reach.
+    return json.dumps({"reached": True, "status": exc.code, "http_error": True})
+except Exception as exc:
+    return json.dumps({"reached": False, "error_type": type(exc).__name__, "error": str(exc)[:400]})
+"""
+
+PY_CREDENTIAL_PROBE = """
+import json, os
+report = {}
+# Every DATABRICKS_* var, and separately the subset that could actually
+# authenticate a request. The distinction matters: the sandbox exports
+# unrelated bookkeeping vars, and counting those as "a credential exists"
+# would turn this row into a false positive.
+CREDENTIAL_VARS = (
+    "DATABRICKS_TOKEN", "DATABRICKS_HOST", "DATABRICKS_CLIENT_ID",
+    "DATABRICKS_CLIENT_SECRET", "DATABRICKS_OAUTH_TOKEN",
+    "DATABRICKS_USERNAME", "DATABRICKS_PASSWORD",
+)
+report["databricks_env_vars"] = sorted(k for k in os.environ if k.startswith("DATABRICKS_"))
+report["credential_env_vars_present"] = sorted(k for k in CREDENTIAL_VARS if os.environ.get(k))
+try:
+    from databricks.sdk import WorkspaceClient
+    report["sdk_importable"] = True
+    try:
+        w = WorkspaceClient()
+        report["sdk_default_auth"] = "constructed"
+        report["sdk_auth_type"] = str(getattr(w.config, "auth_type", None))
+    except Exception as exc:
+        report["sdk_default_auth"] = f"{type(exc).__name__}: {str(exc)[:200]}"
+except Exception as exc:
+    report["sdk_importable"] = f"{type(exc).__name__}: {str(exc)[:200]}"
+try:
+    import IPython
+    report["dbutils_available"] = "dbutils" in dir(IPython.get_ipython() or object())
+except Exception as exc:
+    report["dbutils_available"] = f"unavailable: {type(exc).__name__}"
+try:
+    from pyspark.sql import SparkSession
+    report["spark_session"] = "active" if SparkSession.getActiveSession() else "none"
+except Exception as exc:
+    report["spark_session"] = f"{type(exc).__name__}: {str(exc)[:120]}"
+return json.dumps(report)
+"""
+
+# The concrete administrative action under test. Creating a service principal
+# has no SQL surface at all — it is a SCIM REST call — so a UDF wrapper must
+# make an authenticated outbound request.
+PY_CREATE_SP = """
+import json, urllib.request, urllib.error, os
+result = {}
+token = os.environ.get("DATABRICKS_TOKEN")
+host = os.environ.get("DATABRICKS_HOST")
+result["had_ambient_token"] = bool(token)
+result["had_ambient_host"] = bool(host)
+if not token or not host:
+    result["outcome"] = "no ambient credential in UDF sandbox"
+    return json.dumps(result)
+body = json.dumps({
+    "schemas": ["urn:ietf:params:scim:schemas:core:2.0:ServicePrincipal"],
+    "displayName": name,
+    "active": True,
+}).encode()
+req = urllib.request.Request(
+    host.rstrip("/") + "/api/2.0/preview/scim/v2/ServicePrincipals",
+    data=body,
+    method="POST",
+    headers={"Authorization": "Bearer " + token, "Content-Type": "application/json"},
+)
+try:
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        result["outcome"] = "created"
+        result["status"] = resp.status
+except Exception as exc:
+    result["outcome"] = "failed"
+    result["error_type"] = type(exc).__name__
+    result["error"] = str(exc)[:400]
+return json.dumps(result)
+"""
+
+
+FUNCTIONS = {
+    "f_sql_read_sensitive": f"""
+CREATE OR REPLACE FUNCTION {FQ_SCHEMA}.f_sql_read_sensitive()
+RETURNS BIGINT
+COMMENT 'SQL UDF owned by an admin whose body reads a table the caller cannot select from.'
+RETURN (SELECT count(*) FROM {FQ_SCHEMA}.sensitive_table)
+""",
+    "f_py_egress": f"""
+CREATE OR REPLACE FUNCTION {FQ_SCHEMA}.f_py_egress(url STRING)
+RETURNS STRING
+LANGUAGE PYTHON
+COMMENT 'Attempts one outbound HTTPS request from inside the UC Python UDF sandbox.'
+AS $${PY_EGRESS}$$
+""",
+    "f_py_credential_probe": f"""
+CREATE OR REPLACE FUNCTION {FQ_SCHEMA}.f_py_credential_probe()
+RETURNS STRING
+LANGUAGE PYTHON
+COMMENT 'Reports what credentials and runtime facilities exist inside the UDF sandbox.'
+AS $${PY_CREDENTIAL_PROBE}$$
+""",
+    "f_py_create_sp": f"""
+CREATE OR REPLACE FUNCTION {FQ_SCHEMA}.f_py_create_sp(name STRING)
+RETURNS STRING
+LANGUAGE PYTHON
+COMMENT 'The concrete admin action under test: create a service principal via SCIM.'
+AS $${PY_CREATE_SP}$$
+""",
+}
+
+
+def main() -> int:
+    section("setup: admin-owned objects and caller grants")
+    if not LOWPRIV_APP_ID:
+        raise SystemExit(
+            "EXPERIMENT_LOWPRIV_CLIENT_ID is unset — run 00_create_lowpriv_principal.py first."
+        )
+
+    w = admin_client()
+    wh = warehouse_id(w)
+
+    step(f"creating schema {FQ_SCHEMA}")
+    run_sql_or_die(w, f"CREATE SCHEMA IF NOT EXISTS {FQ_SCHEMA}", wh=wh)
+
+    step("creating sensitive_table (caller gets no grant on it)")
+    run_sql_or_die(
+        w,
+        f"CREATE OR REPLACE TABLE {FQ_SCHEMA}.sensitive_table "
+        "(id INT, secret STRING)",
+        wh=wh,
+    )
+    run_sql_or_die(
+        w,
+        f"INSERT INTO {FQ_SCHEMA}.sensitive_table VALUES "
+        "(1, 'placeholder-row-a'), (2, 'placeholder-row-b'), (3, 'placeholder-row-c')",
+        wh=wh,
+    )
+    ok("sensitive_table created with 3 rows")
+
+    for fname, ddl in FUNCTIONS.items():
+        step(f"creating function {fname}")
+        run_sql_or_die(w, ddl, wh=wh)
+        ok(f"{fname} created")
+
+    step(f"granting the caller ({LOWPRIV_DISPLAY_NAME}) EXECUTE and nothing else")
+    run_sql_or_die(w, f"GRANT USE CATALOG ON CATALOG `{CATALOG}` TO `{LOWPRIV_APP_ID}`", wh=wh)
+    run_sql_or_die(w, f"GRANT USE SCHEMA ON SCHEMA {FQ_SCHEMA} TO `{LOWPRIV_APP_ID}`", wh=wh)
+    for fname in FUNCTIONS:
+        run_sql_or_die(
+            w,
+            f"GRANT EXECUTE ON FUNCTION {FQ_SCHEMA}.{fname} TO `{LOWPRIV_APP_ID}`",
+            wh=wh,
+        )
+    ok("EXECUTE granted on every function; no SELECT granted on sensitive_table")
+
+    step("confirming the caller's effective grants on sensitive_table")
+    grants = run_sql_or_die(
+        w, f"SHOW GRANTS `{LOWPRIV_APP_ID}` ON TABLE {FQ_SCHEMA}.sensitive_table", wh=wh
+    )
+    info(f"grants held by caller on sensitive_table: {grants.rows or 'none'}")
+    if grants.rows:
+        raise SystemExit(
+            "The caller holds a direct grant on sensitive_table — that would "
+            "invalidate the definer-vs-invoker rows. Revoke it and re-run."
+        )
+    ok("caller holds no direct privilege on sensitive_table")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/udf_privilege_delegation/scripts/setup/99_teardown.py
+++ b/experiments/udf_privilege_delegation/scripts/setup/99_teardown.py
@@ -1,0 +1,66 @@
+"""Remove everything the experiment created.
+
+Every matrix row must be re-runnable for reproduction, which means the
+experiment ends with an empty workspace rather than an orphaned sandbox: the
+schema and its functions, the target service principal from row 4, and the
+low-privilege caller identity itself.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from _common import (  # noqa: E402
+    EXPERIMENT_ROOT,
+    FQ_SCHEMA,
+    LOWPRIV_DISPLAY_NAME,
+    admin_client,
+    info,
+    ok,
+    run_sql,
+    section,
+    step,
+)
+
+# Both row-4 and row-7 create a target principal; teardown must know about
+# every one of them or the next run's pre-check fails on stale state.
+TARGET_NAMES = ("udf-delegation-target-sp", "udf-delegation-target-sp-embedded")
+
+
+def drop_principals(w, display_name: str) -> int:
+    dropped = 0
+    for sp in w.service_principals.list(filter=f'displayName eq "{display_name}"'):
+        w.service_principals.delete(id=sp.id)
+        dropped += 1
+    return dropped
+
+
+def main() -> int:
+    section("teardown")
+    w = admin_client()
+
+    step(f"dropping schema {FQ_SCHEMA} (cascade)")
+    outcome = run_sql(w, f"DROP SCHEMA IF EXISTS {FQ_SCHEMA} CASCADE")
+    if outcome.succeeded:
+        ok("schema dropped")
+    else:
+        info(f"schema drop reported: {outcome.error_code}: {outcome.error}")
+
+    for name in (*TARGET_NAMES, LOWPRIV_DISPLAY_NAME):
+        step(f"dropping service principals named {name!r}")
+        count = drop_principals(w, name)
+        ok(f"removed {count}")
+
+    env_path = EXPERIMENT_ROOT / ".env"
+    if env_path.exists():
+        env_path.unlink()
+        ok("removed .env")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/udf_privilege_delegation/scripts/verify.py
+++ b/experiments/udf_privilege_delegation/scripts/verify.py
@@ -1,0 +1,40 @@
+"""Prove auth + connectivity end-to-end with one real request.
+
+Runs `SELECT current_user()` on the warehouse. A config check would not prove
+anything; this proves the profile, the warehouse, and Unity Catalog are all
+reachable and that we know which identity we are.
+"""
+
+from __future__ import annotations
+
+from _common import CATALOG, PROFILE, admin_client, info, ok, run_sql, section, step, warehouse_id
+
+
+def main() -> int:
+    section("verify: auth + connectivity")
+    step(f"building WorkspaceClient from profile {PROFILE!r}")
+    w = admin_client()
+    wh = warehouse_id(w)
+    info(f"warehouse_id={wh}")
+
+    step("SELECT current_user(), current_catalog()")
+    outcome = run_sql(w, "SELECT current_user() AS who, current_version().dbsql_version AS v")
+    if not outcome.succeeded:
+        print(f"  !!  {outcome.error_code}: {outcome.error}")
+        return 1
+
+    who = outcome.rows[0][0]
+    version = outcome.rows[0][1]
+    ok(f"authenticated as {who} on DBSQL {version}")
+
+    step(f"confirming catalog {CATALOG!r} is reachable")
+    cat = run_sql(w, f"SHOW SCHEMAS IN `{CATALOG}`")
+    if not cat.succeeded:
+        print(f"  !!  {cat.error_code}: {cat.error}")
+        return 1
+    ok(f"catalog {CATALOG!r} reachable ({len(cat.rows)} schemas visible)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/udf_privilege_delegation/tests/conftest.py
+++ b/experiments/udf_privilege_delegation/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+# Scripts import each other by bare module name (they run as __main__ from make),
+# so the scripts/ dir has to be importable the same way here.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))

--- a/experiments/udf_privilege_delegation/tests/test_common.py
+++ b/experiments/udf_privilege_delegation/tests/test_common.py
@@ -1,0 +1,79 @@
+"""No-infra tests for the helpers that decide what gets recorded and published.
+
+These cover the two failure modes that would silently corrupt the experiment:
+recording a status the matrix vocabulary does not define, and writing real
+workspace coordinates into a public repo.
+"""
+
+import json
+
+import pytest
+
+import _common
+
+
+def test_status_vocabulary_is_enforced(tmp_path, monkeypatch):
+    monkeypatch.setattr(_common, "RESULTS_PATH", tmp_path / "matrix_results.json")
+    with pytest.raises(ValueError):
+        _common.write_result(
+            "1", question="q", status="works-i-think", finding="f", evidence={}
+        )
+
+
+def test_write_result_redacts_before_committing(tmp_path, monkeypatch):
+    results = tmp_path / "matrix_results.json"
+    monkeypatch.setattr(_common, "RESULTS_PATH", results)
+    monkeypatch.setattr(
+        _common,
+        "_redaction_map",
+        lambda: {"real_catalog": "my_catalog", "abc-123": "00000000"},
+    )
+
+    _common.write_result(
+        "1",
+        question="does it redact?",
+        status="pass",
+        finding="caller abc-123 read real_catalog",
+        evidence={"error": "no SELECT on real_catalog.t for someone@corp.example"},
+    )
+
+    blob = results.read_text()
+    for secret in ("real_catalog", "abc-123", "someone@corp.example"):
+        assert secret not in blob, f"{secret} survived redaction"
+    assert "my_catalog" in blob
+    assert _common.PLACEHOLDER_AUTHOR in blob
+
+
+def test_write_result_round_trips_and_stamps_environment(tmp_path, monkeypatch):
+    results = tmp_path / "matrix_results.json"
+    monkeypatch.setattr(_common, "RESULTS_PATH", results)
+    monkeypatch.setattr(_common, "_redaction_map", dict)
+
+    _common.write_result("1", question="q1", status="pass", finding="f1", evidence={"a": 1})
+    _common.write_result("2", question="q2", status="fail", finding="f2", evidence={"b": 2})
+
+    payload = json.loads(results.read_text())
+    assert set(payload["rows"]) == {"1", "2"}
+    assert payload["rows"]["2"]["status"] == "fail"
+    assert payload["environment"]["cloud"] == "AWS"
+    assert "recorded_at" in payload["rows"]["1"]
+
+
+def test_pat_is_refused():
+    with pytest.raises(SystemExit):
+        _common._refuse_pat("dapiabc123", "DATABRICKS_TOKEN")
+    _common._refuse_pat(None, "DATABRICKS_TOKEN")
+    _common._refuse_pat("oauth-token", "DATABRICKS_TOKEN")
+
+
+def test_sql_outcome_summary_truncates_and_exposes_scalar():
+    outcome = _common.SqlOutcome(True, rows=[["3"]])
+    assert outcome.scalar == "3"
+    assert outcome.summary()["succeeded"] is True
+
+    long_error = "x" * 2000
+    failed = _common.SqlOutcome(False, error=long_error, error_code="BAD_REQUEST")
+    summary = failed.summary()
+    assert summary["error_code"] == "BAD_REQUEST"
+    assert len(summary["error"]) < len(long_error)
+    assert summary["error"].endswith("...[truncated]")


### PR DESCRIPTION
## The question

From a live customer recommendation: an admin defines a reusable UDF, a lower-privilege user is granted `EXECUTE` on it, and the user should be able to perform one narrow administrative action — creating a service principal — without receiving the admin privilege directly. Is the UDF a viable narrowly-scoped wrapper, or is it blocked by the execution model?

Answered with live evidence rather than reasoning: `experiments/udf_privilege_delegation/`, seven rows, one real AWS workspace, a genuinely separate low-privilege OAuth M2M caller holding `USE CATALOG` / `USE SCHEMA` / `EXECUTE` and nothing else.

## Findings

| # | Question | Result |
|---|---|---|
| 1 | SQL UDF body runs with definer (owner) privileges? | ✅ |
| 2 | Python UDF can make an outbound HTTPS request? | ✅ (workspace-policy dependent) |
| 3 | Python UDF receives an ambient Databricks credential? | ❌ |
| 4 | End to end — low-priv caller creates a service principal? | ❌ |
| 5 | Any SQL surface for identity administration? | ❌ |
| 6 | Caller with only `EXECUTE` can read the function body? | ❌ (they can) |
| 7 | Author-embedded credential makes it work? | ✅ |

**For data, the pattern is real.** The caller was refused `SELECT` on the underlying table (`[INSUFFICIENT_PERMISSIONS] ... SQLSTATE: 42501`) and then read it through the admin-owned SQL UDF with nothing but `EXECUTE`. Definer's rights hold.

**For administrative actions, the two halves never meet.** The function type that carries definer's rights (SQL) cannot express the action — `CREATE SERVICE PRINCIPAL` is `PARSE_SYNTAX_ERROR` even for an admin. The function type that could express it (Python, over REST) has network reach but no identity: the sandbox exports one `DATABRICKS_*` variable, a virtualenv path, and `WorkspaceClient()` dies with `default auth: cannot configure default credentials`. The control plane answers `401` — Unity Catalog never denies anything, the request is simply anonymous.

**The workaround is worse than the grant it replaces.** Embedding the author's token in the body does work (HTTP 201, verified by reading the SCIM directory back as admin). But a caller holding only `EXECUTE` can read that body via `DESCRIBE FUNCTION EXTENDED` and `information_schema.routines` — so the "wrapper" discloses the full admin credential rather than exposing one narrow action.

## What is in the PR

House experiment structure: `Makefile` command surface, `verify.py` that proves auth with one real request, numbered scripts one per matrix row, committed `results/matrix_results.json`, README findings matrix, tiered pytest markers.

Two things worth a reviewer's attention:

- **The harness guards its own validity.** An early run silently authenticated the "low-privilege caller" as the admin, because the SDK resolves an exported `DATABRICKS_CONFIG_PROFILE` ahead of explicit `client_id`/`client_secret` — every row would have passed for the wrong reason. `lowpriv_client()` now pins `auth_type="oauth-m2m"` and `assert_distinct_identities()` runs `SELECT current_user()` on both clients and aborts if they match.
- **Redaction happens at the results-write boundary,** not per script, because raw platform error strings are exactly where real coordinates hide and `results/` is committed to a public repo. Catalog, host, caller application id, and anything email-shaped are replaced with placeholders.

`docs/research/2026-07-28-evidence-trail.md` records verbatim platform responses and the three measurement traps that produced plausible-but-wrong statuses first time round (including scoring a live `401` as "unreachable", which would have pointed at a firewall instead of the missing credential).

## Deviation to flag

`uv.lock` is gitignored for this experiment rather than committed as the rest of the repo does. It resolved through an internal Databricks PyPI mirror, so every URL in it points at a host no external consumer can reach. The `.gitignore` comment says how to bring it back in line — regenerate with `uv lock` on a machine resolving against public PyPI.

## Verification

- All seven rows re-run from a single clean provisioning; `make teardown` afterwards leaves no schema and no service principals (confirmed against the SCIM directory).
- `uv run pytest -m "not infrastructure"` — 5 passed.
- `uv run ruff check scripts tests` — clean.
- Staged diff scanned for tokens, hosts, account ids, and emails before commit.

Originating conversation: Buzz `#general`, thread `4c320241`.