### PR TITLE
feat: skill-wrap the Bedrock UC AI Gateway demo

### DIFF
--- a/bedrock-uc-custom-provider/README.md
+++ b/bedrock-uc-custom-provider/README.md
@@ -83,6 +83,20 @@ also available). Passthrough traffic is fully logged — it lands in the provide
 service's `aws_bedrock_payload` inference table and the gateway usage system
 tables.
 
+## Use as a skill
+
+[`skill/`](skill/) packages this setup for a coding agent:
+[`skill/SKILL.md`](skill/SKILL.md) is the flow (store the key as a secret →
+`uv run deploy.py` → invoke via passthrough → explain where the logs land),
+with the constraints and gotchas below turned into agent-actionable triage.
+[`skill/scripts/gateway.py`](skill/scripts/gateway.py) is its companion —
+`preflight` (CLI, auth, and whether the secret exists, without reading its
+value), `status` (provider, model service, and inference tables, including
+orphaned `_payload` tables), and `invoke "<prompt>"` (a passthrough call that
+prints the reply). Stdlib-only; it reads its parameters straight from
+`deploy.py`'s parameter block, so the two cannot drift, and it orchestrates
+`deploy.py` rather than duplicating it.
+
 ## Constraints discovered
 
 Stated plainly, because they shape the opinionated stance:

--- a/bedrock-uc-custom-provider/skill/SKILL.md
+++ b/bedrock-uc-custom-provider/skill/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: bedrock-uc-ai-gateway
+description: >-
+  Set up and call AWS Bedrock (Claude Sonnet 5) behind the Databricks Unity
+  Catalog AI Gateway using a Bedrock long-term API key (ABSK bearer key) — no
+  AWS access-key pair, no IAM role. Trigger when a user wants Bedrock models
+  governed and logged through Unity Catalog, asks why the native AMAZON_BEDROCK
+  provider rejects their Bedrock API key, or hits UnknownOperationException /
+  "Nodes do not exist" on a CUSTOM gateway provider pointed at bedrock-runtime.
+---
+
+# Bedrock behind the Unity Catalog AI Gateway
+
+You are setting up a **CUSTOM** UC AI Gateway provider pointed at Bedrock's
+runtime endpoint, authenticated with a bearer key that lives server-side in
+Unity Catalog. Callers authenticate with their normal Databricks identity and
+never see the AWS key. All traffic logs to inference tables.
+
+```
+caller ──(Databricks OAuth)──► <workspace>/ai-gateway/... ──(ABSK bearer key)──► bedrock-runtime
+```
+
+Everything is created by [`../deploy.py`](../deploy.py). **Orchestrate that
+script — never reimplement its logic here.** If a parameter needs to change,
+edit the parameter block at the top of `deploy.py`; this skill's helper reads
+its settings from that same block, so the two cannot drift.
+
+Companion script: [`scripts/gateway.py`](scripts/gateway.py) — subcommands
+`preflight`, `status`, `invoke`. Background and the full findings write-up:
+[`../README.md`](../README.md).
+
+## Hard rules
+
+- **Never handle the raw `ABSK` key.** Do not accept it in chat, do not write
+  it to a file, do not put it in an env var or a command you run. The human
+  stores it as a Databricks secret; `deploy.py` reads it server-side.
+- **Passthrough is the working path.** Managed serving does not work for Claude
+  on a CUSTOM+Bedrock provider (see Constraints). Do not "fix" a failing
+  managed call by hunting for another `base_url` — that ground is covered.
+- **One provider, one model, one region.** Sonnet 5 (`us.anthropic.claude-sonnet-5`),
+  `us-east-1` by default. Resist adding models until the single path works.
+- **Beta, undocumented APIs.** `model-provider-services` / `model-services` are
+  not GA and not DABs resources. Tell the human this is a demo pattern, not a
+  production one, if they ask about durability.
+
+## Step 0 — Preflight
+
+Run everything below from `bedrock-uc-custom-provider/`.
+
+```sh
+skill/scripts/gateway.py preflight
+```
+
+Checks the Databricks CLI, auth state, `uv`, and whether the Bedrock key is
+present as a secret (it lists keys in the scope — it never reads the value).
+
+- **CLI missing** → have the user install the Databricks CLI, then re-run.
+- **Not authenticated** → run `databricks auth login --host https://<workspace-host>`
+  yourself; the human completes browser SSO. Confirm with `databricks auth describe`.
+- **Secret missing** → Step 1.
+- **`uv` missing** → either install `uv`, or run
+  `pip install 'databricks-sdk>=0.38' && python3 deploy.py`.
+
+## Step 1 — The human stores the Bedrock key (once)
+
+Give them these two commands to run themselves. Do not run the second one for
+them, and do not ask them to paste the key to you:
+
+```sh
+databricks secrets create-scope bedrock
+databricks secrets put-secret bedrock aws_bearer_token_bedrock --string-value 'ABSK...'
+```
+
+Scope and key names come from `SECRET_SCOPE` / `SECRET_KEY` in `deploy.py`.
+Re-run `preflight` to confirm.
+
+## Step 2 — Deploy
+
+```sh
+cd bedrock-uc-custom-provider
+uv run deploy.py                      # BEDROCK_REGION=us-west-2 uv run deploy.py to change region
+```
+
+Idempotent, create-if-missing: catalog → schema → CUSTOM provider service
+(`<catalog>.<schema>.aws_bedrock`, holding the key + `base_url`, with an
+inference table) → model service (`<catalog>.<schema>.sonnet5_bedrock`, with its
+own inference table) → a live verification call.
+
+Expected output on a first run:
+
+```
+catalog ai_gateway_demo: created
+schema ai_gateway_demo.bedrock: created
+model-provider-service ai_gateway_demo.bedrock.aws_bedrock: created (inference table aws_bedrock_payload in ai_gateway_demo.bedrock)
+model-service ai_gateway_demo.bedrock.sonnet5_bedrock: created (inference table sonnet5_bedrock_payload in ai_gateway_demo.bedrock)
+
+new provider service — the gateway routing cache may need ~1–3 min
+verification: Sonnet 5 replied through the gateway: 'gateway OK'
+```
+
+A re-run prints `exists — leaving as-is` for objects already there. That is
+deliberate, not a bug: `config.custom` and `config.routing` are not patchable,
+so the script never tries (see Constraints).
+
+To change the region, catalog, schema, or model, edit the parameter block at
+the top of `deploy.py`. Changing the key, `base_url`, or routing of an
+*existing* object requires delete + recreate — see the recreate recipe below.
+
+## Step 3 — Verify
+
+`deploy.py` already made a live call. To make another one at any time:
+
+```sh
+skill/scripts/gateway.py invoke "Reply with exactly: gateway OK"
+skill/scripts/gateway.py status
+```
+
+`invoke` prints the reply on stdout and token usage on stderr; it retries the
+routing-cache lag for up to 5 minutes. Verified live 2026-07-24 in `us-east-1`:
+Sonnet 5 responds in ~1.6s via `us.anthropic.claude-sonnet-5` (a `global.`
+inference profile is also available).
+
+The request it sends — the only invocation shape you should use here:
+
+```
+POST <workspace>/ai-gateway/model/us.anthropic.claude-sonnet-5/converse
+Authorization: Bearer <databricks OAuth token>
+Databricks-Model-Provider-Service: <catalog>.<schema>.aws_bedrock
+Content-Type: application/json
+
+{"messages":[{"role":"user","content":[{"text":"..."}]}],"inferenceConfig":{"maxTokens":200}}
+```
+
+Two mechanics worth stating to the human: the
+`Databricks-Model-Provider-Service` header picks which registered provider
+(stored key + base URL) handles the call, and everything after `/ai-gateway/`
+path-joins onto that provider's `base_url` with the stored key injected as the
+upstream `Authorization` header — which is why the call lands on Bedrock's
+native Converse API. That path-join requires `forward_unmanaged_paths: true`.
+
+## Step 4 — Tell the human where the logs land
+
+Say this explicitly; it is the point of putting Bedrock behind the gateway.
+
+- **`<catalog>.<schema>.aws_bedrock_payload`** — the provider service's
+  inference table. **This is the one that fills**: passthrough traffic logs
+  here, request and response.
+- **`<catalog>.<schema>.sonnet5_bedrock_payload`** — the model service's
+  inference table. Provisions correctly but **stays empty** until managed
+  serving works for Claude on a CUSTOM provider. Do not present it as broken;
+  it is a placeholder for a gap that is expected to close.
+- **Gateway usage system tables** — passthrough traffic is also counted there.
+
+With defaults, that is `ai_gateway_demo.bedrock.aws_bedrock_payload`. Rows are
+not instant; give the tables a few minutes after a call.
+
+## Constraints
+
+- **Managed serving through the CUSTOM provider does not work against Bedrock
+  today.** The managed routes (`/ai-gateway/anthropic/v1/messages`,
+  `/ai-gateway/openai/v1/chat/completions` with the 3-part model-service name)
+  resolve the model service and its destination correctly, but the upstream
+  request does not land on a valid Bedrock operation — AWS returns
+  `UnknownOperationException` for every `base_url` shape tested (host root,
+  `.../openai`, `.../openai/v1`). Anthropic models are also excluded from AWS's
+  OpenAI-compat layer (`model_not_found`, retested 2026-07-24). There is no
+  Bedrock URL that speaks a gateway-translatable API for Claude.
+- **So passthrough is the working, logged path**, and it satisfies "inference
+  tables enabled in the target namespace" for the traffic that actually flows.
+- **The fully-managed alternative needs different credentials.** If the human
+  needs managed Sonnet 5 serving today, the supported path is the native
+  `AMAZON_BEDROCK` provider type with an IAM access-key pair. Offer it as a
+  trade-off — it abandons this setup's bearer-key-only stance — and let them
+  decide. Do not switch silently.
+
+## Gotchas → what to do
+
+| Symptom | Cause | Action |
+| --- | --- | --- |
+| `Nodes do not exist` | Routing-cache lag on a new/changed service (~1–3 min) | Wait. `deploy.py` and `gateway.py invoke` already retry for 5 min. Do not recreate anything. |
+| `UnknownOperationException` / `model_not_found` | You used a managed route | Switch to passthrough (Step 3). Do not try more `base_url` shapes. |
+| Create succeeded but invocation fails on AWS auth | **Create does not validate credentials** — a typo'd key creates fine | Fix the secret, then delete + recreate the provider (recipe below). The verification call is the real check. |
+| Table `<name>_payload` already exists on create | Deleting a provider/model service **orphans its inference table** | Drop the orphan (or change `table_name_prefix`) before recreating. `gateway.py status` flags orphans. |
+| Need to change key, `base_url`, or routing | `config.custom` and `config.routing` are **not updatable** | Delete + recreate (recipe below). Do not attempt a PATCH. |
+| Provider create rejects `targets[]` | Entries require `native_api_types` | Keep `"anthropic/v1/messages"` as `deploy.py` sets it. |
+
+**Recreate recipe** (the only way to change an existing provider's key, base
+URL, or routing):
+
+1. `DELETE /api/2.1/unity-catalog/model-provider-services/<catalog>.<schema>.aws_bedrock`
+   (or `.../model-services/<...>.sonnet5_bedrock`).
+2. Drop the orphaned inference table: `DROP TABLE <catalog>.<schema>.aws_bedrock_payload`.
+   Skipping this makes the recreate collide.
+3. Re-run `uv run deploy.py`.
+4. Expect the routing-cache lag again before the first successful call.
+
+Confirm the delete with the human first — it is destructive, and dropping the
+`_payload` table discards logged traffic.

--- a/bedrock-uc-custom-provider/skill/scripts/gateway.py
+++ b/bedrock-uc-custom-provider/skill/scripts/gateway.py
@@ -1,0 +1,496 @@
+#!/usr/bin/env python3
+"""gateway.py — mechanical companion for the bedrock-uc-ai-gateway skill.
+
+Subcommands:
+  preflight
+      Checks: databricks CLI, auth state, uv availability, and whether the
+      Bedrock key is present as a Databricks secret. The secret VALUE is never
+      read or printed — only its presence in the scope's key list. Exits
+      non-zero if a blocking check (CLI / auth / secret) fails.
+
+  status
+      GETs the model provider service, the model service, and both `_payload`
+      inference tables, and prints a curated state table. Also flags orphaned
+      `_payload` tables (table present, owning service gone) — the collision
+      that breaks a recreate.
+
+  invoke "<prompt>" [--model <id>] [--max-tokens N]
+      Calls the model through the gateway via provider passthrough (Bedrock's
+      native Converse API), retrying past the routing-cache lag, and prints
+      the reply on stdout (usage goes to stderr).
+
+Parameters (catalog, schema, provider/service ids, model, secret scope/key)
+are read out of ../../deploy.py's parameter block, so this helper never drifts
+from what was actually deployed. Edit deploy.py; this follows.
+
+No third-party dependencies: python3 stdlib + the Databricks CLI. Auth is
+whatever the CLI is already configured with — this script never creates,
+stores, or prints a credential. Output is curated per-field rather than raw
+API JSON, so a stored provider key can never be echoed to a terminal or log.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+DEPLOY_PY = Path(__file__).resolve().parents[2] / "deploy.py"
+
+MPS_API = "/api/2.1/unity-catalog/model-provider-services"
+MS_API = "/api/2.1/unity-catalog/model-services"
+TABLES_API = "/api/2.1/unity-catalog/tables"
+
+REQUIRED_PARAMS = (
+    "TARGET_CATALOG",
+    "TARGET_SCHEMA",
+    "SECRET_SCOPE",
+    "SECRET_KEY",
+    "PROVIDER_ID",
+    "SERVICE_ID",
+    "MODEL_ID",
+)
+
+
+def die(msg: str, code: int = 2) -> "None":
+    print(f"error: {msg}", file=sys.stderr)
+    sys.exit(code)
+
+
+def row(check: str, status: str, detail: str = "") -> None:
+    print(f"{check:<42} {status:<8} {detail}")
+
+
+# ── deploy.py is the single source of truth for parameters ──────────────────
+
+
+def deploy_params() -> dict:
+    """Literal module-level assignments from deploy.py's parameter block.
+
+    Computed values (f-strings, os.environ lookups) are skipped — they are
+    derived here instead, the same way deploy.py derives them.
+    """
+    try:
+        tree = ast.parse(DEPLOY_PY.read_text())
+    except OSError as exc:
+        die(f"cannot read {DEPLOY_PY}: {exc}")
+
+    params: dict = {}
+    for node in tree.body:
+        if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+            continue
+        target = node.targets[0]
+        if not isinstance(target, ast.Name):
+            continue
+        try:
+            params[target.id] = ast.literal_eval(node.value)
+        except (ValueError, SyntaxError, TypeError):
+            continue  # e.g. BEDROCK_REGION = os.environ.get(...)
+
+    missing = [p for p in REQUIRED_PARAMS if p not in params]
+    if missing:
+        die(f"{DEPLOY_PY.name} is missing expected parameters: {', '.join(missing)}")
+
+    params["SCHEMA_FQN"] = f"{params['TARGET_CATALOG']}.{params['TARGET_SCHEMA']}"
+    params["PROVIDER_FQN"] = f"{params['SCHEMA_FQN']}.{params['PROVIDER_ID']}"
+    params["SERVICE_FQN"] = f"{params['SCHEMA_FQN']}.{params['SERVICE_ID']}"
+    params["BEDROCK_REGION"] = os.environ.get("BEDROCK_REGION", "us-east-1")
+    return params
+
+
+# ── Databricks CLI plumbing ─────────────────────────────────────────────────
+
+
+def cli(args: list, profile: str | None, timeout: int = 60):
+    """Run the Databricks CLI. Returns (returncode, stdout, stderr)."""
+    if not shutil.which("databricks"):
+        die("the Databricks CLI is not on PATH — install it, then re-run")
+    cmd = ["databricks", *args]
+    if profile:
+        cmd += ["-p", profile]
+    proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
+
+
+def cli_json(args: list, profile: str | None):
+    """Run a CLI command expected to emit JSON. Returns (obj, error_string)."""
+    rc, out, err = cli(args, profile)
+    if rc != 0:
+        return None, (err or out or f"exit {rc}")
+    if not out:
+        return {}, None  # success, empty body (e.g. a scope with no secrets)
+    try:
+        return json.loads(out), None
+    except json.JSONDecodeError:
+        return None, f"unparseable CLI output: {out[:200]}"
+
+
+def find_key(obj, key: str):
+    """First value for `key` anywhere in a nested JSON structure."""
+    if isinstance(obj, dict):
+        if key in obj and isinstance(obj[key], str):
+            return obj[key]
+        for value in obj.values():
+            found = find_key(value, key)
+            if found:
+                return found
+    elif isinstance(obj, list):
+        for item in obj:
+            found = find_key(item, key)
+            if found:
+                return found
+    return None
+
+
+def auth_describe(profile: str | None):
+    obj, err = cli_json(["auth", "describe", "-o", "json"], profile)
+    if err:
+        return None, err
+    return {
+        "auth_type": find_key(obj, "auth_type"),
+        "host": (find_key(obj, "host") or "").rstrip("/"),
+        "username": find_key(obj, "username"),
+    }, None
+
+
+def workspace_host(profile: str | None) -> str:
+    host = os.environ.get("DATABRICKS_HOST", "").rstrip("/")
+    if host:
+        return host
+    described, err = auth_describe(profile)
+    if err or not described or not described["host"]:
+        die(
+            "cannot resolve the workspace host — run: "
+            "databricks auth login --host https://<workspace-host>"
+        )
+    return described["host"]
+
+
+def bearer_token(profile: str | None) -> str:
+    """A short-lived OAuth token from the CLI. Never printed, never stored."""
+    obj, err = cli_json(["auth", "token"], profile)
+    if obj and obj.get("access_token"):
+        return obj["access_token"]
+    env_token = os.environ.get("DATABRICKS_TOKEN")
+    if env_token:
+        return env_token
+    die(
+        f"cannot mint a token ({err}) — run: "
+        "databricks auth login --host https://<workspace-host>"
+    )
+
+
+def api_get(path: str, profile: str | None):
+    """GET a workspace API path via the CLI. Returns (obj, error_string)."""
+    return cli_json(["api", "get", path], profile)
+
+
+def not_found(err: str) -> bool:
+    # Underscores normalized so RESOURCE_DOES_NOT_EXIST and the prose form
+    # ("... does not exist") both match.
+    normalized = (err or "").lower().replace("_", " ")
+    return any(
+        marker in normalized for marker in ("not found", "does not exist", "404")
+    )
+
+
+# ── preflight ───────────────────────────────────────────────────────────────
+
+
+def cmd_preflight(args, params) -> int:
+    blocking = 0
+    print(f"{'CHECK':<42} {'STATUS':<8} DETAIL")
+    print(f"{'-----':<42} {'------':<8} ------")
+
+    if shutil.which("databricks"):
+        rc, out, _ = cli(["--version"], None)
+        row("databricks CLI", "OK", out if rc == 0 else "found")
+    else:
+        row("databricks CLI", "FAIL", "not on PATH — install the Databricks CLI, then re-run")
+        return blocking_exit(1)
+
+    described, err = auth_describe(args.profile)
+    if err or not described:
+        row("auth", "FAIL", "not authenticated — run: databricks auth login --host https://<workspace-host>")
+        blocking = 1
+    else:
+        detail = (
+            f"auth_type={described['auth_type'] or '?'} "
+            f"user={described['username'] or '?'} host={described['host'] or '?'}"
+        )
+        if described["auth_type"] == "pat":
+            row("auth", "WARN", detail + " — house default is OAuth: databricks auth login")
+        else:
+            row("auth", "OK", detail)
+
+    if shutil.which("uv"):
+        row("uv", "OK", "deploy with: uv run deploy.py")
+    else:
+        row(
+            "uv",
+            "MISSING",
+            "install uv, or: pip install 'databricks-sdk>=0.38' && python3 deploy.py",
+        )
+
+    scope, key = params["SECRET_SCOPE"], params["SECRET_KEY"]
+    obj, err = cli_json(["secrets", "list-secrets", scope, "-o", "json"], args.profile)
+    if err:
+        row(
+            f"secret {scope}/{key}",
+            "FAIL",
+            f"cannot list scope '{scope}' ({err.splitlines()[0][:120] if err else '?'}) — "
+            f"the human runs: databricks secrets create-scope {scope}",
+        )
+        blocking = 1
+    else:
+        # The CLI flattens list responses to a JSON array; accept the wrapped
+        # {"secrets": [...]} shape too.
+        entries = obj.get("secrets", []) if isinstance(obj, dict) else (obj or [])
+        keys = [e.get("key") for e in entries if isinstance(e, dict)]
+        if key in keys:
+            row(f"secret {scope}/{key}", "OK", "present (value never read by this script)")
+        else:
+            row(
+                f"secret {scope}/{key}",
+                "FAIL",
+                f"missing — the human runs: databricks secrets put-secret {scope} {key} "
+                "--string-value 'ABSK...'",
+            )
+            blocking = 1
+
+    return blocking_exit(blocking)
+
+
+def blocking_exit(blocking: int) -> int:
+    if blocking:
+        print("\npreflight: blocking check failed (see FAIL rows above).", file=sys.stderr)
+    return 1 if blocking else 0
+
+
+# ── status ──────────────────────────────────────────────────────────────────
+
+
+def cmd_status(args, params) -> int:
+    print(f"{'OBJECT':<42} {'STATUS':<8} DETAIL")
+    print(f"{'------':<42} {'------':<8} ------")
+
+    provider, perr = api_get(f"{MPS_API}/{params['PROVIDER_FQN']}", args.profile)
+    if provider:
+        config = provider.get("config", {}) or {}
+        base_url = ((config.get("custom") or {}).get("direct") or {}).get("base_url", "?")
+        targets = ", ".join(
+            t.get("model", "?") for t in (config.get("targets") or [])
+        ) or "none"
+        row("provider service", "OK", params["PROVIDER_FQN"])
+        row("  provider_type", "-", config.get("provider_type", "?"))
+        row("  base_url", "-", base_url)
+        row("  forward_unmanaged_paths", "-", str(config.get("forward_unmanaged_paths")))
+        row("  allow_all_targets", "-", str(config.get("allow_all_targets")))
+        row("  targets", "-", targets)
+    elif not_found(perr):
+        row("provider service", "MISSING", f"{params['PROVIDER_FQN']} — run: uv run deploy.py")
+    else:
+        row("provider service", "ERROR", (perr or "?").splitlines()[0][:120])
+
+    service, serr = api_get(f"{MS_API}/{params['SERVICE_FQN']}", args.profile)
+    if service:
+        destinations = ((service.get("config", {}) or {}).get("routing") or {}).get(
+            "destinations"
+        ) or []
+        row("model service", "OK", params["SERVICE_FQN"])
+        for dest in destinations:
+            external = dest.get("external_model_config") or {}
+            model = (external.get("target") or {}).get("model", "?")
+            row(
+                f"  destination {dest.get('name', '?')}",
+                "-",
+                f"{dest.get('traffic_percentage', '?')}% → {model}",
+            )
+    elif not_found(serr):
+        row("model service", "MISSING", f"{params['SERVICE_FQN']} — run: uv run deploy.py")
+    else:
+        row("model service", "ERROR", (serr or "?").splitlines()[0][:120])
+
+    orphans = []
+    for label, owner_present, table in (
+        ("provider", bool(provider), f"{params['PROVIDER_FQN']}_payload"),
+        ("model service", bool(service), f"{params['SERVICE_FQN']}_payload"),
+    ):
+        obj, err = api_get(f"{TABLES_API}/{table}", args.profile)
+        short = table.split(".")[-1]
+        if obj:
+            if owner_present:
+                row(f"inference table {short}", "OK", table)
+            else:
+                row(f"inference table {short}", "ORPHAN", f"{table} — owning {label} is gone")
+                orphans.append(table)
+        elif not_found(err):
+            row(f"inference table {short}", "MISSING", f"{table} (created with the {label})")
+        else:
+            row(f"inference table {short}", "ERROR", (err or "?").splitlines()[0][:120])
+
+    if orphans:
+        print(
+            "\nOrphaned inference table(s): "
+            + ", ".join(orphans)
+            + "\nRecreating the owning service will collide. Drop the table (or change "
+            "table_name_prefix) before re-running deploy.py.",
+            file=sys.stderr,
+        )
+
+    print(
+        "\nPassthrough traffic logs to "
+        f"{params['PROVIDER_FQN']}_payload. {params['SERVICE_FQN']}_payload stays empty "
+        "until managed serving works for Claude on a CUSTOM provider (see SKILL.md)."
+    )
+    return 0
+
+
+# ── invoke ──────────────────────────────────────────────────────────────────
+
+
+def cmd_invoke(args, params) -> int:
+    prompt = args.prompt
+    if prompt == "-":
+        prompt = sys.stdin.read()
+    if not prompt.strip():
+        die("empty prompt")
+
+    model = args.model or params["MODEL_ID"]
+    host = workspace_host(args.profile)
+    url = f"{host}/ai-gateway/model/{model}/converse"
+    payload = json.dumps(
+        {
+            "messages": [{"role": "user", "content": [{"text": prompt}]}],
+            "inferenceConfig": {"maxTokens": args.max_tokens},
+        }
+    ).encode()
+
+    request = urllib.request.Request(
+        url,
+        data=payload,
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {bearer_token(args.profile)}",
+            "Databricks-Model-Provider-Service": params["PROVIDER_FQN"],
+            "Content-Type": "application/json",
+        },
+    )
+
+    deadline = time.time() + args.retry_seconds
+    while True:
+        try:
+            with urllib.request.urlopen(request, timeout=args.timeout) as response:
+                body = json.loads(response.read())
+            break
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode(errors="replace")
+            # New/changed services take ~1-3 min to reach the gateway's
+            # routing cache; 'Nodes do not exist' is that window.
+            if "Nodes do not exist" in detail and time.time() < deadline:
+                print("gateway routing cache not ready yet — retrying in 30s...", file=sys.stderr)
+                time.sleep(30)
+                continue
+            die(explain_http_error(exc.code, detail, model, params), code=1)
+        except urllib.error.URLError as exc:
+            die(f"cannot reach {host}: {exc.reason}", code=1)
+
+    try:
+        text = body["output"]["message"]["content"][0]["text"]
+    except (KeyError, IndexError, TypeError):
+        die(f"unexpected response shape: {json.dumps(body)[:400]}", code=1)
+
+    print(text)
+    print(f"usage: {body.get('usage')}", file=sys.stderr)
+    return 0
+
+
+def explain_http_error(code: int, detail: str, model: str, params: dict) -> str:
+    head = f"HTTP {code} from the gateway: {detail[:400]}"
+    if code in (401, 403):
+        return (
+            head
+            + "\nhint: Databricks-side auth. Re-login (databricks auth login --host ...), "
+            "check the profile, then check permissions on the provider service."
+        )
+    if "UnknownOperationException" in detail or "model_not_found" in detail:
+        return (
+            head
+            + "\nhint: that reads like a managed-serving route. Managed serving does not work "
+            "for Claude on a CUSTOM+Bedrock provider — use provider passthrough "
+            f"(/ai-gateway/model/{model}/converse + the "
+            "Databricks-Model-Provider-Service header), which is what this script sends."
+        )
+    lowered = detail.lower()
+    if "credential" in lowered or "security token" in lowered or "accessdenied" in lowered:
+        return (
+            head
+            + "\nhint: AWS rejected the stored key. Create does not validate credentials, so a "
+            "typo'd ABSK key only fails here. Fix the secret, then delete + recreate the "
+            "provider (config.custom is not patchable) and drop its orphaned _payload table."
+        )
+    if "Nodes do not exist" in detail:
+        return (
+            head
+            + "\nhint: still not in the gateway's routing cache after the retry window. That is "
+            "usually ~1–3 min — wait and retry rather than recreating anything; if it persists, "
+            "check the provider with: gateway.py status."
+        )
+    if code == 404:
+        return (
+            head
+            + f"\nhint: check the provider exists — gateway.py status "
+            f"(expected {params['PROVIDER_FQN']})."
+        )
+    return head
+
+
+# ── main ────────────────────────────────────────────────────────────────────
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="gateway.py",
+        description="Companion helper for the bedrock-uc-ai-gateway skill.",
+    )
+    parser.add_argument(
+        "--profile",
+        default=os.environ.get("DATABRICKS_CONFIG_PROFILE"),
+        help="Databricks CLI profile (default: DATABRICKS_CONFIG_PROFILE, else the CLI default)",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    subparsers.add_parser("preflight", help="CLI, auth, uv, and Bedrock-secret checks")
+    subparsers.add_parser("status", help="report provider, model service, and inference tables")
+
+    invoke = subparsers.add_parser("invoke", help="call the model through provider passthrough")
+    invoke.add_argument("prompt", help="prompt text, or '-' to read stdin")
+    invoke.add_argument("--model", help="model id (default: MODEL_ID from deploy.py)")
+    invoke.add_argument("--max-tokens", type=int, default=200)
+    invoke.add_argument("--timeout", type=int, default=120, help="per-request timeout, seconds")
+    invoke.add_argument(
+        "--retry-seconds",
+        type=int,
+        default=300,
+        help="how long to retry the routing-cache lag (default: 300)",
+    )
+
+    args = parser.parse_args()
+    params = deploy_params()
+    return {
+        "preflight": cmd_preflight,
+        "status": cmd_status,
+        "invoke": cmd_invoke,
+    }[args.command](args, params)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #47.

Packages the merged `bedrock-uc-custom-provider/` demo (#41, PR #45) as an agent skill, following the house shape in `experiments/coding_agent_inference_unity_ai_gateway/skill/` (SKILL.md + scripts/).

## What's here

**`bedrock-uc-custom-provider/skill/SKILL.md`** — trigger description, hard rules, and the opinionated flow:

0. `gateway.py preflight`
1. the **human** stores the `ABSK` key as a Databricks secret (the agent is told never to accept, log, or write the raw key)
2. `uv run deploy.py`, with the expected first-run output quoted verbatim from the script's own prints
3. verify with a passthrough call
4. explain to the human where the logs land — `aws_bedrock_payload` is the table that fills; `sonnet5_bedrock_payload` provisions but stays empty until the managed-translation gap closes

The README's constraints become agent-actionable triage: a symptom → cause → action table covering `Nodes do not exist` (wait, don't recreate), `UnknownOperationException` / `model_not_found` (you used a managed route — stop hunting `base_url` shapes), create-doesn't-validate-credentials, orphaned `_payload` tables, non-patchable `config.custom` / `config.routing`, and `native_api_types` on `targets[]` — plus a delete + recreate recipe that tells the agent to confirm with the human first, since dropping the payload table discards logged traffic.

**`bedrock-uc-custom-provider/skill/scripts/gateway.py`** — stdlib-only companion (python3 + the Databricks CLI, no third-party deps):

- `preflight` — CLI, auth, `uv`, and whether the Bedrock secret exists. Lists keys in the scope; never reads the value.
- `status` — GETs the provider service, model service, and both `_payload` tables into a curated state table, and flags **orphaned** payload tables (table present, owning service gone) — the collision that breaks a recreate. Prints selected fields rather than raw API JSON, so a stored provider key can't be echoed to a terminal or log.
- `invoke "<prompt>"` — the passthrough call (`/ai-gateway/model/<id>/converse` + the `Databricks-Model-Provider-Service` header), retrying the routing-cache lag, reply on stdout and usage on stderr. Error hints route each failure class back to the right constraint.

**Reuses `deploy.py`, never forks it.** `gateway.py` parses the catalog, schema, provider/service ids, model, and secret scope/key straight out of `deploy.py`'s parameter block via `ast`, so editing that block moves the skill with it and the two cannot drift.

**`README.md`** — short "Use as a skill" section linking to the folder.

## Verification

No Databricks or AWS reachable from this workspace, so all expected outputs are quoted from the README / `deploy.py`'s own print statements rather than invented. What was actually exercised locally:

- parameter extraction from `deploy.py` (asserted FQNs and model id), `find_key` over nested `auth describe` JSON, and `not_found` across the `RESOURCE_DOES_NOT_EXIST` / prose / 404 forms
- `preflight` and `status` rendered against a stubbed `databricks` CLI — pass, secret-missing, and orphaned-table cases
- `invoke` against a local HTTP stub: request URL, provider header, bearer header, body shape, `-` stdin prompt, `--max-tokens`, and each error hint — plus a real 30s retry cycle where the first call returns `Nodes do not exist` and the second succeeds
- clean non-zero exits with no `databricks` on PATH and on an empty prompt
- `python3 -m py_compile` clean; no `__pycache__` committed

Public-repo hygiene: placeholders only, no keys, account ids, or workspace URLs (grep-checked).

Not merging — leaving this for review.

This pull request and its description were written by Isaac.