### PR TITLE
feat: live-validate the Bedrock gateway skill + document what blocks in-workspace agents

### DIFF
--- a/bedrock-uc-custom-provider/README.md
+++ b/bedrock-uc-custom-provider/README.md
@@ -95,7 +95,25 @@ value), `status` (provider, model service, and inference tables, including
 orphaned `_payload` tables), and `invoke "<prompt>"` (a passthrough call that
 prints the reply). Stdlib-only; it reads its parameters straight from
 `deploy.py`'s parameter block, so the two cannot drift, and it orchestrates
-`deploy.py` rather than duplicating it.
+`deploy.py` rather than duplicating it. Pass `--catalog` / `--schema` when you
+deployed somewhere other than the defaults, and `--profile` to pick a CLI
+profile.
+
+**Run `deploy.py` from a shell, not from an in-workspace coding agent.** Tested
+with Genie Code (2026-07-29): given only this folder's URL it cloned the repo,
+read the skill, planned correctly, and created the catalog and schema — then
+its safety layer denied the provider-creation step as credential egress,
+because the step reads the Bedrock secret and posts it in the request body.
+That objection can't be satisfied: the beta API accepts the credential only as
+`config.custom.direct.api_key.plaintext`, with no secret-reference form. A
+human running the same script is fine; an autonomous agent inside the workspace
+is not the path.
+
+One more environment note from that run: on a metastore with no default
+storage, `deploy.py`'s catalog creation fails, because it deliberately creates
+catalogs without a `storage_root`. Point `TARGET_CATALOG` at a catalog you
+already own rather than attaching the demo to whatever external location
+happens to be lying around.
 
 ## Constraints discovered
 

--- a/bedrock-uc-custom-provider/skill/SKILL.md
+++ b/bedrock-uc-custom-provider/skill/SKILL.md
@@ -102,6 +102,14 @@ A re-run prints `exists — leaving as-is` for objects already there. That is
 deliberate, not a bug: `config.custom` and `config.routing` are not patchable,
 so the script never tries (see Constraints).
 
+**If catalog creation fails** with a managed-location / storage-root error,
+this metastore has no default storage, and `deploy.py` deliberately creates
+catalogs without a `storage_root`. Do **not** go scavenging the workspace for
+an external location to borrow — that silently plants the demo's data in
+someone else's bucket. Point `TARGET_CATALOG` at a catalog that already exists
+and that the human owns, or have them create one with an explicit storage root.
+Then re-run, and pass `--catalog <name>` to `gateway.py` so it follows you.
+
 To change the region, catalog, schema, or model, edit the parameter block at
 the top of `deploy.py`. Changing the key, `base_url`, or routing of an
 *existing* object requires delete + recreate — see the recreate recipe below.
@@ -183,6 +191,8 @@ not instant; give the tables a few minutes after a call.
 | Table `<name>_payload` already exists on create | Deleting a provider/model service **orphans its inference table** | Drop the orphan (or change `table_name_prefix`) before recreating. `gateway.py status` flags orphans. |
 | Need to change key, `base_url`, or routing | `config.custom` and `config.routing` are **not updatable** | Delete + recreate (recipe below). Do not attempt a PATCH. |
 | Provider create rejects `targets[]` | Entries require `native_api_types` | Keep `"anthropic/v1/messages"` as `deploy.py` sets it. |
+| Catalog create fails on managed location / storage root | The metastore has no default storage | Point `TARGET_CATALOG` at an existing catalog the human owns; don't borrow a storage location you found lying around. Match it with `gateway.py --catalog <name>`. |
+| An in-workspace coding agent refuses to run `deploy.py` | Agent safety layers read "secret value into an API request body" as credential egress | Expected — see below. Run `deploy.py` from a shell or a notebook the human drives. |
 
 **Recreate recipe** (the only way to change an existing provider's key, base
 URL, or routing):
@@ -196,3 +206,18 @@ URL, or routing):
 
 Confirm the delete with the human first — it is destructive, and dropping the
 `_payload` table discards logged traffic.
+
+## Where this runs
+
+Run `deploy.py` from a shell (or a notebook the human is driving). **An
+in-workspace coding agent will not get through it.** Tested with Genie Code on
+2026-07-29: given only the repo URL it cloned the repo, found and read this
+skill, planned correctly, and created the catalog and schema — then its safety
+layer denied the provider-creation step, on the grounds that reading a secret
+and posting it in an API body is credential egress, and suggested a secret
+reference instead. There is no secret-reference form in this beta API;
+`api_key.plaintext` is the only shape it accepts, so the objection cannot be
+satisfied — it can only be overridden by a human who understands the trade.
+
+If you are that agent: say this plainly to your human and hand them the shell
+command. Do not try to reshape the request until the guardrail stops noticing.

--- a/bedrock-uc-custom-provider/skill/scripts/gateway.py
+++ b/bedrock-uc-custom-provider/skill/scripts/gateway.py
@@ -72,11 +72,15 @@ def row(check: str, status: str, detail: str = "") -> None:
 # ── deploy.py is the single source of truth for parameters ──────────────────
 
 
-def deploy_params() -> dict:
+def deploy_params(overrides: dict | None = None) -> dict:
     """Literal module-level assignments from deploy.py's parameter block.
 
     Computed values (f-strings, os.environ lookups) are skipped — they are
     derived here instead, the same way deploy.py derives them.
+
+    `overrides` (from --catalog / --schema) win over the file. A workspace
+    where you cannot create a catalog is a real case: deploy.py gets pointed
+    at an existing catalog, and this helper has to follow it there.
     """
     try:
         tree = ast.parse(DEPLOY_PY.read_text())
@@ -98,6 +102,8 @@ def deploy_params() -> dict:
     missing = [p for p in REQUIRED_PARAMS if p not in params]
     if missing:
         die(f"{DEPLOY_PY.name} is missing expected parameters: {', '.join(missing)}")
+
+    params.update({k: v for k, v in (overrides or {}).items() if v})
 
     params["SCHEMA_FQN"] = f"{params['TARGET_CATALOG']}.{params['TARGET_SCHEMA']}"
     params["PROVIDER_FQN"] = f"{params['SCHEMA_FQN']}.{params['PROVIDER_ID']}"
@@ -466,6 +472,11 @@ def main() -> int:
         default=os.environ.get("DATABRICKS_CONFIG_PROFILE"),
         help="Databricks CLI profile (default: DATABRICKS_CONFIG_PROFILE, else the CLI default)",
     )
+    parser.add_argument(
+        "--catalog",
+        help="override TARGET_CATALOG from deploy.py (use when you deployed elsewhere)",
+    )
+    parser.add_argument("--schema", help="override TARGET_SCHEMA from deploy.py")
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     subparsers.add_parser("preflight", help="CLI, auth, uv, and Bedrock-secret checks")
@@ -484,7 +495,7 @@ def main() -> int:
     )
 
     args = parser.parse_args()
-    params = deploy_params()
+    params = deploy_params({"TARGET_CATALOG": args.catalog, "TARGET_SCHEMA": args.schema})
     return {
         "preflight": cmd_preflight,
         "status": cmd_status,


### PR DESCRIPTION
Follow-up to #48. Ran the merged skill against real workspaces and tested whether an in-workspace coding agent can drive it from the repo URL alone. Three findings, each fixed or documented.

## 1. `gateway.py` couldn't follow a deployment that moved (fixed)

The helper read its catalog from `deploy.py` with no override. The very first real-world run diverged from that default — a metastore with no default storage forced the deployment into an existing catalog — which left the helper unable to see what had actually been deployed.

Added `--catalog` / `--schema`. `deploy.py` remains the source of defaults; the flags just let you point at where things really landed.

## 2. Catalog creation fails on a metastore with no default storage (documented)

`deploy.py` creates catalogs without a `storage_root` on purpose, which is fine on a metastore with default storage and a hard failure without one. Now covered in SKILL.md (step 2 + gotchas table) and the README — including an explicit instruction *not* to go scavenging for an external location to satisfy it. An agent did exactly that unprompted and created the demo catalog on another team's S3 bucket.

## 3. An in-workspace coding agent can't complete this setup (documented)

Genie Code, given only `https://github.com/randypitcherii/shareables/tree/main/bedrock-uc-custom-provider` and told the key was already in the `bedrock` secret scope:

- ✅ cloned the repo — it reaches github.com fine
- ✅ found and read `README.md`, `deploy.py`, `SKILL.md`, and `gateway.py` without being pointed at them
- ✅ produced a sensible three-step plan
- ✅ created the catalog and schema, recovering on its own from the storage-root failure
- ❌ **denied at provider creation by its own safety layer** — reading a secret and posting it in an API body reads as credential egress. It suggested using a secret reference instead.

That suggestion has no implementation: the beta API accepts the credential only as `config.custom.direct.api_key.plaintext`. The objection is coherent and cannot be satisfied — only overridden by a human who understands the trade.

So there is no copy/paste "point Genie Code at this URL" command in this PR. Writing one would document something that doesn't work. Instead there's a **Where this runs** section stating the finding, plus an instruction to an agent that hits this: tell your human plainly and hand them the shell command, rather than reshaping the request until the guardrail stops noticing.

## Live verification

This supersedes the stub-only testing in #48 — that PR's claim that the workspace couldn't reach Databricks was inherited from the task brief and was wrong.

Against FEVM (2026-07-29):

- `preflight` — all green, including secret presence via key listing (never reads the value)
- `status` — correct `MISSING` / `OK` readings across two catalogs and two workspaces, verified against `databricks catalogs get` and raw REST
- `invoke` — **Sonnet 5 replied `gateway OK` through the gateway**, `inputTokens=19 outputTokens=7`, ~6s end to end
- `--profile logfood` resolves and reports against a second workspace

## Note for the reviewer

Genie Code left `ai_gateway_demo` behind on FEVM (catalog + `bedrock` schema, no gateway objects), with its `storage_root` pointing at an unrelated team's external location — `s3://vdm-classic-pbquq5-ext-s3-.../`. Worth dropping; it isn't referenced by anything here.

Separately, `deploy.py`'s `sys.exit(main())` surfaces as a spurious error when run inside a Databricks notebook (`sys.exit(None)` raises `SystemExit`). Harmless from a shell, so I left it alone rather than touching a file outside this PR's scope — flagging it in case you want it changed.

This pull request and its description were written by Isaac.