### PR TITLE
experiment: constrained delegation paths for service-principal creation

### DIFF
--- a/experiments/udf_privilege_delegation/Makefile
+++ b/experiments/udf_privilege_delegation/Makefile
@@ -13,7 +13,7 @@ export
 
 PY := uv run python
 
-.PHONY: help auth-check verify setup matrix row-1 row-2 row-3 row-4 row-5 row-6 row-7 teardown test test-infrastructure lint
+.PHONY: help auth-check verify setup matrix row-1 row-2 row-3 row-4 row-5 row-6 row-7 row-8 row-9 row-10 row-11 row-12 row-13 row-14 teardown test test-infrastructure lint
 
 help: ## List available targets
 	@echo "Targets:"
@@ -35,8 +35,10 @@ verify: auth-check ## Prove auth + connectivity end-to-end with one real request
 setup: verify ## Create the low-privilege caller, the admin-owned objects, and the grants
 	$(PY) scripts/setup/00_create_lowpriv_principal.py
 	$(PY) scripts/setup/01_provision_objects.py
+	$(PY) scripts/setup/02_provision_connection.py
+	$(PY) scripts/setup/03_provision_delegated_job.py
 
-matrix: row-1 row-2 row-3 row-4 row-5 row-6 row-7 ## Run every matrix row and rewrite results/matrix_results.json
+matrix: row-1 row-2 row-3 row-4 row-5 row-6 row-7 row-8 row-9 row-10 row-11 row-12 row-13 row-14 ## Run every matrix row and rewrite results/matrix_results.json
 
 row-1: ## SQL UDF — definer vs invoker rights
 	$(PY) scripts/delegation/01_sql_udf_definer_vs_invoker.py
@@ -59,7 +61,28 @@ row-6: ## Function body readability — can a caller with only EXECUTE read the 
 row-7: ## Author-embedded credential — does the delegated action work then?
 	$(PY) scripts/delegation/07_embedded_credential_end_to_end.py
 
-teardown: ## Remove the schema, the functions, and both service principals
+row-8: ## UC connection — does the privilege resolve as definer or invoker?
+	$(PY) scripts/delegation/08_connection_definer_vs_invoker.py
+
+row-9: ## UC connection — is the stored credential readable by its grantees?
+	$(PY) scripts/delegation/09_connection_credential_readable_by_caller.py
+
+row-10: ## UC connection — what does USE CONNECTION actually authorise?
+	$(PY) scripts/delegation/10_connection_grant_blast_radius.py
+
+row-11: ## UC connection — is this workspace's control plane reachable at all?
+	$(PY) scripts/delegation/11_control_plane_reachable_via_connection.py
+
+row-12: ## Job run-as — can a CAN_MANAGE_RUN caller cause the shaped action?
+	$(PY) scripts/delegation/12_job_run_as_delegated_action.py
+
+row-13: ## Job run-as — what does CAN_MANAGE_RUN withhold?
+	$(PY) scripts/delegation/13_job_manage_run_boundary.py
+
+row-14: ## SQL SECURITY DEFINER procedure — does it change row 8's answer?
+	$(PY) scripts/delegation/14_definer_procedure_vs_connection.py
+
+teardown: ## Remove the schema, connections, broker job, and every service principal
 	$(PY) scripts/setup/99_teardown.py
 
 test: ## Run no-infra tests only (unit + composition)

--- a/experiments/udf_privilege_delegation/README.md
+++ b/experiments/udf_privilege_delegation/README.md
@@ -1,24 +1,31 @@
-# Can a Unity Catalog UDF wrap one privileged action for less-privileged callers?
+# Can one privileged action be wrapped for less-privileged callers?
 
-**The question.** A high-privilege admin defines a reusable UDF. A lower-privilege
-user is granted permission to invoke it. The user should *not* receive the
-underlying admin privilege directly. Can the function act as a narrowly scoped
-wrapper around a single administrative action — creating a service principal,
-concretely — rather than a broad grant?
+**The question.** A high-privilege admin defines something reusable. A
+lower-privilege user is granted permission to invoke it. The user should *not*
+receive the underlying admin privilege directly. Can that thing act as a narrowly
+scoped wrapper around a single administrative action — creating a service
+principal, concretely — rather than a broad grant?
 
-**The answer, in one line.** For *data*, yes and it is a real boundary. For
-*administrative actions*, no — not through the function model. It can be forced
-to work by hardcoding a credential in the function body, and that hands the
-credential to every caller in plaintext, so the workaround is worse than the
-grant it replaces.
+**The answer, in one line.** Not through Unity Catalog's function model, and not
+through a UC connection either — but yes through a **job whose `run_as` identity
+holds the privilege**, where the credential lives on the compute and the
+constraints live in code the caller can neither read nor edit.
 
-Run date: **2026-07-28**. One real AWS Databricks workspace, Unity Catalog
-enabled, serverless SQL warehouse on the PRO channel. Author identity: a
-workspace admin. Caller identity: an OAuth M2M service principal that is a plain
-workspace user, holds `USE CATALOG` / `USE SCHEMA` / `EXECUTE` and `CAN_USE` on
-the warehouse, and nothing else. Every row below was produced by a script in
-`scripts/` writing to `results/matrix_results.json`; that file is the source of
-truth and this table is its readable projection.
+The matrix runs in three parts. Rows 1–7 (2026-07-28) close the UDF route. Rows
+8–11 and 14 (2026-07-29) close the UC connection route, which looked like the
+closest fit and is not one. Rows 12–13 (2026-07-29) measure the route that works.
+The ranked write-up of every mechanism surveyed, including the five not tested
+live, is in
+[docs/research/2026-07-29-service-principal-delegation-options.md](docs/research/2026-07-29-service-principal-delegation-options.md).
+
+Run dates: **2026-07-28** (rows 1–7) and **2026-07-29** (rows 8–14). One real AWS
+Databricks workspace, Unity Catalog enabled, serverless SQL warehouse on the PRO
+channel, IP access lists enabled. Author identity: a workspace admin. Caller
+identity: an OAuth M2M service principal that is a plain workspace user, holds
+`USE CATALOG` / `USE SCHEMA` / `EXECUTE` and `CAN_USE` on the warehouse, plus
+`CAN_MANAGE_RUN` on one job, and nothing else. Every row below was produced by a
+script in `scripts/` writing to `results/matrix_results.json`; that file is the
+source of truth and this table is its readable projection.
 
 ## Findings matrix
 
@@ -31,6 +38,13 @@ truth and this table is its readable projection.
 | 5 | Is there any **SQL surface** for identity administration a definer-rights SQL UDF could wrap? | inferred from row 1 | ❌ | `CREATE SERVICE PRINCIPAL`, `CREATE USER`, `CREATE LOGIN` all `[PARSE_SYNTAX_ERROR] ... SQLSTATE: 42601` for a workspace admin. The grammar does not exist. |
 | 6 | Can a caller holding **only `EXECUTE`** read the function body, and therefore any credential embedded in it? | the obvious workaround to rows 3–5 | ❌ | The caller read the body via **`DESCRIBE FUNCTION EXTENDED`** and via **`information_schema.routines`**. A planted sentinel string was visible through both. (`SHOW CREATE TABLE` was refused — `TABLE_OR_VIEW_NOT_FOUND`.) The caller could still invoke, so it genuinely held only `EXECUTE`. |
 | 7 | Does embedding the author's credential in the body make the delegated action succeed? | the workaround, tested | ✅ | Caller holding only `EXECUTE` invoked the wrapper; SCIM returned **HTTP 201** and the principal was present in the directory on read-back. Works — via a stored secret, not via the function model. Function dropped immediately; token never written to `results/`. |
+| 8 | Does a SQL UDF resolve **`USE CONNECTION`** on an admin-owned connection as **definer**, the way it resolved table `SELECT`? | [http_request](https://docs.databricks.com/aws/en/sql/language-manual/functions/http_request), [CREATE CONNECTION](https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-syntax-ddl-create-connection) | ❌ | **Invoker.** Caller holding `EXECUTE` on the wrapper and nothing on the connection got the *same* refusal it got calling directly — `PERMISSION_DENIED … User is missing USE CONNECTION on <connection>`. Control: the admin's identical call returned **200**. Definer's rights cover what a body reads, not the connection it calls out through. |
+| 9 | Can a caller granted `USE CONNECTION` read the credential the connection stores? | the row 6 question, asked of the other primitive | ✅ | **The credential stays hidden.** With the grant held and demonstrably in use, `DESCRIBE CONNECTION`, `SHOW CONNECTIONS`, `system.information_schema.connections` and the connections REST API were all allowed and none returned the sentinel. `DESCRIBE` reports `auth_scheme -> bearer` and the host, and stops. This is the one thing rows 6–7 could not deliver. |
+| 10 | Is `USE CONNECTION` scoped to the author's call, or to the whole connection? | inferred from row 8 | ❌ | **The whole connection.** Holding it, the caller reached the origin on every shape the wrapper never makes: `GET` on another path (**404**), `POST` (**405**), `DELETE` (**405**) — each answered by the far end, which is what proves the platform dispatched it. Only the host and `base_path` bind: `../../etc/passwd` was rejected `INVALID_HTTP_REQUEST_PATH`. |
+| 11 | Can `http_request()` reach *this* workspace's own SCIM API? | prerequisite for the whole connection family | ❌ | **Reached, then refused.** Sentinel credential → **401** about the credential, so the round trip completes. Same call with a valid credential → **403** from the workspace's IP access list, naming the egress address. Environment-dependent, and independent of every privilege question. |
+| 12 | Can a caller holding only `CAN_MANAGE_RUN` cause a service principal to be created, in a shape the author fixed? | the customer's requirement, aimed at a job | ✅ | Caller was refused the SCIM create directly (`PermissionDenied`), then triggered the job and `udf-delegation-job-sp-alpha` was present on admin read-back — the prefix composed by the notebook, not supplied by the caller. Suffix `../Evil Name` was rejected by the notebook's rule and created nothing. |
+| 13 | Does `CAN_MANAGE_RUN` withhold the ability to change what the job does? | the row 6 question, asked of the job | ✅ | Repointing the task, changing `run_as`, and self-granting `CAN_MANAGE` were all `PermissionDenied`; reading the notebook came back `ResourceDoesNotExist`. Reading the output of runs it triggered **is** allowed — by design, and the operational rule that follows from it. |
+| 14 | Does an explicit **`SQL SECURITY DEFINER` procedure** change row 8's answer? | extension — procedures state the security mode outright | ◑ | Changes the answer without delivering the outcome. The caller was **not** refused for missing `USE CONNECTION`, so the clause clears that check; the call then failed at credential resolution — **401** `Credential was not sent or was of an unsupported type`, carrying a Databricks request id. Measured behaviour, not a documented contract. |
 
 Status vocabulary: ✅ works as claimed · ❌ does not, with evidence ·
 ◑ partially · ❓ could not be isolated.
@@ -85,19 +99,78 @@ silently, whenever someone runs `DESCRIBE`.
 It also expires. The embedded token is short-lived, so the wrapper stops working
 at a time unrelated to any change anyone made to it.
 
+### A connection hides the credential and still does not wrap the action
+
+The UC HTTP connection is the primitive Unity Catalog offers for exactly the
+problem row 6 exposed, and it solves that problem. Row 9 granted the caller
+`USE CONNECTION`, confirmed it was really using the connection, and then failed
+to extract the stored token through four different read paths. That is the
+property the embedded-credential workaround could not provide, and it is worth
+stating plainly because it is the reason someone will reach for a connection.
+
+Then it fails on the other half. Row 8: the connection privilege resolves as
+**invoker**, so a caller holding only `EXECUTE` on an admin-owned wrapper gets
+the identical refusal it gets calling `http_request()` itself. Definer's rights
+cover the objects a body *reads* — that is row 1, and it still holds — not the
+connection a body *calls out through*.
+
+Because row 8 forces the caller to hold `USE CONNECTION` directly, row 10 becomes
+the question that matters, and its answer is that the grant is scoped to the
+connection rather than to the author's call. The caller reached the origin with a
+different path, with `POST`, and with `DELETE` — none of which the wrapper makes.
+The only thing that binds is the connection's host and `base_path`.
+
+For the concrete use case that is the whole story: a connection pointed at
+`/api/2.0/preview/scim/v2/` does not delegate *create one service principal under
+a fixed prefix*. It delegates the SCIM API — create, enumerate, delete, users as
+well as principals — to everyone granted `USE CONNECTION`, whatever the wrapper
+says. **Use a connection to hide a credential. Do not expect it to shape an
+action.**
+
+Row 14 is the same finding from an unexpected angle. A `SQL SECURITY DEFINER`
+stored procedure — where the author states the intent in the object definition,
+which the function model gave no way to do — gets *past* the `USE CONNECTION`
+check and then fails at credential resolution with a platform-emitted 401. Not a
+delegation, not the function's refusal, and not described anywhere in the public
+documentation, so it is recorded as a measurement rather than a contract.
+
+### The job is the primitive that has all three parts
+
+What every earlier row lacks is a single place that has an identity, a credential
+the caller cannot read, and an enforcement point the caller cannot reach. A job
+has all three, and rows 12–13 measured it rather than assuming it.
+
+Row 12: the caller was refused the SCIM create directly, triggered a job it holds
+only `CAN_MANAGE_RUN` on, and a service principal existed afterwards under a name
+the notebook composed. The suffix `../Evil Name` was rejected by the notebook's
+own rule and created nothing — so the constraint is code running as the
+privileged identity, not a convention the caller is trusted to follow.
+
+Row 13 is the row 6 question asked of the job, and it comes back the other way.
+The caller could not repoint the task, could not change `run_as`, could not grant
+itself `CAN_MANAGE`, and could not read the notebook. The one thing
+`CAN_MANAGE_RUN` does grant is reading the output of runs it triggers — by
+design, and worth designing around: **whatever the job prints, the caller reads.**
+
+The failure mode to guard is the permission itself. `CAN_MANAGE` instead of
+`CAN_MANAGE_RUN` lets the holder repoint the task, which converts one narrow
+action into the run-as identity's full privilege. That is one dropdown away, and
+nothing in the platform will flag it.
+
 ### Viability verdict
 
-| Delegation target | Viable via UDF? | Why |
-|---|---|---|
-| Reading data the caller lacks `SELECT` on | **Yes** | Definer's rights, row 1. Sound and supported. |
-| Any administrative action (identity, workspace config, ACLs) | **No** | No SQL surface (row 5); Python sandbox has no identity (row 3). |
-| Same, forced with an embedded credential | **No — actively harmful** | Works (row 7) but discloses the credential to every caller (row 6). |
+| Delegation target | Mechanism | Viable? | Why |
+|---|---|---|---|
+| Reading data the caller lacks `SELECT` on | SQL UDF | **Yes** | Definer's rights, row 1. Sound and supported. |
+| Any administrative action | SQL / Python UDF | **No** | No SQL surface (row 5); Python sandbox has no identity (row 3). |
+| Same, forced with an embedded credential | UDF + hardcoded token | **No — actively harmful** | Works (row 7) but discloses the credential to every caller (row 6). |
+| Hiding a credential from the principals that use it | UC HTTP connection | **Yes** | Row 9. Four read paths, none disclosed it. |
+| Constraining *which* call those principals may make | UC HTTP connection | **No** | Invoker rights (row 8); the grant covers the connection, not the call (row 10). A definer procedure gets past the check and still fails (row 14). |
+| An administrative action, shaped and delegated | Job with `run_as` | **Yes** | Rows 12–13. Action delivered, shape enforced in code, every edit path refused. |
 
-For the administrative case the primitive to reach for is one that has a real
-run-as identity of its own — a job or Databricks App running as a service
-principal that holds the narrow privilege — rather than a function. That keeps
-the credential outside anything the caller can read. Scoping that alternative is
-outside this experiment; the point here is only that the UDF route is closed.
+The ranked survey of every mechanism considered — including the five judged from
+documentation rather than measured — is in
+[docs/research/2026-07-29-service-principal-delegation-options.md](docs/research/2026-07-29-service-principal-delegation-options.md).
 
 ## Caveats and scope
 
@@ -111,29 +184,55 @@ outside this experiment; the point here is only that the UDF route is closed.
 - **Row 6 is a negative scoped to the paths probed** — `DESCRIBE FUNCTION EXTENDED`,
   `SHOW CREATE TABLE`, `information_schema.routines`. Two of the three leaked, so
   the finding stands regardless, but this is not a claim that those are the only
-  read paths.
-- Rows 1–6 come from a single provisioning run; row 7 re-ran after a teardown fix
-  against the same provisioned objects. Timestamps are in
-  `results/matrix_results.json`.
-- Not tested: Scala/Java UDFs, UDFs on classic (non-serverless) compute,
-  UC Connections or service credentials as an alternative credential source
-  inside the sandbox.
+  read paths. **Row 9 is a positive with the same scope limit** and matters more
+  for it: four read paths returned no credential, which is not a proof that none
+  exists.
+- **Rows 8–10 and 14 point at `example.com`, not at the SCIM API.** That is
+  deliberate. Row 11 shows this workspace's IP access list refuses the
+  authenticated self-referential call, so a SCIM target would have answered 403
+  for a reason unrelated to privilege and the definer/invoker question would
+  never have been reached. The privilege finding is therefore measured cleanly;
+  what it does *not* license is any claim about SCIM behaving differently, and
+  nothing here assumes it would.
+- **Row 11 is about this workspace, not about Unity Catalog.** A workspace
+  without IP access lists, or one whose list covers the serverless egress
+  address, would not see it.
+- **Row 14 is a measurement, not a documented contract.** No public documentation
+  describes how a `SQL SECURITY DEFINER` procedure resolves a connection
+  credential; this is one workspace on one date, and it is the kind of edge that
+  changes without notice.
+- **`http_request` is deprecated.** Databricks now points at the
+  [Unity Catalog connections proxy endpoint](https://docs.databricks.com/aws/en/query-federation/http)
+  for new code. It takes the same `USE CONNECTION` grant, so rows 9 and 10 are
+  expected to carry over — credential hidden, grant scoped to host and
+  `base_path` — but that was not measured here.
+- Rows 1–14 come from a single `make setup && make matrix` run on 2026-07-29;
+  timestamps are in `results/matrix_results.json`.
+- Not tested: Scala/Java UDFs, UDFs on classic (non-serverless) compute, the
+  connections proxy endpoint, Databricks Apps, and every desk-researched
+  candidate in the research document.
 
 ## Running it
 
 ```bash
 make                         # list targets
 make verify                  # one real request — proves auth, warehouse, catalog
-make setup                   # low-privilege caller + admin-owned objects + grants
-make matrix                  # all seven rows -> results/matrix_results.json
-make teardown                # remove schema, functions, and both service principals
+make setup                   # caller + objects + connections + broker job + grants
+make matrix                  # all fourteen rows -> results/matrix_results.json
+make teardown                # remove everything: schema, connections, job, principals
 ```
 
 Configure via env vars (all echoed by `make help`): `DATABRICKS_CONFIG_PROFILE`,
 `EXPERIMENT_CATALOG`, `EXPERIMENT_SCHEMA`, `EXPERIMENT_WAREHOUSE_ID`.
 
 The experiment needs a workspace admin profile (it creates service principals
-and mints their OAuth secrets) and a serverless SQL warehouse. Authentication is
+and mints their OAuth secrets) and a serverless SQL warehouse. It also needs
+`CREATE CONNECTION` on the metastore for rows 8–11 and 14. Authentication is
 SSO/OAuth only — `scripts/_common.py` refuses a `dapi…` personal access token on
-sight. Real coordinates are redacted at the results-write boundary, so committed
-evidence carries placeholders only.
+sight. Real coordinates are redacted at the results-write boundary — catalog,
+host, caller id, anything email-shaped, any IPv4 address, and any credential a
+row registers — so committed evidence carries placeholders only.
+
+Connections live in a flat metastore-wide namespace and the broker job lives
+outside Unity Catalog, so neither is removed by dropping the schema. `make
+teardown` removes both explicitly, along with every principal the matrix created.

--- a/experiments/udf_privilege_delegation/docs/research/2026-07-28-evidence-trail.md
+++ b/experiments/udf_privilege_delegation/docs/research/2026-07-28-evidence-trail.md
@@ -106,12 +106,138 @@ diagnosis entirely (a firewall) instead of the right one (no credential).
 `reached: true` with the status code. Reachability and authorization are
 different questions and a probe that conflates them answers neither.
 
+## Trap 4 — an authorization refusal wearing an HTTP status code
+
+Rows 8–11 and 14 were added on 2026-07-29 and immediately reproduced the same
+family of mistake, from the other direction.
+
+`http_request()` does not fail the statement when Unity Catalog refuses the
+connection. It returns, successfully, a `STRUCT<status_code, text>` whose
+`status_code` is `403` and whose `text` carries the refusal:
+
+```
+{"status_code":"403","text":"[REMOTE_FUNCTION_HTTP_FAILED_ERROR] The remote HTTP
+request failed with code 403, and error message 'HTTP request failed with status:
+{"error_code":"PERMISSION_DENIED","message":"Failed request to <host>. Error:
+User is missing USE CONNECTION on <connection>"}' SQLSTATE: 57012"}
+```
+
+The first version of row 8 scored on `outcome.succeeded`, so the caller's refusal
+counted as a working call and the row recorded **inconclusive** on the grounds
+that the caller "could use the connection directly". Read one step further and it
+would have recorded **pass** — definer's rights work — which is the opposite of
+what happened.
+
+This is trap 3 inverted. There the harness treated an HTTP answer as a
+connectivity failure; here it treated an authorization failure as an HTTP answer.
+The general form is the same: `http_request()` returns a transport-shaped value
+for both transport outcomes and authorization outcomes, so the status code alone
+never says which one occurred. Scoring now goes through
+`_delegation_common.http_request_outcome`, which classifies on the body, and a
+call counts as allowed only when the platform did not refuse it *and* the origin
+answered.
+
+## Trap 5 — one probe cannot separate "unreachable" from "not allowed"
+
+Row 11 asks whether `http_request()` can reach this workspace's own SCIM API. The
+first version asked it once, with the sentinel credential, and got:
+
+```
+{"status_code":"401","text":"... {"error_code":401,"message":"Credential was not
+sent or was of an unsupported type for this API. [ReqId: ...]"}"}
+```
+
+Scored as "refused", which was true and useless. A 401 about the credential is
+evidence the request *arrived* — DNS, egress and TLS all worked and the platform
+got as far as looking at what was presented. Reporting that as unreachable
+invites the firewall diagnosis all over again.
+
+The same call with a valid credential is refused `403`, by the workspace's IP
+access list, naming the egress address. That is the real answer, and it can only
+appear after authentication succeeds — an access list has nothing to evaluate
+until it knows who is asking.
+
+So the row runs both probes deliberately: the sentinel establishes that the
+round trip completes, and the live credential establishes that the authenticated
+request is then refused at the perimeter. Either probe alone tells a coherent
+and wrong story.
+
 ## What survived
 
 Rows 1, 5, 6, and 7 were correct on the first run and unchanged by the fixes.
 Rows 2 and 3 changed status. Row 4 was correct throughout but for a reason the
 first harness could not have articulated — it fails because of row 3, and rows
 2 and 3 had to be measured properly before that attribution was earned.
+
+Of the 2026-07-29 additions, rows 9, 10, 12 and 13 were correct on the first run.
+Row 8 changed status once its scoring was fixed (trap 4) and row 11 changed once
+it stopped asking its question with a single probe (trap 5). Row 14 was written
+after the fixes and inherits both.
+
+## Verbatim platform responses, 2026-07-29
+
+Row 8, the caller through the admin-owned SQL UDF, holding only `EXECUTE`:
+
+```
+PERMISSION_DENIED: Failed request to <host>. Error:
+User is missing USE CONNECTION on <connection>
+```
+
+Identical, string for string, to what the same caller got calling
+`http_request()` directly. That identity is the finding.
+
+Row 9, the same caller *after* `GRANT USE CONNECTION`, running
+`DESCRIBE CONNECTION`:
+
+```
+Connection Name  <connection>
+Type             HTTP
+Owner            author@example.com
+Read-only        true
+Options          auth_scheme -> bearer, host -> <host>, port -> 443, base_path -> /
+```
+
+No `bearer_token`. `SHOW CONNECTIONS`, `system.information_schema.connections`
+and the connections REST API were all allowed and all silent about it too.
+
+Row 10, the same caller, request shapes the author's function never makes:
+
+```
+GET  <base_path>                    -> 200   (origin answered)
+GET  some/other/resource            -> 404   (origin answered)
+POST <base_path>                    -> 405   (origin answered)
+DELETE <base_path>                  -> 405   (origin answered)
+GET  ../../etc/passwd               -> [INVALID_HTTP_REQUEST_PATH] rejected
+```
+
+A 404 is a stronger result than a 200 here: it can only have come from the far
+end, so the platform dispatched a call nobody authored.
+
+Row 12, the caller triggering the broker job with the two suffixes:
+
+```json
+{"requested_suffix": "alpha", "run_as": "author@example.com", "outcome": "created",
+ "created_display_name": "udf-delegation-job-sp-alpha"}
+{"requested_suffix": "../Evil Name", "outcome": "rejected",
+ "reason": "suffix must match ^[a-z0-9-]{1,24}$"}
+```
+
+Row 13, the same caller against the job's edges: `edit_task`, `change_run_as` and
+`regrant_self` all `PermissionDenied`; reading the notebook the job runs came
+back `ResourceDoesNotExist`, which is a refusal that hides the object's existence
+rather than naming the privilege — still a refusal, but not an authorization
+answer, and the README says so rather than rounding it up.
+
+Row 14, the caller through a `SQL SECURITY DEFINER` procedure, with
+`USE CONNECTION` revoked:
+
+```
+401 Credential was not sent or was of an unsupported type for this API. [ReqId: ...]
+```
+
+Not the `USE CONNECTION` refusal the UDF produced, and not a working call. The
+`ReqId` marks it as platform-emitted rather than anything the target host would
+say.
 
 ## Environment dependence worth restating
 

--- a/experiments/udf_privilege_delegation/docs/research/2026-07-29-service-principal-delegation-options.md
+++ b/experiments/udf_privilege_delegation/docs/research/2026-07-29-service-principal-delegation-options.md
@@ -1,0 +1,361 @@
+---
+title: "Constrained delegation paths for service-principal creation"
+tags: [unity-catalog, service-principals, delegation, identity, jobs, connections]
+status: active
+created: 2026-07-29
+---
+
+# Constrained delegation paths for service-principal creation
+
+## The question
+
+An under-privileged principal needs to cause service principals to be created —
+dynamically, and in a shape somebody else fixed: constrained naming, constrained
+entitlements and group membership, constrained quantity, auditable, revocable.
+It must never handle, and never need to be trusted with, a credential. That rules
+out the whole secret-in-the-loop family: tokens embedded in function bodies,
+caller-supplied secret arguments, secret scopes read at call time, UC secrets.
+
+The prior experiment ([README](../../README.md), rows 1–7) closed the obvious
+route. A Unity Catalog UDF cannot do it: the function type that carries definer's
+rights has no grammar for identity administration, the function type that could
+express it has no identity to spend, and forcing it with an embedded credential
+discloses that credential to every caller. This document ranks what is left.
+
+**What was tested live vs. sourced from documentation.** Rows 8–14 of the
+findings matrix are live measurements against one real AWS workspace on
+2026-07-29, produced by scripts in `scripts/delegation/` writing to
+`results/matrix_results.json`. Those rows cover candidates 1 and 2 — the UC
+connection family and the job-as-broker family. Every other candidate below is
+desk research against public Databricks documentation, and is labelled as such
+in its section. Where a section makes a claim that was measured, it cites the
+matrix row.
+
+## The recommendation, in two sentences
+
+**Broker the action through a Databricks job whose `run_as` identity holds the
+privilege, and grant the caller `CAN_MANAGE_RUN` and nothing else.** The
+credential lives on the compute the job runs on, where the caller has no read
+path to it; the naming, entitlement and quantity constraints live in the job's
+code, which `CAN_MANAGE_RUN` does not permit the caller to read or change; and
+the caller's interface is a job parameter.
+
+That is the only candidate surveyed that supplies all three properties at once —
+a real execution identity, an enforcement point the caller cannot reach, and a
+narrow interface — and rows 12 and 13 measured it end to end rather than
+inferring it.
+
+## Ranked shortlist
+
+| Rank | Mechanism | Credential hidden? | Shape enforced where? | Evidence | Status |
+|---|---|---|---|---|---|
+| 1 | **Job with `run_as` a service principal** | Yes — on the compute | Job code (row 13: caller cannot read or edit it) | Live, rows 12–13 | GA |
+| 2 | Databricks App running as its own SP | Yes — injected env vars | App code | Docs | GA |
+| 3 | Pre-provisioned pool + native delegated roles | N/A — no creation at call time | Pool size, group rules | Docs | GA / Public Preview |
+| 4 | IdP-driven SCIM provisioning | Yes — outside Databricks | IdP group rules | Docs | GA |
+| 5 | Terraform / CI with an approval gate | Yes — in CI | Code review + module | Docs | GA |
+| 6 | Model Serving endpoint / agent tool | Yes | Endpoint code | Docs | GA |
+| 7 | UC HTTP connection + `http_request()` | **Yes** (row 9) | **Nowhere** (rows 8, 10, 14) | Live, rows 8–11, 14 | Deprecated |
+| — | A native fine-grained role for creation | — | — | Docs + row 5 | Does not exist |
+
+Ranks 1–2 are runtime delegation. Ranks 3–5 relocate the problem, which for many
+requirements is the better answer. Rank 6 is rank 1's shape with more moving
+parts. Rank 7 is refuted as a delegation primitive and kept in the list because
+the refutation is the useful part.
+
+---
+
+## 1. Job with `run_as` a service principal — recommended
+
+**Tested live.** Matrix rows 12 and 13.
+
+An admin creates a job whose task is the delegated action and whose `run_as`
+identity holds the privilege. The caller is granted `CAN_MANAGE_RUN`, which
+permits triggering a run and reading its output, and nothing else. The caller's
+only input is a job parameter.
+
+**Does the credential stay unreadable?** Yes, and for a better reason than
+"nobody granted it": there is no credential to read. The job's identity is
+attached to the compute at run time by the platform. Row 13 measured the four
+ways a caller might reach around it — repoint the task at different code, change
+the `run_as` identity, grant itself `CAN_MANAGE`, read the notebook the job runs
+— and all four were refused. That last probe is row 6 asked of the new object,
+and it comes back the other way: the logic the delegation depends on is not
+readable by the population allowed to trigger it.
+
+**How are shape constraints enforced?** In the job's code, which is exactly where
+the caller cannot reach. In the tested implementation the caller supplies a
+suffix; the notebook validates it against `^[a-z0-9-]{1,24}$`, prepends a fixed
+prefix, sets the entitlements itself, and creates exactly one principal. Row 12
+triggered it twice — once with a well-formed suffix, which produced a principal
+the admin then found in the SCIM directory under the composed name, and once
+with `../Evil Name`, which the notebook rejected and which created nothing.
+
+Quantity, group membership and tags are the same kind of constraint: they are
+whatever the code says, and the code is not the caller's to change.
+
+**What must the caller be granted?** `CAN_MANAGE_RUN` on one job. Nothing on the
+catalog, nothing on the identity APIs, no entitlements.
+
+**GA / Preview?** GA. Jobs, `run_as`, and job ACLs are all long-standing.
+
+**Latency and operational cost.** A job run — seconds to a couple of minutes
+depending on compute warm-up, so this is an asynchronous request/fulfil
+interface, not a synchronous API. Operationally it is one job and one privileged
+identity to review.
+
+**What breaks it.**
+
+- **`CAN_MANAGE` instead of `CAN_MANAGE_RUN`.** `CAN_MANAGE` lets the holder
+  repoint the task, so the grant stops being one action and becomes the run-as
+  identity's full privilege. This is the single mistake that inverts the whole
+  design, and it is one dropdown away.
+- **Anything the job prints.** Row 13 confirmed the caller can read the output of
+  runs it triggers. That is by design and it is fine — until someone logs a
+  token, a connection string, or another principal's details. Job output is part
+  of the caller's surface even though the job's credential is not.
+- **Parameter handling in the job code.** The enforcement point is code, so it
+  fails the way code fails. The suffix is concatenated into an identity name; if
+  it were concatenated into a SQL statement, an API path, or a shell command, the
+  narrow interface would be a wide one. Validate against an allowlist pattern,
+  never a denylist.
+- **The standing privileged identity.** The `run_as` identity holds the
+  privilege permanently, so it is worth scoping to the minimum that works and
+  reviewing like any other admin credential.
+- **Auditability depends on reading two records.** The job run history attributes
+  the trigger to the caller; the identity-management audit events attribute the
+  creation to the `run_as` identity. Neither alone tells the whole story.
+
+---
+
+## 2. Databricks App running as its own service principal
+
+**Desk research.** Public documentation; not measured here.
+
+Structurally the same trust argument as the job, with a synchronous interface. An
+app gets a dedicated service principal — Databricks documents it as "unique to
+the app instance", stable across deployments, and deleted with the app — and the
+platform "automatically injects service principal credentials into the app's
+environment", so the credential is server-side and not exposed to end users. End
+users are granted `CAN_USE` on the app.
+
+The difference that matters is authorization granularity. The documentation is
+explicit that app authorization "doesn't support user-level access control. All
+users who interact with the app share the same permissions defined for the
+service principal." So per-caller rules — who may create how many, under which
+prefix — have to be implemented in the app's own code against the authenticated
+user identity the app receives. The on-behalf-of-user mode does not help here,
+because the whole premise is that the user does *not* hold the privilege.
+
+Choose this over the job when the requester needs an answer immediately, a form
+rather than a parameter, or a UI. Choose the job when an asynchronous interface
+is acceptable, because the job needs no always-on service to operate and has less
+code in the trusted position.
+
+---
+
+## 3. Pre-provisioned pool plus native delegated roles
+
+**Desk research.** Public documentation, plus matrix row 5.
+
+This candidate is not on the original list and it deserves to be, because it is
+the one that dissolves the problem rather than solving it.
+
+Databricks has no role that lets a non-admin *create* a service principal — see
+section 7 — but it does have real non-admin roles over principals that already
+exist:
+
+- **Service Principal Manager**, which manages roles on a service principal. The
+  creator holds it on what they created, and account admins hold it on
+  everything.
+- **Service Principal User**, which allows running jobs as that service
+  principal.
+- **`Manage` on a group** (Public Preview), which lets a non-admin manage group
+  membership, delete the group, and pass those permissions on. Group *creation*
+  still requires an admin.
+
+So an admin can create a pool of N principals up front under the naming
+convention, and delegate membership and assignment to a non-admin. "Constrained
+quantity" becomes the pool size, "constrained naming" becomes the names the admin
+chose, and "constrained entitlements" becomes group membership the delegate is
+natively allowed to manage.
+
+Worth asking before building anything: is the requirement genuinely *creation*,
+or is it "a team needs identities allocated to it without waiting on an admin"?
+If it is the second, this is a supported answer today with no broker in the path.
+It fails only where the number of principals is genuinely unbounded, or where
+each must be created at an unpredictable moment.
+
+---
+
+## 4. IdP-driven SCIM provisioning
+
+**Desk research.** Public documentation; not measured here.
+
+The identity lifecycle moves out of Databricks entirely: Okta or Entra ID owns
+creation, and group-membership rules in the IdP drive what lands in Databricks
+and with which entitlements. Naming and quantity are governed by the IdP's own
+provisioning rules; revocation is deprovisioning; the audit trail is the IdP's.
+
+This is the strongest governance story of anything here, and it is the right
+answer whenever the organisation already runs SCIM provisioning — which, at the
+kind of organisation that asks this question, it usually does.
+
+It is ranked below the brokers because it answers a slightly different question.
+It does not give a low-privilege *Databricks* principal a runtime path; it
+relocates the privilege to whoever administers the IdP. That is an improvement in
+governance and often a step backwards in self-service latency. Where the
+requester's workflow lives in Databricks and needs an identity mid-flight, a
+broker still has to sit in front of it.
+
+---
+
+## 5. Terraform or a CI pipeline with an approval gate
+
+**Desk research.** Public documentation; not measured here.
+
+The requester opens a pull request against a repository that owns the service
+principals as code; CI holds the credential; a reviewer approves; the pipeline
+applies. Constraints are enforced twice — by the module's interface, which can
+accept only a suffix and derive everything else, and by code review.
+
+The credential never leaves CI, the audit trail is the git history, and
+revocation is a revert. It is the most auditable option here and the least
+dynamic: the round trip is a human review, so it is minutes to days rather than
+seconds.
+
+Use it when creation is rare, consequential, or needs a second pair of eyes. It
+composes well with the job broker rather than competing with it — the same
+constraint logic can live in a Terraform module for planned creation and in job
+code for runtime creation.
+
+---
+
+## 6. Model Serving endpoint or agent tool as an action broker
+
+**Desk research.** Public documentation; not measured here.
+
+A served model or agent endpoint runs with an identity of its own and can expose
+a shaped tool. As a trust argument this is rank 1 with more moving parts: the
+credential is server-side, the constraint is in the endpoint's code, the caller
+is granted invocation on the endpoint.
+
+It is ranked last of the working options because it adds a serving stack to a
+problem that does not need one. It is worth reaching for only when the delegated
+action already belongs to an agent workflow — when a model is going to decide
+that a principal is needed. Note also that Databricks now steers agent tooling
+toward MCP services and the Unity Catalog connections proxy for reaching external
+services rather than toward UC functions wrapping `http_request`, so an agent
+route should be designed against the current guidance rather than against the
+function-tool pattern.
+
+---
+
+## 7. UC HTTP connection and `http_request()` — refuted
+
+**Tested live.** Matrix rows 8, 9, 10, 11 and 14. This was the most promising
+candidate on the original list and the one worth being precise about, because it
+gets one thing exactly right and still does not work.
+
+The idea: a connection object holds the credential, an admin-owned SQL UDF calls
+`http_request()` against it with the method and path fixed, and callers are
+granted only `EXECUTE`. If the connection privilege resolved as **definer** — the
+way table `SELECT` did in row 1 — this would be the original proposal, working.
+
+**It resolves as invoker (row 8).** The caller, holding `EXECUTE` on the
+admin-owned function and nothing on the connection, was refused with the same
+message it got calling the connection directly: *User is missing USE CONNECTION
+on …*. Definer's rights cover the objects a function body reads; they do not
+cover the connection a function body calls out through.
+
+**The credential really is hidden (row 9).** This is the one property the
+mechanism delivers, and it is the property the embedded-credential workaround
+could not. With `USE CONNECTION` granted and demonstrably in use, none of
+`DESCRIBE CONNECTION`, `SHOW CONNECTIONS`,
+`system.information_schema.connections`, or the connections REST API returned the
+token. `DESCRIBE` reports `auth_scheme -> bearer` and the host and stops.
+
+**But the grant is connection-wide, not call-wide (row 10).** Because row 8
+forces the caller to hold `USE CONNECTION` directly, the question becomes what
+that grant authorises — and it authorises the connection, not the author's call.
+Holding it, the caller reached the origin on every request shape the author's
+function never makes: a different path, a `POST`, a `DELETE`. Each was answered
+by the far end rather than refused by the platform, which is the proof that the
+platform let it out. The one boundary that does hold is the connection's host and
+`base_path`: a path that tried to climb above it was rejected outright with
+`INVALID_HTTP_REQUEST_PATH`.
+
+The consequence for the original use case is the whole finding. A connection
+pointed at `/api/2.0/preview/scim/v2/` does not delegate "create one service
+principal under a fixed prefix". It delegates the SCIM API — creating,
+enumerating, and deleting principals and users alike — to everyone granted
+`USE CONNECTION`, whatever the wrapper function says.
+
+**A `SQL SECURITY DEFINER` procedure changes the answer without fixing it
+(row 14).** Stored procedures require the security mode as an explicit clause,
+so an author can state the intent the function model could not. Called by the
+low-privilege caller, the procedure was *not* refused for missing
+`USE CONNECTION` — so the clause is honoured far enough to clear that check — and
+then failed at credential resolution with a platform-shaped 401, *Credential was
+not sent or was of an unsupported type*. That is neither a working delegation nor
+the function's refusal. It is recorded as a measured behaviour of one workspace
+on one date, not as a contract: no public documentation describes this path.
+
+**Reachability is its own problem (row 11).** On a workspace with IP access lists
+enabled, a UC connection pointed at the workspace that hosts it makes a call that
+leaves and re-enters the perimeter. The sentinel probe proved the request
+completes the round trip — the control plane answered about the credential — and
+the same call with a valid credential was then refused by the IP access list,
+naming the egress address `http_request()` presents. This is environment-specific
+and independent of every privilege question, and it is the kind of thing that
+surfaces after the design is finished rather than before.
+
+**Finally, `http_request` is deprecated.** Databricks documents the Unity Catalog
+connections proxy endpoint as its replacement:
+`/api/2.0/unity-catalog/connections/<name>/proxy[/<sub-path>]`, requiring
+`USE CONNECTION` on the connection, with the credential injected server-side.
+That is the supported way to get the row 9 property, and it inherits row 10's
+shape: the grant is scoped to the connection's host and `base_path`, not to one
+action. **Use a connection to hide a credential. Do not expect it to shape an
+action.**
+
+---
+
+## 8. A native fine-grained role for creating service principals — does not exist
+
+**Desk research plus matrix row 5.**
+
+There is no account-level or workspace-level role short of admin that can create
+a service principal. Creation is an account admin action in the account console
+and a workspace admin action in a workspace. The roles that do exist —
+Service Principal Manager, Service Principal User, and group `Manage` — all
+operate on principals and groups that already exist, which is what makes section
+3 possible and this section short.
+
+Row 5 is the SQL-side half of the same answer: `CREATE SERVICE PRINCIPAL`,
+`CREATE USER` and `CREATE LOGIN` are all `PARSE_SYNTAX_ERROR` even for a
+workspace admin. The grammar does not exist, so no SQL-layer object — function or
+procedure — can wrap it.
+
+If a native constrained-creation role is something the organisation wants, the
+honest answer is that it is a product request, and the mechanisms above are what
+bridges the gap in the meantime.
+
+---
+
+## What this changes about the earlier conclusion
+
+The prior README ended by pointing at "a job or Databricks App running as a
+service principal" as the primitive to reach for, and called scoping it out of
+scope. That instinct was right and is now measured: rows 12 and 13 show the job
+route delivering the action end to end, with the caller refused every path to the
+code, the identity, and the permissions behind it.
+
+The new information is about the connection family, which looked like a closer
+fit and is not one. It solves the credential-disclosure problem that killed rows
+6 and 7 — genuinely, and that is worth knowing — and then fails on the half of
+the problem the function model was supposed to solve, because `USE CONNECTION`
+grants the connection rather than the call. A design that reaches for a
+connection to hide a secret is sound. A design that reaches for one to constrain
+an action is not, and the failure is silent: the wrapper compiles, the grants
+look narrow, and the caller can go around them.

--- a/experiments/udf_privilege_delegation/results/matrix_results.json
+++ b/experiments/udf_privilege_delegation/results/matrix_results.json
@@ -4,6 +4,7 @@
     "caller_identity": "OAuth M2M service principal, workspace user (non-admin)",
     "cloud": "AWS",
     "compute": "serverless SQL warehouse (PRO channel)",
+    "network": "IP access lists enabled (allow lists not covering serverless egress)",
     "unity_catalog": "enabled",
     "workspace": "one real Databricks workspace (host redacted)"
   },
@@ -25,8 +26,209 @@
       },
       "finding": "Definer's rights. The caller was denied a direct read of sensitive_table but successfully invoked an admin-owned SQL UDF whose body reads it, receiving 3. A SQL UDF is therefore a genuine privilege boundary for data access: EXECUTE on the function is sufficient and the caller never gains the underlying SELECT.",
       "question": "Does a UC SQL UDF body run with definer (owner) privileges on objects the caller cannot access?",
-      "recorded_at": "2026-07-28T21:55:40+00:00",
+      "recorded_at": "2026-07-29T16:00:26+00:00",
       "status": "pass"
+    },
+    "10": {
+      "evidence": {
+        "author_blessed_call__GET_root": {
+          "allowed": true,
+          "body": "<!doctype html><html lang=\"en\"><head><title>Example Domain</title><link rel=\"icon\" href=\"data:,\"><meta name=\"viewport\" content=\"width=device-width, initial-scale=1\"><style>body{background:#eee;width:60vw;margin:15vh auto;font-family:system-ui,sans-serif}h1{font-size:1.5em}div{opacity:0.8}a:link,a:visited{color:#348}</style></head><body><div><h1>Example Domain</h1><p>This domain is for use in documentation examples without needing permission. Avoid use in operations.</p><p><a href=\"https://iana.o ...[truncated]",
+          "denied_by_unity_catalog": false,
+          "error": null,
+          "error_code": null,
+          "method": "GET",
+          "path": "",
+          "statement_succeeded": true,
+          "status_code": "200"
+        },
+        "escape_above_base_path": {
+          "allowed": false,
+          "body": null,
+          "denied_by_unity_catalog": false,
+          "error": "Exception thrown in awaitResult: [INVALID_HTTP_REQUEST_PATH] The input parameter: path, value: ../../etc/passwd is not a valid parameter for http_request because path traversal is not allowed. SQLSTATE: 22023",
+          "error_code": "ServiceErrorCode.BAD_REQUEST",
+          "method": "GET",
+          "path": "../../etc/passwd",
+          "refusal_kind": "input validation (path traversal)",
+          "statement_succeeded": false,
+          "status_code": null
+        },
+        "unblessed_method__DELETE_root": {
+          "allowed": false,
+          "body": "[REMOTE_FUNCTION_HTTP_FAILED_ERROR] The remote HTTP request failed with code 405, and error message 'HTTP request failed with status: <!doctype html><html lang=\"en\"><head><title>Example Domain</title><link rel=\"icon\" href=\"data:,\"><meta name=\"viewport\" content=\"width=device-width, initial-scale=1\"><style>body{background:#eee;width:60vw;margin:15vh auto;font-family:system-ui,sans-serif}h1{font-size:1.5em}div{opacity:0.8}a:link,a:visited{color:#348}</style></head><body><div><h1>Example Domain</h1> ...[truncated]",
+          "denied_by_unity_catalog": false,
+          "error": null,
+          "error_code": null,
+          "method": "DELETE",
+          "path": "",
+          "statement_succeeded": true,
+          "status_code": "405"
+        },
+        "unblessed_method__POST_root": {
+          "allowed": false,
+          "body": "[REMOTE_FUNCTION_HTTP_FAILED_ERROR] The remote HTTP request failed with code 405, and error message 'HTTP request failed with status: <!doctype html><html lang=\"en\"><head><title>Example Domain</title><link rel=\"icon\" href=\"data:,\"><meta name=\"viewport\" content=\"width=device-width, initial-scale=1\"><style>body{background:#eee;width:60vw;margin:15vh auto;font-family:system-ui,sans-serif}h1{font-size:1.5em}div{opacity:0.8}a:link,a:visited{color:#348}</style></head><body><div><h1>Example Domain</h1> ...[truncated]",
+          "denied_by_unity_catalog": false,
+          "error": null,
+          "error_code": null,
+          "method": "POST",
+          "path": "",
+          "statement_succeeded": true,
+          "status_code": "405"
+        },
+        "unblessed_path__GET_other": {
+          "allowed": false,
+          "body": "[REMOTE_FUNCTION_HTTP_FAILED_ERROR] The remote HTTP request failed with code 404, and error message 'HTTP request failed with status: <!doctype html><html lang=\"en\"><head><title>Example Domain</title><link rel=\"icon\" href=\"data:,\"><meta name=\"viewport\" content=\"width=device-width, initial-scale=1\"><style>body{background:#eee;width:60vw;margin:15vh auto;font-family:system-ui,sans-serif}h1{font-size:1.5em}div{opacity:0.8}a:link,a:visited{color:#348}</style></head><body><div><h1>Example Domain</h1> ...[truncated]",
+          "denied_by_unity_catalog": false,
+          "error": null,
+          "error_code": null,
+          "method": "GET",
+          "path": "some/other/resource",
+          "statement_succeeded": true,
+          "status_code": "404"
+        }
+      },
+      "finding": "USE CONNECTION is scoped to the connection, not to the author's call. Holding it, the caller reached the origin on 3 request shapes the author's function never makes (unblessed_path__GET_other, unblessed_method__POST_root, unblessed_method__DELETE_root) \u2014 different paths and different methods, each answered by the far end rather than refused by the platform. The wrapper function's fixed method and path are therefore not a constraint on the caller; they are a convention the caller can decline to follow. The one boundary the connection does enforce is its host and base_path \u2014 the probe that tried to climb above base_path was rejected outright with INVALID_HTTP_REQUEST_PATH, before any privilege was consulted.",
+      "question": "Is USE CONNECTION scoped to the call the author's function makes, or to the whole connection?",
+      "recorded_at": "2026-07-29T16:05:39+00:00",
+      "status": "fail"
+    },
+    "11": {
+      "evidence": {
+        "live_credential_probe": {
+          "allowed": false,
+          "body": "[REMOTE_FUNCTION_HTTP_FAILED_ERROR] The remote HTTP request failed with code 403, and error message 'HTTP request failed with status: {\"error_code\":403,\"message\":\"Source IP address: 203.0.113.0 is blocked by Databricks IP ACL for workspace: 0 [ReqId: abfe6d69-ed1b-445b-8aee-91d05435aca7]\"}' SQLSTATE: 57012",
+          "denied_by_unity_catalog": false,
+          "error": null,
+          "error_code": null,
+          "refused_by_network_perimeter": true,
+          "statement_succeeded": true,
+          "status_code": "403"
+        },
+        "sentinel_credential_probe": {
+          "allowed": false,
+          "body": "[REMOTE_FUNCTION_HTTP_FAILED_ERROR] The remote HTTP request failed with code 401, and error message 'HTTP request failed with status: {\"error_code\":401,\"message\":\"Credential was not sent or was of an unsupported type for this API. [ReqId: aaa62a02-4894-416c-857d-ce81a7ba25b7]\"}' SQLSTATE: 57012",
+          "denied_by_unity_catalog": false,
+          "error": null,
+          "error_code": null,
+          "reached_authentication": true,
+          "statement_succeeded": true,
+          "status_code": "401"
+        }
+      },
+      "finding": "Reached, then refused. The sentinel probe came back as an answer about the credential (401), which establishes the request completes the round trip \u2014 this is not a firewall or DNS failure. The same call with a valid credential was then refused (403) by the workspace's IP access list, naming the egress address http_request() presents. So on an IP-access-listed workspace, a UC connection pointed at the workspace that hosts it is a call that leaves and re-enters the perimeter, and the perimeter gets a vote \u2014 independently of every privilege question. Environment-dependent: a workspace without IP access lists, or one whose list covers serverless egress, would not see this.",
+      "question": "Can http_request() reach this workspace's own SCIM API, or does the network perimeter stop it first?",
+      "recorded_at": "2026-07-29T16:06:45+00:00",
+      "status": "fail"
+    },
+    "12": {
+      "evidence": {
+        "caller_direct_scim_create": {
+          "error": "unable to parse response. This is likely a bug in the Databricks SDK for Python or the underlying API. Please report this issue with the following debugging information to the SDK issue tracker at https://github.com/databricks/databricks-sdk-py/issues. Request log:```POST /api/2.0/preview/scim/v2/Se",
+          "error_type": "PermissionDenied",
+          "refused": true
+        },
+        "hostile_suffix_rejected": true,
+        "job_run_as": "author@example.com",
+        "principal_present_on_readback": true,
+        "principals_matching_prefix_after_both_runs": [
+          "udf-delegation-job-sp-alpha"
+        ],
+        "run_with_rejected_suffix": {
+          "error": null,
+          "life_cycle_state": "TERMINATED",
+          "notebook_output": "{\"requested_suffix\": \"../Evil Name\", \"outcome\": \"rejected\", \"reason\": \"suffix must match ^[a-z0-9-]{1,24}$\"}",
+          "result_state": "SUCCESS",
+          "run_id": 0,
+          "suffix_supplied_by_caller": "../Evil Name"
+        },
+        "run_with_valid_suffix": {
+          "error": null,
+          "life_cycle_state": "TERMINATED",
+          "notebook_output": "{\"requested_suffix\": \"alpha\", \"run_as\": \"author@example.com\", \"outcome\": \"created\", \"created_display_name\": \"udf-delegation-job-sp-alpha\", \"created_application_id\": \"a6f4a757-0224-4266-8702-a34a371285d3\"}",
+          "result_state": "SUCCESS",
+          "run_id": 0,
+          "suffix_supplied_by_caller": "alpha"
+        },
+        "stale_principals_removed": []
+      },
+      "finding": "The job is a real delegation boundary. The caller was refused the SCIM create directly, then triggered a job it holds only CAN_MANAGE_RUN on and a service principal existed afterwards \u2014 named 'udf-delegation-job-sp-alpha', composed by the notebook from a prefix the caller never supplied. The hostile suffix was rejected by the notebook's own rule and created nothing, so the shape constraint is enforced by code running as the privileged identity rather than by trusting the caller. No credential passed through the caller's hands at any point: the job's identity lives on the compute, not in anything the caller can read (contrast rows 6-7).",
+      "question": "Can a caller holding only CAN_MANAGE_RUN cause a service principal to be created, in a shape the author fixed?",
+      "recorded_at": "2026-07-29T16:08:19+00:00",
+      "status": "pass"
+    },
+    "13": {
+      "evidence": {
+        "job_id_probed": "redacted-by-shape",
+        "read_run_output": {
+          "note": "the caller was allowed to do this",
+          "refused": false
+        },
+        "run_as": "author@example.com",
+        "withheld_probes": {
+          "change_run_as": {
+            "error": "User 00000000-0000-0000-0000-0 does not have Admin or Owner permissions on job 0. Config: [redacted]",
+            "error_type": "PermissionDenied",
+            "refused": true
+          },
+          "edit_task": {
+            "error": "User 00000000-0000-0000-0000-0 does not have Admin or Owner permissions on job 0. Config: [redacted]",
+            "error_type": "PermissionDenied",
+            "refused": true
+          },
+          "read_source": {
+            "error": "Path (/Users/author@example.com/udf_delegation_create_sp) doesn't exist.",
+            "error_type": "ResourceDoesNotExist",
+            "refused": true
+          },
+          "regrant_self": {
+            "error": "00000000-0000-0000-0000-0 does not have Manage permissions on Job with ID: ElasticJobId(0). Please contact the owner or an administrator for access. Config: [redacted]",
+            "error_type": "PermissionDenied",
+            "refused": true
+          }
+        }
+      },
+      "finding": "CAN_MANAGE_RUN withholds every probed way of changing what the job does. The caller could not repoint the task, could not change the run-as identity, could not grant itself CAN_MANAGE, and could not read the notebook the job executes \u2014 the last being the question that killed the embedded-credential wrapper in row 6, answered the other way here. (The source read is refused as ResourceDoesNotExist rather than PermissionDenied: the workspace hides the object's existence instead of naming it. Still a refusal, but it is an existence answer, not an authorization one.) The one thing it does grant is reading the output of runs it triggers, confirmed live: whatever the job prints, the caller reads, so job output is part of the caller's surface even though the job's credential is not. Scoped to the probes listed; not a proof that no other edit path exists.",
+      "question": "Does CAN_MANAGE_RUN withhold the ability to change what the job does, who it runs as, and what code it executes?",
+      "recorded_at": "2026-07-29T16:08:58+00:00",
+      "status": "pass"
+    },
+    "14": {
+      "evidence": {
+        "admin_call": {
+          "allowed": true,
+          "body": "<!doctype html><html lang=\"en\"><head><title>Example Domain</title><link rel=\"icon\" href=\"data:,\"><meta name=\"viewport\" content=\"width=device-width, initial-scale=1\"><style>body{background:#eee;width:60vw;margin:15vh auto;font-family:system-ui,sans-serif}h1{font-size:1.5em}div{opacity:0.8}a:link,a:visited{color:#348}</style></head><body><div><h1>Example Domain</h1><p>This domain is for use in documentation examples without needing permission. Avoid use in operations.</p><p><a href=\"https://iana.o ...[truncated]",
+          "denied_by_unity_catalog": false,
+          "error": null,
+          "error_code": null,
+          "statement_succeeded": true,
+          "status_code": "200"
+        },
+        "caller_call": {
+          "allowed": false,
+          "body": "[REMOTE_FUNCTION_HTTP_FAILED_ERROR] The remote HTTP request failed with code 401, and error message 'HTTP request failed with status: {\"error_code\":401,\"message\":\"Credential was not sent or was of an unsupported type for this API. [ReqId: d4ee6831-6fba-42a3-97e3-45f048bf296e]\"}' SQLSTATE: 57012",
+          "denied_by_unity_catalog": false,
+          "error": null,
+          "error_code": null,
+          "failed_at_credential_resolution": true,
+          "refused_for_missing_use_connection": false,
+          "statement_succeeded": true,
+          "status_code": "401"
+        },
+        "caller_direct_call": {
+          "allowed": false,
+          "body": "[REMOTE_FUNCTION_HTTP_FAILED_ERROR] The remote HTTP request failed with code 403, and error message 'HTTP request failed with status: {\"error_code\":\"PERMISSION_DENIED\",\"message\":\"Failed request to https://example.com:443/. Error: User is missing USE CONNECTION on udf_delegation_conn\"}' SQLSTATE: 57012",
+          "denied_by_unity_catalog": true,
+          "error": null,
+          "error_code": null,
+          "statement_succeeded": true,
+          "status_code": "403"
+        }
+      },
+      "finding": "The procedure changes the answer without delivering the outcome. The caller was NOT refused for missing USE CONNECTION \u2014 the refusal row 8 produced through the UDF \u2014 so the definer clause is honoured far enough to get past that check. The call then failed at credential resolution: status_code 401, 'Credential was not sent or was of an unsupported type', a platform-shaped message carrying a Databricks request id rather than anything the target host would say. The definer-rights procedure therefore resolves the connection but does not present its credential, which is neither a working delegation nor the same refusal as the function. Treat this as a measured behaviour of one workspace on one date, not as a documented contract: nothing in the public documentation describes this path, and it is the kind of edge that changes without notice.",
+      "question": "Does a SQL SECURITY DEFINER stored procedure resolve the connection privilege as definer, where the SQL UDF did not?",
+      "recorded_at": "2026-07-29T16:09:39+00:00",
+      "status": "partial"
     },
     "2": {
       "evidence": {
@@ -87,7 +289,7 @@
       },
       "finding": "The UC Python UDF sandbox has outbound network access. As the low-privilege caller: workspace_control_plane -> HTTP 401, public_internet -> HTTP 200. A REST-based administrative action is therefore mechanically reachable from inside a function body \u2014 egress is not the constraint. Whether the request can be *authenticated* is row 3.",
       "question": "Can a UC Python UDF make an outbound HTTPS request (the prerequisite for any REST-based admin action)?",
-      "recorded_at": "2026-07-28T21:55:48+00:00",
+      "recorded_at": "2026-07-29T16:00:50+00:00",
       "status": "pass"
     },
     "3": {
@@ -131,7 +333,7 @@
       },
       "finding": "No ambient credential. The UC Python UDF sandbox exposed no DATABRICKS_* environment variables and the SDK could not construct a default-auth client, for either identity. A function body therefore has nothing to authenticate as \u2014 it cannot act on the owner's behalf even in principle. Any credential would have to be passed in explicitly by the caller, which inverts the pattern: the caller would need to already hold the privileged credential.",
       "question": "Does a UC Python UDF receive an ambient Databricks credential it could use to act as the function owner?",
-      "recorded_at": "2026-07-28T21:55:57+00:00",
+      "recorded_at": "2026-07-29T16:01:40+00:00",
       "status": "fail"
     },
     "4": {
@@ -151,7 +353,7 @@
       },
       "finding": "End-to-end delegation did not work. The caller could invoke the admin-owned function, but no service principal was created \u2014 the function body could not perform the administrative action. The failure is a capability failure inside the sandbox (see rows 2 and 3), not an authorization failure on the function itself.",
       "question": "Can a low-privilege caller create a service principal by invoking an admin-owned UDF wrapper?",
-      "recorded_at": "2026-07-28T21:56:02+00:00",
+      "recorded_at": "2026-07-29T16:02:18+00:00",
       "status": "fail"
     },
     "5": {
@@ -186,7 +388,7 @@
       },
       "finding": "No SQL surface. Every identity-administration statement was rejected by the parser even for a workspace admin, so principal creation is reachable only over the SCIM REST API. The one function type that carries definer's rights (SQL UDFs, row 1) therefore cannot express the action, and the one that could express it (Python UDFs) has neither egress nor a credential (rows 2-3). The two halves of the pattern never meet.",
       "question": "Does any SQL surface exist for creating a principal, such that a definer-rights SQL UDF could wrap it?",
-      "recorded_at": "2026-07-28T21:56:05+00:00",
+      "recorded_at": "2026-07-29T16:02:36+00:00",
       "status": "fail"
     },
     "6": {
@@ -221,7 +423,7 @@
       },
       "finding": "The function body is readable by a caller holding only EXECUTE, via describe_function_extended, information_schema_routines. A credential hardcoded into the body is therefore disclosed to exactly the population the wrapper was meant to keep it from \u2014 the workaround is not a delegation boundary, it is a credential handout with extra steps.",
       "question": "Can a caller holding only EXECUTE read the function body, and therefore any credential embedded in it?",
-      "recorded_at": "2026-07-28T21:56:14+00:00",
+      "recorded_at": "2026-07-29T16:03:14+00:00",
       "status": "fail"
     },
     "7": {
@@ -241,7 +443,88 @@
       },
       "finding": "It works, by embedding a credential. A caller holding only EXECUTE created a service principal through an admin-authored Python UDF whose body carries the author's token. The action is genuinely delegated and genuinely narrow \u2014 the caller can pass only a display name. But the elevation comes from a stored secret, not from the function model: the platform never re-authorizes the body as the owner, it simply replays whatever credential the author left in the source. Row 6 decides whether that secret stays hidden from the caller, and the token expires, so the wrapper silently stops working when it does.",
       "question": "Does embedding the author's credential in the function body make the delegated admin action succeed for a low-privilege caller?",
-      "recorded_at": "2026-07-28T21:56:41+00:00",
+      "recorded_at": "2026-07-29T16:03:51+00:00",
+      "status": "pass"
+    },
+    "8": {
+      "evidence": {
+        "admin_direct_call": {
+          "allowed": true,
+          "body": "<!doctype html><html lang=\"en\"><head><title>Example Domain</title><link rel=\"icon\" href=\"data:,\"><meta name=\"viewport\" content=\"width=device-width, initial-scale=1\"><style>body{background:#eee;width:60vw;margin:15vh auto;font-family:system-ui,sans-serif}h1{font-size:1.5em}div{opacity:0.8}a:link,a:visited{color:#348}</style></head><body><div><h1>Example Domain</h1><p>This domain is for use in documentation examples without needing permission. Avoid use in operations.</p><p><a href=\"https://iana.o ...[truncated]",
+          "denied_by_unity_catalog": false,
+          "error": null,
+          "error_code": null,
+          "statement_succeeded": true,
+          "status_code": "200"
+        },
+        "caller_direct_call": {
+          "allowed": false,
+          "body": "[REMOTE_FUNCTION_HTTP_FAILED_ERROR] The remote HTTP request failed with code 403, and error message 'HTTP request failed with status: {\"error_code\":\"PERMISSION_DENIED\",\"message\":\"Failed request to https://example.com:443/. Error: User is missing USE CONNECTION on udf_delegation_conn\"}' SQLSTATE: 57012",
+          "denied_by_unity_catalog": true,
+          "error": null,
+          "error_code": null,
+          "statement_succeeded": true,
+          "status_code": "403"
+        },
+        "caller_via_function": {
+          "allowed": false,
+          "body": "[REMOTE_FUNCTION_HTTP_FAILED_ERROR] The remote HTTP request failed with code 403, and error message 'HTTP request failed with status: {\"error_code\":\"PERMISSION_DENIED\",\"message\":\"Failed request to https://example.com:443/. Error: User is missing USE CONNECTION on udf_delegation_conn\"}' SQLSTATE: 57012",
+          "denied_by_unity_catalog": true,
+          "error": null,
+          "error_code": null,
+          "statement_succeeded": true,
+          "status_code": "403"
+        }
+      },
+      "finding": "Invoker. The caller holds EXECUTE on the admin-owned function and was refused anyway, with the same message it got calling the connection directly \u2014 'User is missing USE CONNECTION on udf_delegation_conn', surfaced as status_code 403 inside a successful statement. Unity Catalog re-checks the connection privilege against the invoker, so wrapping http_request() in a SQL UDF confers nothing. Definer's rights cover the objects the body reads, not the connection the body calls out through.",
+      "question": "Does a UC SQL UDF resolve the USE CONNECTION privilege on an admin-owned connection as definer, the way it resolves table SELECT?",
+      "recorded_at": "2026-07-29T16:04:16+00:00",
+      "status": "fail"
+    },
+    "9": {
+      "evidence": {
+        "connections_rest_api": {
+          "response": "{\"connection_id\": \"a3a50837-d610-4cc1-924b-19ba4e5a5979\", \"connection_type\": \"HTTP\", \"created_at\": 0, \"created_by\": \"author@example.com\", \"credential_type\": \"BEARER_TOKEN\", \"full_name\": \"udf_delegation_conn\", \"metastore_id\": \"c0da88f1-c020-4992-b8c9-c828e556889d\", \"name\": \"udf_delegation_conn\", \"options\": {\"auth_scheme\": \"bearer\", \"host\": \"https://example.com\", \"port\": \"443\", \"base_path\": \"/\"}, \"owner\": \"author@example.com\", \"provisioning_info\": {\"state\": \"ACTIVE\"}, \"read_only\": true, \"securable_type\": \"CONNECTION\", \"updated_at\": 0, \"updated_by\": \"author@example.com\", \"url\": \"https://example.com:443/\"}",
+          "sentinel_visible_to_caller": false,
+          "succeeded": true
+        },
+        "describe_connection": {
+          "error": null,
+          "error_code": null,
+          "row_count": 5,
+          "sentinel_visible_to_caller": false,
+          "statement": "DESCRIBE CONNECTION `udf_delegation_conn`",
+          "succeeded": true
+        },
+        "grant_control": {
+          "allowed": true,
+          "body": "<!doctype html><html lang=\"en\"><head><title>Example Domain</title><link rel=\"icon\" href=\"data:,\"><meta name=\"viewport\" content=\"width=device-width, initial-scale=1\"><style>body{background:#eee;width:60vw;margin:15vh auto;font-family:system-ui,sans-serif}h1{font-size:1.5em}div{opacity:0.8}a:link,a:visited{color:#348}</style></head><body><div><h1>Example Domain</h1><p>This domain is for use in documentation examples without needing permission. Avoid use in operations.</p><p><a href=\"https://iana.o ...[truncated]",
+          "denied_by_unity_catalog": false,
+          "error": null,
+          "error_code": null,
+          "statement_succeeded": true,
+          "status_code": "200"
+        },
+        "information_schema_connections": {
+          "error": null,
+          "error_code": null,
+          "row_count": 1,
+          "sentinel_visible_to_caller": false,
+          "statement": "SELECT * FROM system.information_schema.connections WHERE connection_name = 'udf_delegation_conn'",
+          "succeeded": true
+        },
+        "show_connections": {
+          "error": null,
+          "error_code": null,
+          "row_count": 3348,
+          "sentinel_visible_to_caller": false,
+          "statement": "SHOW CONNECTIONS",
+          "succeeded": true
+        }
+      },
+      "finding": "The credential stays hidden. The caller held USE CONNECTION and demonstrably used the connection, and none of DESCRIBE CONNECTION, SHOW CONNECTIONS, system.information_schema.connections, or the connections REST API returned the sentinel the connection was created with \u2014 DESCRIBE reports 'auth_scheme -> bearer' and the host, and stops there. This is the one property the embedded-credential workaround could not provide (row 6). Scoped to the paths probed; not a proof that no read path exists.",
+      "question": "Can a caller granted USE CONNECTION read the credential the connection stores?",
+      "recorded_at": "2026-07-29T16:04:55+00:00",
       "status": "pass"
     }
   }

--- a/experiments/udf_privilege_delegation/scripts/README.md
+++ b/experiments/udf_privilege_delegation/scripts/README.md
@@ -10,13 +10,15 @@ row; the number ties script → row → entry in `results/matrix_results.json`.
   exits if `DATABRICKS_TOKEN` looks like a `dapi…` personal access token.
 - A **serverless** SQL warehouse. UC Python UDFs do not run on classic warehouses.
 - A Unity Catalog catalog the profile can create schemas in.
+- **`CREATE CONNECTION` on the metastore** for rows 8–11 and 14.
+- Permission to create jobs and upload a notebook for rows 12–13.
 
 ## Shared modules
 
 | File | Purpose |
 |---|---|
-| `_common.py` | Auth (`admin_client`, `lowpriv_client`), `.env` loading, SQL execution, results writing, redaction. |
-| `delegation/_delegation_common.py` | Function invocation and JSON decoding for the matrix rows. |
+| `_common.py` | Auth (`admin_client`, `lowpriv_client`), `.env` loading, SQL execution, results writing, redaction, object names shared across rows. |
+| `delegation/_delegation_common.py` | Function invocation, JSON decoding, and `http_request_outcome` — the classifier rows 8, 10, 11 and 14 score on. |
 
 Three things in `_common.py` are load-bearing and easy to break:
 
@@ -28,9 +30,19 @@ Three things in `_common.py` are load-bearing and easy to break:
   identities.** It runs `SELECT current_user()` on each client and refuses to
   continue if they match. Configuration is not trusted; the warehouse is asked.
 - **`write_result()` redacts.** Catalog name, workspace host, caller application
-  id, and anything email-shaped are replaced with placeholders before anything
-  is written, because raw platform error strings are exactly where real
-  coordinates hide and `results/` is committed to a public repo.
+  id, anything email-shaped, any IPv4 address, and any credential a row passes to
+  `register_secret()` are replaced with placeholders before anything is written,
+  because raw platform error strings are exactly where real coordinates hide and
+  `results/` is committed to a public repo. Only row 11 registers a credential,
+  and only because its question cannot be answered without presenting one.
+
+`http_request_outcome` in `delegation/_delegation_common.py` is load-bearing for
+the same reason: `http_request()` returns a `STRUCT<status_code, text>` for both
+transport outcomes *and* authorization refusals, so a Unity Catalog
+`PERMISSION_DENIED` arrives as `status_code = 403` inside a statement that
+succeeded. Scoring on `outcome.succeeded` reads a refusal as a working call. The
+classifier keys on the body and counts a call as allowed only when the platform
+did not refuse it and the origin answered — see trap 4 in the evidence trail.
 
 ## Setup and teardown
 
@@ -39,7 +51,9 @@ Three things in `_common.py` are load-bearing and easy to break:
 | `verify.py` | One real request (`SELECT current_user()`, then `SHOW SCHEMAS`) to prove profile + warehouse + catalog before any matrix work. |
 | `setup/00_create_lowpriv_principal.py` | Creates the caller service principal, mints a workspace OAuth secret, grants `CAN_USE` on the warehouse, asserts it is not in `admins`, writes the gitignored `.env`, and proves it authenticates as itself. |
 | `setup/01_provision_objects.py` | Creates the schema, `sensitive_table`, the four probe functions, and grants the caller `USE CATALOG` / `USE SCHEMA` / `EXECUTE` — then asserts via `SHOW GRANTS` that the caller holds *nothing* on `sensitive_table`. |
-| `setup/99_teardown.py` | Drops the schema cascade and deletes both target principals and the caller. Run it before re-running row 4 or row 7 — both refuse to produce a result if their target principal already exists. |
+| `setup/02_provision_connection.py` | Creates the HTTP connection carrying a sentinel token, the SQL UDF and the `SQL SECURITY DEFINER` procedure that wrap `http_request()` against it, and a second connection pointed at the workspace's own SCIM API. Revokes any `USE CONNECTION` left by a previous run, then asserts the caller holds nothing on the connection — without which row 8 cannot tell definer from invoker. |
+| `setup/03_provision_delegated_job.py` | Uploads the notebook that performs the delegated action, creates the broker job with `run_as` the author, grants the caller `CAN_MANAGE_RUN`, and asserts the caller did *not* end up with `CAN_MANAGE`. |
+| `setup/99_teardown.py` | Drops the schema cascade, drops all three connections, deletes the broker job and its notebook, and deletes every principal the matrix created — the two fixed targets, everything under the row 12 prefix, and the caller. Connections are metastore-level and the job is outside UC, so neither goes away with the schema. Run it before re-running row 4 or row 7 — both refuse to produce a result if their target principal already exists. |
 
 ## Matrix rows
 
@@ -52,14 +66,32 @@ Three things in `_common.py` are load-bearing and easy to break:
 | `delegation/05_sql_surface_for_identity_admin.py` | 5 | Is identity administration expressible in SQL at all? Probed as admin — if the grammar is absent for an admin it is absent for everyone. |
 | `delegation/06_function_body_readable_by_caller.py` | 6 | Can a caller with only `EXECUTE` read the body? Plants a sentinel (never a real secret) and tries three read paths. |
 | `delegation/07_embedded_credential_end_to_end.py` | 7 | Does an author-embedded credential make it work? Uses the author's short-lived OAuth token, never logs the DDL, and drops the function in a `finally` block. |
+| `delegation/08_connection_definer_vs_invoker.py` | 8 | Does a connection privilege resolve as definer? Three calls: the admin's (proves the connection works), the caller's direct call (proves it is unprivileged), the caller's call through the wrapper (the measurement). |
+| `delegation/09_connection_credential_readable_by_caller.py` | 9 | Can a `USE CONNECTION` grantee read the stored token? Grants the privilege, proves the grant took effect, then probes four read paths for a sentinel. |
+| `delegation/10_connection_grant_blast_radius.py` | 10 | What does `USE CONNECTION` authorise? Issues request shapes the wrapper never makes and separates platform refusals from origin responses — a 404 from the origin is the finding. |
+| `delegation/11_control_plane_reachable_via_connection.py` | 11 | Is the workspace's own SCIM API reachable? Two probes — sentinel then live credential — because neither alone separates "unreachable" from "not allowed". Creates and drops its own connection; registers the token for redaction. |
+| `delegation/12_job_run_as_delegated_action.py` | 12 | Can a `CAN_MANAGE_RUN` caller cause the shaped action? Verdict is the SCIM directory read back as admin, not the run's result state. Clears its own prior principals first so the read-back means this run. |
+| `delegation/13_job_manage_run_boundary.py` | 13 | What does `CAN_MANAGE_RUN` withhold? Probes four ways to change what the job does, plus the one thing it does allow — reading run output. |
+| `delegation/14_definer_procedure_vs_connection.py` | 14 | Does an explicit `SQL SECURITY DEFINER` procedure change row 8's answer? Revokes `USE CONNECTION` for the duration and restores it in a `finally` block so rows 9–10 stay reproducible in any order. |
 
 ## Reading the output
 
 Failure output is data. `INSUFFICIENT_PERMISSIONS` (row 1's control),
-`PARSE_SYNTAX_ERROR` (row 5), and `HTTP 401` (row 2) are each the finding for
-their row — *which* thing refused and *how* is the result, so scripts print the
-rejected error body rather than swallowing it.
+`PARSE_SYNTAX_ERROR` (row 5), `HTTP 401` (row 2), and `User is missing USE
+CONNECTION` (row 8) are each the finding for their row — *which* thing refused
+and *how* is the result, so scripts print the rejected error body rather than
+swallowing it. Rows 10 and 14 turn on distinctions between kinds of refusal:
+Unity Catalog declining, `http_request()` rejecting an argument before dispatch,
+and the origin answering are three different things and the scripts label them
+separately.
 
 Scripts are idempotent (`CREATE OR REPLACE` throughout) except where a
 pre-existing target would make a result meaningless: rows 4 and 7 check the SCIM
-directory first and record `inconclusive` rather than a false pass.
+directory first and record `inconclusive` rather than a false pass. Row 12 faces
+the same hazard and resolves it the other way — it deletes principals left by its
+own previous run, because refusing would make `make matrix` non-repeatable.
+
+Two rows mutate state other rows depend on, and both are written so the order
+does not matter: row 9 grants `USE CONNECTION` and leaves it granted (row 10
+needs it), and row 14 revokes it and restores it in a `finally`. Re-running
+`setup/02` revokes it too, so row 8 always starts from the state it needs.

--- a/experiments/udf_privilege_delegation/scripts/_common.py
+++ b/experiments/udf_privilege_delegation/scripts/_common.py
@@ -55,6 +55,32 @@ LOWPRIV_DISPLAY_NAME = os.environ.get(
     "EXPERIMENT_LOWPRIV_DISPLAY_NAME", "udf-delegation-lowpriv"
 )
 
+# Connections are metastore-level objects with a flat, shared namespace, so the
+# name is prefixed and torn down explicitly rather than left to a schema drop.
+CONNECTION_NAME = os.environ.get(
+    "EXPERIMENT_CONNECTION_NAME", "udf_delegation_conn"
+)
+
+# A second connection, pointed at this workspace's own control plane, for the
+# question rows 8-10 deliberately keep out of the way: whether the SCIM API is
+# even reachable from where http_request() egresses.
+CONNECTION_SCIM_NAME = os.environ.get(
+    "EXPERIMENT_CONNECTION_SCIM_NAME", "udf_delegation_scim_conn"
+)
+
+# The connection's stored credential. A sentinel, not a secret: rows 8-10 ask
+# whether the connection *hides* what it stores and how far that store reaches,
+# and both questions are answerable without putting a live token in a public
+# repo's blast radius.
+CONNECTION_SENTINEL_TOKEN = "SENTINEL-NOT-A-REAL-SECRET-9f3a2c"
+
+# The job-as-broker scenario (rows 12-13).
+JOB_NAME = os.environ.get("EXPERIMENT_JOB_NAME", "udf-delegation-broker-job")
+JOB_ID = os.environ.get("EXPERIMENT_JOB_ID", "")
+# Every principal the brokered action is allowed to create carries this prefix.
+# The job's notebook prepends it; the caller supplies only what comes after.
+JOB_SP_PREFIX = os.environ.get("EXPERIMENT_JOB_SP_PREFIX", "udf-delegation-job-sp-")
+
 
 # --------------------------------------------------------------------------
 # output
@@ -252,8 +278,23 @@ PLACEHOLDER_AUTHOR = "author@example.com"
 PLACEHOLDER_CALLER = "00000000-0000-0000-0000-000000000000"
 
 
+# Rows that must present a live credential to answer their question register it
+# here, so the results writer scrubs it even if a platform error quotes it back.
+# Registering is not a substitute for not writing secrets down; it is the second
+# line for the case where the platform, not the script, chooses the output.
+_REGISTERED_SECRETS: list[str] = []
+PLACEHOLDER_SECRET = "<redacted-credential>"
+
+
+def register_secret(value: str | None) -> None:
+    if value and len(value) > 8:
+        _REGISTERED_SECRETS.append(value)
+
+
 def _redaction_map() -> dict[str, str]:
     mapping = {CATALOG: PLACEHOLDER_CATALOG}
+    for secret in _REGISTERED_SECRETS:
+        mapping[secret] = PLACEHOLDER_SECRET
     caller_id = os.environ.get("EXPERIMENT_LOWPRIV_CLIENT_ID")
     if caller_id:
         mapping[caller_id] = PLACEHOLDER_CALLER
@@ -264,6 +305,8 @@ def _redaction_map() -> dict[str, str]:
         # bare hostname, for error strings that omit the scheme
         if cfg.hostname:
             mapping[cfg.hostname] = PLACEHOLDER_HOST.removeprefix("https://")
+        if cfg.account_id:
+            mapping[cfg.account_id] = PLACEHOLDER_ACCOUNT_ID
     except Exception:  # pragma: no cover - redaction must never break a run
         pass
     return mapping
@@ -271,12 +314,60 @@ def _redaction_map() -> dict[str, str]:
 
 _EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
 
+# Platform error strings quote the egress address the request presented. It is
+# infrastructure detail from a real workspace and it has no bearing on any
+# finding, so it does not travel into a public repo either.
+PLACEHOLDER_IP = "203.0.113.0"
+PLACEHOLDER_ACCOUNT_ID = "00000000-0000-0000-0000-000000000000"
+_IPV4_RE = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
+
+# The Databricks SDK appends its whole client config to some errors:
+#   "... Config: host=..., account_id=..., workspace_id=..., discovery_url=..."
+# Scripts truncate long errors before recording them, which can cut that dump
+# mid-hostname — and a half-written workspace URL is past every exact-match
+# replacement above while still naming the workspace. The dump is SDK
+# diagnostics, never the finding, so it is removed rather than patched up.
+_SDK_CONFIG_DUMP_RE = re.compile(r"\s*Config:\s.*", re.DOTALL)
+
+# Job ids, run ids and principal ids are workspace-specific object identifiers.
+PLACEHOLDER_LONG_ID = 0
+_LONG_ID_RE = re.compile(r"\b\d{12,}\b")
+
 
 def redact(blob: str) -> str:
+    """Scrub one string. Callers redact *values*, never serialised JSON.
+
+    An earlier version ran this over the whole `json.dumps` output, which meant
+    every pattern here had to reason about JSON escaping — and one of them got
+    it wrong, matching up to the `"` of an escaped `\\"` and leaving a dangling
+    backslash that made the results file unparseable. Redacting the object tree
+    instead removes that entire class of bug: each string arrives unescaped and
+    the structure is never at risk.
+    """
+    blob = _SDK_CONFIG_DUMP_RE.sub(" Config: [redacted]", blob)
     for real, placeholder in _redaction_map().items():
         if real:
             blob = blob.replace(real, placeholder)
-    return _EMAIL_RE.sub(PLACEHOLDER_AUTHOR, blob)
+    blob = _EMAIL_RE.sub(PLACEHOLDER_AUTHOR, blob)
+    blob = _IPV4_RE.sub(PLACEHOLDER_IP, blob)
+    return _LONG_ID_RE.sub(str(PLACEHOLDER_LONG_ID), blob)
+
+
+def redact_tree(value: Any) -> Any:
+    """Apply `redact` to every string in a nested structure, in place of the
+    structure's shape. Integers wide enough to be a job or run id are flattened
+    too — they are workspace-specific handles that carry no finding."""
+    if isinstance(value, str):
+        return redact(value)
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return PLACEHOLDER_LONG_ID if abs(value) >= 10**11 else value
+    if isinstance(value, dict):
+        return {redact(str(k)): redact_tree(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [redact_tree(v) for v in value]
+    return value
 
 
 def write_result(
@@ -302,19 +393,22 @@ def write_result(
     else:
         payload = {"rows": {}}
 
-    payload["rows"][row_id] = json.loads(
-        redact(
-            json.dumps(
-                {
-                    "question": question,
-                    "status": status,
-                    "finding": finding,
-                    "evidence": evidence,
-                    "recorded_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
-                }
-            )
+    # json round-trip first so anything the SDK handed back (enums, dataclasses)
+    # becomes plain data, then redact the tree. Redacting the *serialised* form
+    # is what broke this once — see `redact`.
+    row = json.loads(
+        json.dumps(
+            {
+                "question": question,
+                "status": status,
+                "finding": finding,
+                "evidence": evidence,
+                "recorded_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            },
+            default=str,
         )
     )
+    payload["rows"][row_id] = redact_tree(row)
     payload["environment"] = environment_shape()
     RESULTS_PATH.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
     ok(f"recorded row {row_id}: {status}")
@@ -333,4 +427,7 @@ def environment_shape() -> dict[str, str]:
         "unity_catalog": "enabled",
         "caller_identity": "OAuth M2M service principal, workspace user (non-admin)",
         "author_identity": "workspace admin",
+        # Row 11 is a claim about this posture rather than about the platform, so
+        # the posture belongs in the record next to the rows it explains.
+        "network": "IP access lists enabled (allow lists not covering serverless egress)",
     }

--- a/experiments/udf_privilege_delegation/scripts/delegation/08_connection_definer_vs_invoker.py
+++ b/experiments/udf_privilege_delegation/scripts/delegation/08_connection_definer_vs_invoker.py
@@ -1,0 +1,162 @@
+"""Row 8 — does a connection privilege resolve as definer, the way table SELECT did?
+
+Row 1 established that a UC SQL UDF is a real privilege boundary for *data*: the
+caller read a table it had been refused, through a function it merely held
+EXECUTE on. This row asks whether that property extends to a Unity Catalog
+**connection** — the platform's own primitive for holding a credential somewhere
+the caller cannot read it.
+
+If it does, the shape the original proposal wanted actually exists: an admin owns
+a connection carrying the credential, writes a SQL UDF that calls http_request()
+against it with the method and path fixed, and grants callers nothing but
+EXECUTE. The caller gets one shaped action and is never trusted with a secret.
+
+If it does not — if the platform re-checks the connection privilege against the
+invoker — then the connection is not a wrapping primitive at all. Whoever can
+use it through the function can use it directly, at any method and path they
+choose, and the author's fixed shape constrains nothing.
+
+Two measurements, and the control is what makes the row mean anything:
+
+  control     the caller calls http_request() on the connection *directly*.
+              It must be refused. Without that, a successful call through the
+              function is indistinguishable from the caller having held the
+              privilege all along — the same mistake trap 1 records about the
+              identity of the caller itself.
+  measurement the same caller invokes the admin-owned function.
+
+Scoring note: Unity Catalog reports this refusal as ``status_code = 403`` inside
+a *successful* statement rather than as a SQL error, so both calls are
+classified by ``http_request_outcome`` on the body of the response, not on
+whether the statement ran. See trap 4 in the evidence trail.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _common import (  # noqa: E402
+    CONNECTION_NAME,
+    FQ_SCHEMA,
+    admin_client,
+    assert_distinct_identities,
+    fail,
+    info,
+    lowpriv_client,
+    ok,
+    section,
+    step,
+    write_result,
+)
+from _delegation_common import http_request_outcome  # noqa: E402
+
+ROW = "8"
+QUESTION = (
+    "Does a UC SQL UDF resolve the USE CONNECTION privilege on an admin-owned "
+    "connection as definer, the way it resolves table SELECT?"
+)
+
+DIRECT_CALL = (
+    f"SELECT to_json(http_request(conn => '{CONNECTION_NAME}', method => 'GET', path => ''))"
+)
+VIA_FUNCTION = f"SELECT {FQ_SCHEMA}.f_sql_http_via_connection()"
+
+
+def _describe(label: str, result: dict) -> None:
+    if result["allowed"]:
+        ok(f"{label}: allowed (status_code {result['status_code']})")
+    elif result["denied_by_unity_catalog"]:
+        info(f"{label}: refused by Unity Catalog (status_code {result['status_code']})")
+    else:
+        fail(f"{label}: neither allowed nor a recognisable refusal — {result}")
+
+
+def main() -> int:
+    section(f"row {ROW}: connection privilege — definer or invoker?")
+    admin = admin_client()
+    caller = lowpriv_client()
+    admin_who, caller_who = assert_distinct_identities(admin, caller)
+    info(f"author={admin_who}  caller={caller_who}")
+
+    step("control: admin calls http_request() directly (proves the connection works at all)")
+    admin_direct = http_request_outcome(admin, DIRECT_CALL)
+    _describe("admin direct", admin_direct)
+
+    step("control: caller calls http_request() directly (must be refused)")
+    caller_direct = http_request_outcome(caller, DIRECT_CALL)
+    _describe("caller direct", caller_direct)
+
+    step("measurement: caller invokes the admin-owned function that wraps it")
+    caller_via_fn = http_request_outcome(caller, VIA_FUNCTION)
+    _describe("caller via function", caller_via_fn)
+
+    evidence = {
+        "admin_direct_call": admin_direct,
+        "caller_direct_call": caller_direct,
+        "caller_via_function": caller_via_fn,
+    }
+
+    if not admin_direct["allowed"]:
+        write_result(
+            ROW,
+            question=QUESTION,
+            status="inconclusive",
+            finding=(
+                "Could not isolate the question: the connection did not work for its "
+                "own owner, so neither the control nor the measurement says anything "
+                "about how the privilege resolves."
+            ),
+            evidence=evidence,
+        )
+    elif not caller_direct["denied_by_unity_catalog"]:
+        write_result(
+            ROW,
+            question=QUESTION,
+            status="inconclusive",
+            finding=(
+                "Could not isolate the question: the caller was not refused the "
+                "connection directly, so using it through the function is not "
+                "evidence of definer's rights."
+            ),
+            evidence=evidence,
+        )
+    elif caller_via_fn["allowed"]:
+        write_result(
+            ROW,
+            question=QUESTION,
+            status="pass",
+            finding=(
+                "Definer. The caller was refused the connection directly and then "
+                "used it through the admin-owned function holding nothing but "
+                "EXECUTE. The connection privilege resolves against the function's "
+                "owner, exactly as table SELECT did in row 1."
+            ),
+            evidence=evidence,
+        )
+    else:
+        write_result(
+            ROW,
+            question=QUESTION,
+            status="fail",
+            finding=(
+                "Invoker. The caller holds EXECUTE on the admin-owned function and "
+                "was refused anyway, with the same message it got calling the "
+                "connection directly — 'User is missing USE CONNECTION on "
+                f"{CONNECTION_NAME}', surfaced as status_code "
+                f"{caller_via_fn['status_code']} inside a successful statement. "
+                "Unity Catalog re-checks the connection privilege against the "
+                "invoker, so wrapping http_request() in a SQL UDF confers nothing. "
+                "Definer's rights cover the objects the body reads, not the "
+                "connection the body calls out through."
+            ),
+            evidence=evidence,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/udf_privilege_delegation/scripts/delegation/09_connection_credential_readable_by_caller.py
+++ b/experiments/udf_privilege_delegation/scripts/delegation/09_connection_credential_readable_by_caller.py
@@ -1,0 +1,184 @@
+"""Row 9 — does a connection hide its credential from the principals granted it?
+
+This is row 6 asked of the other primitive. Row 6 killed the embedded-credential
+workaround: a caller holding only EXECUTE read the function body, sentinel and
+all, through DESCRIBE FUNCTION EXTENDED and information_schema.routines. The
+whole reason to reach for a connection instead is the claim that Unity Catalog
+stores the secret somewhere the grantee cannot read.
+
+Row 8 showed the grantee has to be given USE CONNECTION for the connection to be
+usable at all, so the population that can read it is exactly the population that
+can use it. That makes this the load-bearing question for the entire connection
+family: if USE CONNECTION also discloses the token, the connection is row 6 with
+a nicer name.
+
+The caller is granted USE CONNECTION *first* — with a control proving the grant
+took effect — and then every read path is probed for the sentinel the connection
+was created with.
+
+A negative here is scoped to the paths actually probed. It is not a proof that
+no read path exists, and the finding says so.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _common import (  # noqa: E402
+    CONNECTION_NAME,
+    CONNECTION_SENTINEL_TOKEN,
+    admin_client,
+    assert_distinct_identities,
+    fail,
+    info,
+    lowpriv_client,
+    ok,
+    run_sql,
+    run_sql_or_die,
+    section,
+    step,
+    write_result,
+)
+from _delegation_common import http_request_outcome  # noqa: E402
+
+ROW = "9"
+QUESTION = (
+    "Can a caller granted USE CONNECTION read the credential the connection stores?"
+)
+
+DIRECT_CALL = (
+    f"SELECT to_json(http_request(conn => '{CONNECTION_NAME}', method => 'GET', path => ''))"
+)
+
+
+def _sdk_read(caller) -> dict:
+    """The REST path the SQL probes do not cover: GET /connections/{name}."""
+    try:
+        conn = caller.connections.get(name=CONNECTION_NAME)
+        blob = json.dumps(conn.as_dict(), default=str)
+        return {"succeeded": True, "response": blob[:800], "sentinel_visible_to_caller": CONNECTION_SENTINEL_TOKEN in blob}
+    except Exception as exc:  # noqa: BLE001 - the refusal is the evidence
+        return {
+            "succeeded": False,
+            "error_type": type(exc).__name__,
+            "error": str(exc)[:400],
+            "sentinel_visible_to_caller": CONNECTION_SENTINEL_TOKEN in str(exc),
+        }
+
+
+def main() -> int:
+    section(f"row {ROW}: is the connection's credential readable by its grantees?")
+    admin = admin_client()
+    caller = lowpriv_client()
+    admin_who, caller_who = assert_distinct_identities(admin, caller)
+    info(f"author={admin_who}  caller={caller_who}")
+
+    step("granting the caller USE CONNECTION (row 8 proved it needs this to use it at all)")
+    run_sql_or_die(
+        admin, f"GRANT USE CONNECTION ON CONNECTION `{CONNECTION_NAME}` TO `{caller_who}`"
+    )
+    ok("USE CONNECTION granted")
+
+    step("control: the grant took effect — the caller can now use the connection")
+    control = http_request_outcome(caller, DIRECT_CALL)
+    if control["allowed"]:
+        ok(f"caller's direct call now allowed (status_code {control['status_code']})")
+    else:
+        fail("the grant did not take effect; the read probes below would prove nothing")
+
+    read_paths = {
+        "describe_connection": f"DESCRIBE CONNECTION `{CONNECTION_NAME}`",
+        "show_connections": "SHOW CONNECTIONS",
+        "information_schema_connections": (
+            "SELECT * FROM system.information_schema.connections "
+            f"WHERE connection_name = '{CONNECTION_NAME}'"
+        ),
+    }
+
+    evidence: dict[str, object] = {"grant_control": control}
+    leaked_via = []
+
+    for name, stmt in read_paths.items():
+        step(f"caller attempts: {name}")
+        outcome = run_sql(caller, stmt)
+        blob = " ".join(" ".join(str(c) for c in row) for row in outcome.rows)
+        leaked = CONNECTION_SENTINEL_TOKEN in blob
+        evidence[name] = {
+            "statement": stmt,
+            "succeeded": outcome.succeeded,
+            "error_code": outcome.error_code,
+            "error": outcome.error,
+            "row_count": len(outcome.rows),
+            "sentinel_visible_to_caller": leaked,
+        }
+        if leaked:
+            leaked_via.append(name)
+            fail("the stored credential is visible to the caller through this path")
+        elif outcome.succeeded:
+            ok(f"allowed, {len(outcome.rows)} row(s), no credential in the output")
+        else:
+            ok(f"refused: {outcome.error_code}")
+
+    step("caller attempts: connections REST API (GET /unity-catalog/connections/{name})")
+    sdk = _sdk_read(caller)
+    evidence["connections_rest_api"] = sdk
+    if sdk["sentinel_visible_to_caller"]:
+        leaked_via.append("connections_rest_api")
+        fail("the stored credential came back through the REST API")
+    elif sdk["succeeded"]:
+        ok("allowed, but the response carried no credential")
+    else:
+        ok(f"refused: {sdk.get('error_type')}")
+
+    if leaked_via:
+        write_result(
+            ROW,
+            question=QUESTION,
+            status="fail",
+            finding=(
+                "The connection discloses its credential to the principals granted "
+                f"USE CONNECTION, via {', '.join(leaked_via)}. That is row 6 with a "
+                "different object: the population that can use the connection can "
+                "also extract what it holds, so the connection narrows nothing."
+            ),
+            evidence=evidence,
+        )
+    elif not control["allowed"]:
+        write_result(
+            ROW,
+            question=QUESTION,
+            status="inconclusive",
+            finding=(
+                "Could not isolate the question: the USE CONNECTION grant did not "
+                "take effect, so it is not established that the read paths were "
+                "probed by a principal that actually held the privilege."
+            ),
+            evidence=evidence,
+        )
+    else:
+        write_result(
+            ROW,
+            question=QUESTION,
+            status="pass",
+            finding=(
+                "The credential stays hidden. The caller held USE CONNECTION and "
+                "demonstrably used the connection, and none of DESCRIBE CONNECTION, "
+                "SHOW CONNECTIONS, system.information_schema.connections, or the "
+                "connections REST API returned the sentinel the connection was "
+                "created with — DESCRIBE reports 'auth_scheme -> bearer' and the "
+                "host, and stops there. This is the one property the embedded-"
+                "credential workaround could not provide (row 6). Scoped to the "
+                "paths probed; not a proof that no read path exists."
+            ),
+            evidence=evidence,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/udf_privilege_delegation/scripts/delegation/10_connection_grant_blast_radius.py
+++ b/experiments/udf_privilege_delegation/scripts/delegation/10_connection_grant_blast_radius.py
@@ -1,0 +1,158 @@
+"""Row 10 — how wide is USE CONNECTION? What does the grant actually authorise?
+
+Row 8 forced the caller to hold USE CONNECTION directly, and row 9 established
+that holding it does not disclose the credential. Those two together define the
+only usable shape for the connection family: the caller is granted the
+connection, and the author hopes a wrapper function keeps the caller to one
+action.
+
+This row asks what that grant is actually scoped to. The author's function fixes
+a method (GET) and a path (the connection root). If USE CONNECTION is scoped to
+the *connection* rather than to the author's chosen call, the caller can ignore
+the function entirely and issue any request under the connection's base_path —
+and every shape constraint the author thought they were enforcing is decoration.
+
+The distinction the probes turn on is the one trap 3 records: a status code from
+the origin is proof the platform let the request out. A 404 from example.com for
+a path the author never blessed is a *stronger* result than a 200, because it
+can only have come from the far end.
+
+The last probe is the constraint that does exist — the connection pins one host
+and one base_path, and the documentation says traversal above it is rejected.
+Measuring where the boundary really is matters as much as measuring that it is
+too wide.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _common import (  # noqa: E402
+    CONNECTION_NAME,
+    admin_client,
+    assert_distinct_identities,
+    fail,
+    info,
+    lowpriv_client,
+    ok,
+    section,
+    step,
+    write_result,
+)
+from _delegation_common import http_request_outcome  # noqa: E402
+
+ROW = "10"
+QUESTION = (
+    "Is USE CONNECTION scoped to the call the author's function makes, or to the "
+    "whole connection?"
+)
+
+
+def _call(method: str, path: str) -> str:
+    return (
+        f"SELECT to_json(http_request(conn => '{CONNECTION_NAME}', "
+        f"method => '{method}', path => '{path}'))"
+    )
+
+
+# The author's function makes exactly one of these. Every other entry is a call
+# the author never wrote and never intended to expose.
+PROBES = {
+    "author_blessed_call__GET_root": ("GET", ""),
+    "unblessed_path__GET_other": ("GET", "some/other/resource"),
+    "unblessed_method__POST_root": ("POST", ""),
+    "unblessed_method__DELETE_root": ("DELETE", ""),
+    "escape_above_base_path": ("GET", "../../etc/passwd"),
+}
+
+
+def main() -> int:
+    section(f"row {ROW}: what does USE CONNECTION authorise?")
+    admin = admin_client()
+    caller = lowpriv_client()
+    admin_who, caller_who = assert_distinct_identities(admin, caller)
+    info(f"author={admin_who}  caller={caller_who}")
+    info("the caller holds USE CONNECTION, granted by row 9")
+
+    evidence: dict[str, object] = {}
+    reached_origin = []
+    refused_by_uc = []
+    blocked_by_validation = []
+
+    for label, (method, path) in PROBES.items():
+        step(f"caller attempts: {method} {path or '<connection root>'}")
+        result = http_request_outcome(caller, _call(method, path))
+        result["method"] = method
+        result["path"] = path
+        evidence[label] = result
+
+        if "INVALID_HTTP_REQUEST_PATH" in (result["error"] or ""):
+            # Not an authorization decision — http_request() rejects the argument
+            # before any privilege is consulted. Worth separating: it is the one
+            # place the connection's base_path really does bound the caller.
+            blocked_by_validation.append(label)
+            result["refusal_kind"] = "input validation (path traversal)"
+            ok("rejected before dispatch: path traversal above base_path is not allowed")
+        elif result["denied_by_unity_catalog"]:
+            refused_by_uc.append(label)
+            result["refusal_kind"] = "unity catalog authorization"
+            ok("refused by Unity Catalog")
+        elif result["statement_succeeded"] and result["status_code"]:
+            # Any status code from the far end means Unity Catalog let it out.
+            reached_origin.append(label)
+            info(
+                f"permitted — the origin answered {result['status_code']}, so the "
+                "platform allowed a call the author never wrote"
+            )
+        else:
+            fail(f"neither a refusal nor an origin response: {result}")
+
+    unblessed_reached = [x for x in reached_origin if not x.startswith("author_blessed")]
+
+    if unblessed_reached:
+        write_result(
+            ROW,
+            question=QUESTION,
+            status="fail",
+            finding=(
+                "USE CONNECTION is scoped to the connection, not to the author's "
+                f"call. Holding it, the caller reached the origin on {len(unblessed_reached)} "
+                "request shapes the author's function never makes "
+                f"({', '.join(unblessed_reached)}) — different paths and different "
+                "methods, each answered by the far end rather than refused by the "
+                "platform. The wrapper function's fixed method and path are therefore "
+                "not a constraint on the caller; they are a convention the caller can "
+                "decline to follow. The one boundary the connection does enforce is "
+                "its host and base_path"
+                + (
+                    " — the probe that tried to climb above base_path was rejected "
+                    "outright with INVALID_HTTP_REQUEST_PATH, before any privilege "
+                    "was consulted."
+                    if blocked_by_validation
+                    else "."
+                )
+            ),
+            evidence=evidence,
+        )
+    else:
+        write_result(
+            ROW,
+            question=QUESTION,
+            status="pass",
+            finding=(
+                "USE CONNECTION did not authorise any request shape beyond the one "
+                "the author's function makes: every unblessed method and path was "
+                "refused by the platform. On this evidence the connection is scoped "
+                "narrowly enough to carry the author's constraints."
+            ),
+            evidence=evidence,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/udf_privilege_delegation/scripts/delegation/11_control_plane_reachable_via_connection.py
+++ b/experiments/udf_privilege_delegation/scripts/delegation/11_control_plane_reachable_via_connection.py
@@ -1,0 +1,174 @@
+"""Row 11 — can http_request() reach this workspace's own control plane at all?
+
+Rows 8-10 point at example.com on purpose, so the privilege question is answered
+without a second variable in the way. This row is that second variable, measured
+on its own: the whole connection family assumes a SQL statement can call the
+Databricks SCIM API, and on a workspace with IP access lists enabled that
+assumption is worth checking before anyone designs around it.
+
+Two probes, because one of them alone is misleading in both directions:
+
+  sentinel credential   answers whether the request arrives at the control plane
+                        and is evaluated at all. A 401 here is a *good* result —
+                        it means DNS, egress and TLS all worked and the platform
+                        got as far as looking at the credential. Reading that 401
+                        as "unreachable" would be trap 3 exactly.
+  live credential       answers whether an authenticated request from this egress
+                        address is then allowed. This is where an IP access list
+                        speaks, and it cannot speak until authentication has
+                        already succeeded.
+
+Only the second probe needs a real token, and it is the author's own short-lived
+one. It is registered with the results writer so a platform error that quotes it
+cannot carry it into the repo, and the connection holding it is dropped before
+this script returns.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _common import (  # noqa: E402
+    CONNECTION_SCIM_NAME,
+    admin_client,
+    fail,
+    info,
+    ok,
+    register_secret,
+    run_sql,
+    run_sql_or_die,
+    section,
+    step,
+    write_result,
+)
+from _delegation_common import http_request_outcome  # noqa: E402
+
+ROW = "11"
+QUESTION = (
+    "Can http_request() reach this workspace's own SCIM API, or does the network "
+    "perimeter stop it first?"
+)
+
+LIVE_CONNECTION = "udf_delegation_scim_live_conn"
+
+# Markers that say an *authenticated* request was refused by the perimeter rather
+# than by authentication. An invalid-token answer names the credential; these
+# name the caller's address.
+_PERIMETER_MARKERS = ("Source IP address", "IP access", "ip_access")
+_AUTH_MARKERS = ("Credential was not sent", "invalid access token", "Invalid access token")
+
+
+def _probe(w, connection: str) -> dict:
+    return http_request_outcome(
+        w,
+        f"SELECT to_json(http_request(conn => '{connection}', method => 'GET', path => 'Me'))",
+    )
+
+
+def main() -> int:
+    section(f"row {ROW}: is the control plane reachable from http_request()?")
+    admin = admin_client()
+
+    step("probe 1: sentinel credential — does the request reach authentication?")
+    sentinel = _probe(admin, CONNECTION_SCIM_NAME)
+    sentinel_body = sentinel["body"] or sentinel["error"] or ""
+    sentinel["reached_authentication"] = any(m in sentinel_body for m in _AUTH_MARKERS)
+    if sentinel["reached_authentication"]:
+        ok(
+            f"the control plane answered {sentinel['status_code']} about the credential "
+            "— the request completed the round trip"
+        )
+    else:
+        info(f"unexpected answer to the sentinel probe: {sentinel_body[:200]}")
+
+    token = admin.config.authenticate()["Authorization"].removeprefix("Bearer ")
+    register_secret(token)
+
+    live: dict = {}
+    try:
+        step("probe 2: live credential — is an authenticated request from here allowed?")
+        run_sql(admin, f"DROP CONNECTION IF EXISTS `{LIVE_CONNECTION}`")
+        run_sql_or_die(
+            admin,
+            f"""
+CREATE CONNECTION `{LIVE_CONNECTION}` TYPE HTTP
+OPTIONS (
+  host '{admin.config.host.rstrip("/")}',
+  port '443',
+  base_path '/api/2.0/preview/scim/v2/',
+  bearer_token '{token}'
+)
+""",
+        )
+        live = _probe(admin, LIVE_CONNECTION)
+    finally:
+        run_sql(admin, f"DROP CONNECTION IF EXISTS `{LIVE_CONNECTION}`")
+        ok("live-credential connection dropped")
+
+    live_body = live.get("body") or live.get("error") or ""
+    live["refused_by_network_perimeter"] = any(m in live_body for m in _PERIMETER_MARKERS)
+
+    if live.get("allowed"):
+        ok(f"authenticated call allowed — the control plane answered {live['status_code']}")
+    elif live["refused_by_network_perimeter"]:
+        info(f"authenticated call refused at the perimeter (status_code {live['status_code']})")
+    else:
+        fail(f"refused, but not by the perimeter: {live_body[:200]}")
+
+    evidence = {"sentinel_credential_probe": sentinel, "live_credential_probe": live}
+
+    if live.get("allowed"):
+        write_result(
+            ROW,
+            question=QUESTION,
+            status="pass",
+            finding=(
+                "Reachable. An authenticated request from the address http_request() "
+                "egresses on was allowed and the SCIM API answered, so in this "
+                "environment the connection family's viability turns on the privilege "
+                "questions in rows 8-10 rather than on connectivity."
+            ),
+            evidence=evidence,
+        )
+    elif live["refused_by_network_perimeter"]:
+        write_result(
+            ROW,
+            question=QUESTION,
+            status="fail",
+            finding=(
+                "Reached, then refused. The sentinel probe came back as an answer "
+                f"about the credential ({sentinel['status_code']}), which establishes "
+                "the request completes the round trip — this is not a firewall or DNS "
+                "failure. The same call with a valid credential was then refused "
+                f"({live['status_code']}) by the workspace's IP access list, naming the "
+                "egress address http_request() presents. So on an IP-access-listed "
+                "workspace, a UC connection pointed at the workspace that hosts it is "
+                "a call that leaves and re-enters the perimeter, and the perimeter "
+                "gets a vote — independently of every privilege question. "
+                "Environment-dependent: a workspace without IP access lists, or one "
+                "whose list covers serverless egress, would not see this."
+            ),
+            evidence=evidence,
+        )
+    else:
+        write_result(
+            ROW,
+            question=QUESTION,
+            status="inconclusive",
+            finding=(
+                "The authenticated call did not succeed and its refusal could not be "
+                "attributed to the network perimeter, so this row cannot separate a "
+                "reachability problem from an authorization one. The raw responses "
+                "are in the evidence."
+            ),
+            evidence=evidence,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/udf_privilege_delegation/scripts/delegation/12_job_run_as_delegated_action.py
+++ b/experiments/udf_privilege_delegation/scripts/delegation/12_job_run_as_delegated_action.py
@@ -1,0 +1,273 @@
+"""Row 12 — can a caller holding only CAN_MANAGE_RUN cause the privileged action?
+
+This is row 4 asked of a primitive that has what the function model lacked. Row 4
+failed because the Python UDF sandbox is anonymous: it had the network and the
+code but no identity, so the control plane answered it like any stranger. A job
+runs as a named principal on compute holding that principal's credential, so the
+question becomes worth asking again — and it is the same question the customer
+started with, only pointed at a different object.
+
+Three measurements:
+
+  control     the caller creates a service principal directly, via SCIM. It must
+              be refused, or nothing that follows distinguishes delegation from
+              the caller simply having had the privilege.
+  measurement the caller triggers the job with a well-formed suffix. Success is
+              not the run finishing — it is a principal existing afterwards,
+              read back by the admin from the SCIM directory, with the name the
+              notebook composed rather than the one the caller asked for.
+  constraint  the caller triggers the job with a suffix the notebook's rules
+              reject. If that also creates something, the shape constraint is
+              decorative and this row is no better than row 7.
+
+The caller passes a suffix; the notebook prepends the prefix. Whether that
+division holds under a caller that supplies something hostile is the whole
+difference between a delegated action and a delegated credential.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from databricks.sdk.service import iam  # noqa: E402
+
+from _common import (  # noqa: E402
+    JOB_NAME,
+    JOB_SP_PREFIX,
+    admin_client,
+    assert_distinct_identities,
+    fail,
+    info,
+    lowpriv_client,
+    ok,
+    section,
+    step,
+    write_result,
+)
+
+ROW = "12"
+QUESTION = (
+    "Can a caller holding only CAN_MANAGE_RUN cause a service principal to be "
+    "created, in a shape the author fixed?"
+)
+
+GOOD_SUFFIX = "alpha"
+# Uppercase, a slash and a leading dot: rejected by the notebook's rule, and the
+# shapes someone would try if they wanted to steer the name somewhere else.
+BAD_SUFFIX = "../Evil Name"
+
+
+def _resolve_job_id(w) -> int:
+    job = next(iter(w.jobs.list(name=JOB_NAME)), None)
+    if not job or not job.job_id:
+        raise SystemExit(f"Job {JOB_NAME!r} not found — run 03_provision_delegated_job.py first.")
+    return job.job_id
+
+
+def _run_and_wait(caller, job_id: int, suffix: str, timeout_s: int = 900) -> dict:
+    """Trigger as the caller and return the task's exit payload."""
+    waiter = caller.jobs.run_now(
+        job_id=job_id, notebook_params={"suffix": suffix}
+    )
+    run_id = waiter.run_id
+    deadline = time.time() + timeout_s
+    state = None
+    while time.time() < deadline:
+        run = caller.jobs.get_run(run_id=run_id)
+        state = run.state
+        if state and state.life_cycle_state and state.life_cycle_state.value in (
+            "TERMINATED",
+            "SKIPPED",
+            "INTERNAL_ERROR",
+        ):
+            break
+        time.sleep(10)
+
+    record: dict = {
+        "suffix_supplied_by_caller": suffix,
+        "run_id": run_id,
+        "life_cycle_state": state.life_cycle_state.value if state and state.life_cycle_state else None,
+        "result_state": state.result_state.value if state and state.result_state else None,
+    }
+
+    run = caller.jobs.get_run(run_id=run_id)
+    task_run_id = run.tasks[0].run_id if run.tasks else None
+    if task_run_id:
+        output = caller.jobs.get_run_output(run_id=task_run_id)
+        record["notebook_output"] = output.notebook_output.result if output.notebook_output else None
+        record["error"] = output.error
+    return record
+
+
+def _directory_contains(admin, display_name: str) -> bool:
+    return any(
+        admin.service_principals.list(filter=f'displayName eq "{display_name}"')
+    )
+
+
+def main() -> int:
+    section(f"row {ROW}: job run-as as a delegation boundary")
+    admin = admin_client()
+    caller = lowpriv_client()
+    admin_who, caller_who = assert_distinct_identities(admin, caller)
+    info(f"author={admin_who}  caller={caller_who}")
+
+    job_id = _resolve_job_id(admin)
+    evidence: dict[str, object] = {"job_run_as": admin_who}
+
+    # A previous run leaves its principal behind, and the read-back below cannot
+    # tell "this run created it" from "last run did". Rows 4 and 7 answer the
+    # same hazard by refusing to produce a result; that would make `make matrix`
+    # non-repeatable, so this row clears its own prior output instead. The prefix
+    # is the row's own, so nothing outside the experiment can match it.
+    step("clearing principals left by a previous run of this row")
+    stale = [
+        sp
+        for sp in admin.service_principals.list()
+        if (sp.display_name or "").startswith(JOB_SP_PREFIX)
+    ]
+    for sp in stale:
+        admin.service_principals.delete(id=sp.id)
+    evidence["stale_principals_removed"] = [sp.display_name for sp in stale]
+    ok(f"removed {len(stale)}")
+
+    step("control: the caller tries to create a service principal directly")
+    try:
+        caller.service_principals.create(
+            display_name=f"{JOB_SP_PREFIX}control",
+            active=True,
+            entitlements=[iam.ComplexValue(value="workspace-access")],
+        )
+        evidence["caller_direct_scim_create"] = {"refused": False}
+        fail("the caller can create service principals directly — this row proves nothing")
+    except Exception as exc:  # noqa: BLE001 - the refusal is the evidence
+        evidence["caller_direct_scim_create"] = {
+            "refused": True,
+            "error_type": type(exc).__name__,
+            "error": str(exc)[:300],
+        }
+        ok(f"refused, as required: {type(exc).__name__}")
+
+    step(f"measurement: caller triggers the job with suffix {GOOD_SUFFIX!r}")
+    good = _run_and_wait(caller, job_id, GOOD_SUFFIX)
+    evidence["run_with_valid_suffix"] = good
+    info(f"run {good['run_id']} finished {good['result_state']}")
+    info(f"notebook output: {good.get('notebook_output')}")
+
+    expected_name = f"{JOB_SP_PREFIX}{GOOD_SUFFIX}"
+    step(f"admin reads the SCIM directory back, looking for {expected_name!r}")
+    created = _directory_contains(admin, expected_name)
+    evidence["principal_present_on_readback"] = created
+    if created:
+        ok("the principal exists — the action really happened, as the run-as identity")
+    else:
+        fail("no such principal; the run did not produce the delegated action")
+
+    step(f"constraint: caller triggers the job with suffix {BAD_SUFFIX!r}")
+    bad = _run_and_wait(caller, job_id, BAD_SUFFIX)
+    evidence["run_with_rejected_suffix"] = bad
+    info(f"notebook output: {bad.get('notebook_output')}")
+
+    rejected = False
+    try:
+        payload = json.loads(bad.get("notebook_output") or "{}")
+        rejected = payload.get("outcome") == "rejected"
+    except (TypeError, ValueError):
+        rejected = False
+    evidence["hostile_suffix_rejected"] = rejected
+
+    step("admin confirms the rejected suffix created nothing")
+    stray = [
+        sp.display_name
+        for sp in admin.service_principals.list()
+        if (sp.display_name or "").startswith(JOB_SP_PREFIX)
+    ]
+    evidence["principals_matching_prefix_after_both_runs"] = sorted(stray)
+    info(f"principals carrying the prefix: {sorted(stray)}")
+
+    caller_refused_directly = bool(
+        evidence["caller_direct_scim_create"].get("refused")  # type: ignore[union-attr]
+    )
+
+    if not caller_refused_directly:
+        write_result(
+            ROW,
+            question=QUESTION,
+            status="inconclusive",
+            finding=(
+                "Could not isolate the question: the caller can create service "
+                "principals directly, so causing one through the job is not evidence "
+                "of delegation."
+            ),
+            evidence=evidence,
+        )
+    elif not created:
+        write_result(
+            ROW,
+            question=QUESTION,
+            status="fail",
+            finding=(
+                "The caller triggered the job and no principal existed afterwards. "
+                f"Run finished {good.get('result_state')}; the notebook returned "
+                f"{good.get('notebook_output')!r}. The job route did not deliver the "
+                "delegated action in this environment."
+            ),
+            evidence=evidence,
+        )
+    elif not rejected:
+        write_result(
+            ROW,
+            question=QUESTION,
+            status="partial",
+            finding=(
+                "The delegated action works but its shape does not hold: the caller "
+                "caused a principal to be created through the job, and the suffix the "
+                "notebook was supposed to reject was not rejected. The mechanism "
+                "delegates the action; this implementation of the constraint does not "
+                f"constrain it. Directory after both runs: {sorted(stray)}."
+            ),
+            evidence=evidence,
+        )
+    elif sorted(stray) != [expected_name]:
+        write_result(
+            ROW,
+            question=QUESTION,
+            status="inconclusive",
+            finding=(
+                "The delegated action happened and the hostile suffix was rejected, "
+                "but the directory does not match what the two runs should have "
+                f"produced: expected exactly {[expected_name]}, found {sorted(stray)}. "
+                "Something outside these two runs is creating principals under the "
+                "same prefix, so the shape claim cannot be attributed to this row."
+            ),
+            evidence=evidence,
+        )
+    else:
+        write_result(
+            ROW,
+            question=QUESTION,
+            status="pass",
+            finding=(
+                "The job is a real delegation boundary. The caller was refused the "
+                "SCIM create directly, then triggered a job it holds only "
+                "CAN_MANAGE_RUN on and a service principal existed afterwards — "
+                f"named {expected_name!r}, composed by the notebook from a prefix the "
+                "caller never supplied. The hostile suffix was rejected by the "
+                "notebook's own rule and created nothing, so the shape constraint is "
+                "enforced by code running as the privileged identity rather than by "
+                "trusting the caller. No credential passed through the caller's hands "
+                "at any point: the job's identity lives on the compute, not in "
+                "anything the caller can read (contrast rows 6-7)."
+            ),
+            evidence=evidence,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/udf_privilege_delegation/scripts/delegation/13_job_manage_run_boundary.py
+++ b/experiments/udf_privilege_delegation/scripts/delegation/13_job_manage_run_boundary.py
@@ -1,0 +1,202 @@
+"""Row 13 — what does CAN_MANAGE_RUN *not* let the caller do?
+
+Row 12 shows the job delivers the delegated action. That is only half the claim.
+Row 6 is the reminder why: the embedded-credential wrapper also delivered the
+action, and was still worthless, because the permission that let a caller invoke
+it also let them read what it contained. A delegation boundary is defined by
+what the grant withholds, not by what it permits.
+
+So this row probes the edges of CAN_MANAGE_RUN as the caller:
+
+  edit the task        can the caller repoint the job at different code?
+  change run-as        can the caller swap the identity the job executes as?
+  regrant itself       can the caller give itself CAN_MANAGE?
+  read the source      can the caller read the notebook the job runs — the row 6
+                       question, asked of the object that now holds the logic?
+  read run output      can the caller read what a run returned?
+
+The last one is expected to succeed, and it is not a defect — it is the
+operational rule that falls out of the design. Whoever can trigger a run can
+read what that run printed, so the job's output is part of the caller's
+attack surface even though its credential is not. Anything the job prints, the
+caller reads.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from databricks.sdk.service import jobs  # noqa: E402
+
+from _common import (  # noqa: E402
+    JOB_NAME,
+    admin_client,
+    assert_distinct_identities,
+    fail,
+    info,
+    lowpriv_client,
+    ok,
+    section,
+    step,
+    write_result,
+)
+
+ROW = "13"
+QUESTION = (
+    "Does CAN_MANAGE_RUN withhold the ability to change what the job does, who it "
+    "runs as, and what code it executes?"
+)
+
+
+def _attempt(label: str, fn) -> dict:
+    """Run one probe; a refusal is the result, not an error."""
+    try:
+        fn()
+        return {"refused": False, "note": "the caller was allowed to do this"}
+    except Exception as exc:  # noqa: BLE001 - the refusal is the evidence
+        return {
+            "refused": True,
+            "error_type": type(exc).__name__,
+            "error": str(exc)[:300],
+        }
+
+
+def main() -> int:
+    section(f"row {ROW}: the edges of CAN_MANAGE_RUN")
+    admin = admin_client()
+    caller = lowpriv_client()
+    admin_who, caller_who = assert_distinct_identities(admin, caller)
+    info(f"author={admin_who}  caller={caller_who}")
+
+    job = next(iter(admin.jobs.list(name=JOB_NAME)), None)
+    if not job or not job.job_id:
+        raise SystemExit(f"Job {JOB_NAME!r} not found — run 03_provision_delegated_job.py first.")
+    job_id = job.job_id
+    settings = admin.jobs.get(job_id=job_id).settings
+    notebook_path = settings.tasks[0].notebook_task.notebook_path  # type: ignore[union-attr,index]
+
+    evidence: dict[str, object] = {"job_id_probed": "redacted-by-shape", "run_as": admin_who}
+    must_refuse = {}
+
+    step("caller attempts: repoint the job's task at different code")
+    must_refuse["edit_task"] = _attempt(
+        "edit_task",
+        lambda: caller.jobs.update(
+            job_id=job_id,
+            new_settings=jobs.JobSettings(
+                tasks=[
+                    jobs.Task(
+                        task_key="create_service_principal",
+                        notebook_task=jobs.NotebookTask(notebook_path="/Shared/not_the_authors_code"),
+                    )
+                ]
+            ),
+        ),
+    )
+
+    step("caller attempts: change the identity the job runs as")
+    must_refuse["change_run_as"] = _attempt(
+        "change_run_as",
+        lambda: caller.jobs.update(
+            job_id=job_id,
+            new_settings=jobs.JobSettings(
+                run_as=jobs.JobRunAs(service_principal_name=caller_who)
+            ),
+        ),
+    )
+
+    step("caller attempts: grant itself CAN_MANAGE on the job")
+    must_refuse["regrant_self"] = _attempt(
+        "regrant_self",
+        lambda: caller.jobs.update_permissions(
+            job_id=str(job_id),
+            access_control_list=[
+                jobs.JobAccessControlRequest(
+                    service_principal_name=caller_who,
+                    permission_level=jobs.JobPermissionLevel.CAN_MANAGE,
+                )
+            ],
+        ),
+    )
+
+    step("caller attempts: read the notebook the job runs (the row 6 question)")
+    must_refuse["read_source"] = _attempt(
+        "read_source", lambda: caller.workspace.export(path=notebook_path)
+    )
+
+    for label, result in must_refuse.items():
+        if result["refused"]:
+            ok(f"{label}: refused ({result.get('error_type')})")
+        else:
+            fail(f"{label}: ALLOWED — the grant does not withhold this")
+    evidence["withheld_probes"] = must_refuse
+
+    step("caller attempts: read the output of a run it triggered (expected to succeed)")
+    runs = list(caller.jobs.list_runs(job_id=job_id, limit=1))
+    output_readable = None
+    if runs and runs[0].run_id:
+        run = caller.jobs.get_run(run_id=runs[0].run_id)
+        task_run_id = run.tasks[0].run_id if run.tasks else None
+        if task_run_id:
+            probe = _attempt(
+                "read_run_output", lambda: caller.jobs.get_run_output(run_id=task_run_id)
+            )
+            output_readable = not probe["refused"]
+            evidence["read_run_output"] = probe
+            if output_readable:
+                info("allowed — anything the job prints is readable by whoever triggers it")
+            else:
+                info("refused")
+
+    all_withheld = all(r["refused"] for r in must_refuse.values())
+    allowed = [k for k, v in must_refuse.items() if not v["refused"]]
+
+    if all_withheld:
+        write_result(
+            ROW,
+            question=QUESTION,
+            status="pass",
+            finding=(
+                "CAN_MANAGE_RUN withholds every probed way of changing what the job "
+                "does. The caller could not repoint the task, could not change the "
+                "run-as identity, could not grant itself CAN_MANAGE, and could not "
+                "read the notebook the job executes — the last being the question "
+                "that killed the embedded-credential wrapper in row 6, answered the "
+                "other way here. (The source read is refused as ResourceDoesNotExist "
+                "rather than PermissionDenied: the workspace hides the object's "
+                "existence instead of naming it. Still a refusal, but it is an "
+                "existence answer, not an authorization one.) The one thing it does "
+                "grant is reading the output of runs it triggers"
+                + (
+                    ", confirmed live: whatever the job prints, the caller reads, so "
+                    "job output is part of the caller's surface even though the job's "
+                    "credential is not."
+                    if output_readable
+                    else "."
+                )
+                + " Scoped to the probes listed; not a proof that no other edit path "
+                "exists."
+            ),
+            evidence=evidence,
+        )
+    else:
+        write_result(
+            ROW,
+            question=QUESTION,
+            status="fail",
+            finding=(
+                "CAN_MANAGE_RUN does not withhold what the delegation depends on: the "
+                f"caller was allowed to {', '.join(allowed)}. A caller who can change "
+                "what the job does holds the run-as identity's privileges in full, not "
+                "the one action the author intended to expose."
+            ),
+            evidence=evidence,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/udf_privilege_delegation/scripts/delegation/14_definer_procedure_vs_connection.py
+++ b/experiments/udf_privilege_delegation/scripts/delegation/14_definer_procedure_vs_connection.py
@@ -1,0 +1,189 @@
+"""Row 14 — does an explicit SQL SECURITY DEFINER procedure change row 8's answer?
+
+Row 8 measured a SQL *function*, where definer's rights are implicit in the
+object type. Databricks also has stored procedures, and there the security mode
+is a required clause — `CREATE PROCEDURE` refuses to compile without
+`SQL SECURITY DEFINER` or `SQL SECURITY INVOKER`. An author who writes DEFINER
+has said, in the object definition, exactly the thing row 8 found the function
+model would not do. Whether the platform honours it for a *connection* is a
+different question from whether it honours it for a table, and it is cheap to
+ask, so it gets asked rather than assumed.
+
+The row is deliberately three-way, because there turn out to be three distinct
+answers and collapsing any two of them would lose the finding:
+
+  admin CALL      the owner invoking their own procedure — the control that says
+                  the procedure and the connection both work.
+  caller direct   the caller calling http_request() itself, with USE CONNECTION
+                  revoked — the control that says the caller is unprivileged.
+  caller CALL     the measurement.
+
+This row revokes USE CONNECTION from the caller (row 9 grants it) and restores it
+before returning, so rows 9-10 stay reproducible in any order.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _common import (  # noqa: E402
+    CONNECTION_NAME,
+    FQ_SCHEMA,
+    admin_client,
+    assert_distinct_identities,
+    fail,
+    info,
+    lowpriv_client,
+    ok,
+    run_sql,
+    section,
+    step,
+    write_result,
+)
+from _delegation_common import http_request_outcome  # noqa: E402
+
+ROW = "14"
+QUESTION = (
+    "Does a SQL SECURITY DEFINER stored procedure resolve the connection privilege "
+    "as definer, where the SQL UDF did not?"
+)
+
+DIRECT_CALL = (
+    f"SELECT to_json(http_request(conn => '{CONNECTION_NAME}', method => 'GET', path => ''))"
+)
+PROCEDURE_CALL = f"CALL {FQ_SCHEMA}.p_http_via_connection()"
+
+# The refusal row 8 saw: Unity Catalog declining the connection outright.
+_UC_REFUSAL = "USE CONNECTION"
+# A different refusal: the connection resolved, but no credential was presented.
+_CREDENTIAL_MARKERS = ("Credential was not sent", "unsupported type for this API")
+
+
+def main() -> int:
+    section(f"row {ROW}: definer-rights procedure against a connection")
+    admin = admin_client()
+    caller = lowpriv_client()
+    admin_who, caller_who = assert_distinct_identities(admin, caller)
+    info(f"author={admin_who}  caller={caller_who}")
+
+    step("revoking USE CONNECTION from the caller so the question is the procedure's")
+    revoked = run_sql(
+        admin, f"REVOKE USE CONNECTION ON CONNECTION `{CONNECTION_NAME}` FROM `{caller_who}`"
+    )
+    info(f"revoke reported: {'ok' if revoked.succeeded else revoked.error_code}")
+
+    try:
+        step("control: admin CALLs its own procedure")
+        admin_call = http_request_outcome(admin, PROCEDURE_CALL)
+        if admin_call["allowed"]:
+            ok(f"allowed (status_code {admin_call['status_code']})")
+        else:
+            fail(f"the owner's own CALL did not work: {admin_call}")
+
+        step("control: caller calls http_request() directly (must be refused)")
+        caller_direct = http_request_outcome(caller, DIRECT_CALL)
+        if caller_direct["denied_by_unity_catalog"]:
+            ok("refused, as required — the caller holds nothing on the connection")
+        else:
+            fail("the caller was not refused; this row cannot isolate its question")
+
+        step("measurement: caller CALLs the definer-rights procedure")
+        caller_call = http_request_outcome(caller, PROCEDURE_CALL)
+        caller_body = caller_call["body"] or caller_call["error"] or ""
+        caller_call["refused_for_missing_use_connection"] = _UC_REFUSAL in caller_body
+        caller_call["failed_at_credential_resolution"] = any(
+            m in caller_body for m in _CREDENTIAL_MARKERS
+        )
+        if caller_call["allowed"]:
+            ok(f"allowed (status_code {caller_call['status_code']})")
+        elif caller_call["refused_for_missing_use_connection"]:
+            info("refused for missing USE CONNECTION — same answer as the UDF")
+        elif caller_call["failed_at_credential_resolution"]:
+            info(
+                f"not refused for missing USE CONNECTION; failed at credential "
+                f"resolution instead (status_code {caller_call['status_code']})"
+            )
+        else:
+            info(f"refused, unclassified: {caller_body[:200]}")
+    finally:
+        run_sql(
+            admin,
+            f"GRANT USE CONNECTION ON CONNECTION `{CONNECTION_NAME}` TO `{caller_who}`",
+        )
+        ok("USE CONNECTION restored to the caller")
+
+    evidence = {
+        "admin_call": admin_call,
+        "caller_direct_call": caller_direct,
+        "caller_call": caller_call,
+    }
+
+    if not admin_call["allowed"] or not caller_direct["denied_by_unity_catalog"]:
+        write_result(
+            ROW,
+            question=QUESTION,
+            status="inconclusive",
+            finding=(
+                "Could not isolate the question: either the procedure did not work "
+                "for its own owner, or the caller was not actually unprivileged on "
+                "the connection."
+            ),
+            evidence=evidence,
+        )
+    elif caller_call["allowed"]:
+        write_result(
+            ROW,
+            question=QUESTION,
+            status="pass",
+            finding=(
+                "A SQL SECURITY DEFINER procedure does what the SQL UDF would not: "
+                "the caller, refused the connection directly, completed the same call "
+                "through the procedure holding only EXECUTE. Row 8's answer is a "
+                "property of the function object, not of connections."
+            ),
+            evidence=evidence,
+        )
+    elif caller_call["failed_at_credential_resolution"]:
+        write_result(
+            ROW,
+            question=QUESTION,
+            status="partial",
+            finding=(
+                "The procedure changes the answer without delivering the outcome. The "
+                "caller was NOT refused for missing USE CONNECTION — the refusal row 8 "
+                "produced through the UDF — so the definer clause is honoured far "
+                "enough to get past that check. The call then failed at credential "
+                f"resolution: status_code {caller_call['status_code']}, 'Credential was "
+                "not sent or was of an unsupported type', a platform-shaped message "
+                "carrying a Databricks request id rather than anything the target host "
+                "would say. The definer-rights procedure therefore resolves the "
+                "connection but does not present its credential, which is neither a "
+                "working delegation nor the same refusal as the function. Treat this "
+                "as a measured behaviour of one workspace on one date, not as a "
+                "documented contract: nothing in the public documentation describes "
+                "this path, and it is the kind of edge that changes without notice."
+            ),
+            evidence=evidence,
+        )
+    else:
+        write_result(
+            ROW,
+            question=QUESTION,
+            status="fail",
+            finding=(
+                "Same answer as the SQL UDF. The definer-rights procedure was refused "
+                "for the caller's missing USE CONNECTION, so the connection privilege "
+                "is re-checked against the invoker regardless of the object wrapping "
+                "the call or of an explicit SQL SECURITY DEFINER clause."
+            ),
+            evidence=evidence,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/udf_privilege_delegation/scripts/delegation/_delegation_common.py
+++ b/experiments/udf_privilege_delegation/scripts/delegation/_delegation_common.py
@@ -11,6 +11,62 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from _common import FQ_SCHEMA, SqlOutcome, run_sql  # noqa: E402
 
+# Unity Catalog refuses a connection the caller lacks USE CONNECTION on by
+# returning a 403 *inside* an otherwise successful statement, in the struct
+# http_request() hands back — not by failing the statement. Scoring on
+# `outcome.succeeded` therefore reads an authorization refusal as a working
+# call, which is trap 3 wearing a different hat: an HTTP-shaped answer is not
+# proof that the thing the HTTP status describes was allowed.
+_DENIAL_MARKERS = ("PERMISSION_DENIED", "USE CONNECTION", "INSUFFICIENT_PERMISSIONS")
+
+
+def http_request_outcome(w, sql: str) -> dict[str, Any]:
+    """Run a statement whose single column is an http_request() struct, and
+    classify the result as allowed, denied-by-Unity-Catalog, or statement error.
+
+    ``sql`` must select the struct itself (``SELECT http_request(...) AS r``) so
+    both halves of the answer — the status code and the body carrying the
+    refusal — survive to the classifier.
+    """
+    outcome = run_sql(w, sql)
+    if not outcome.succeeded:
+        # A statement-level refusal is still a refusal; UC raises this shape when
+        # the object cannot be resolved at all rather than when the call is denied.
+        denied = any(m in (outcome.error or "") for m in _DENIAL_MARKERS)
+        return {
+            "statement_succeeded": False,
+            "status_code": None,
+            "body": None,
+            "error_code": outcome.error_code,
+            "error": outcome.error,
+            "denied_by_unity_catalog": denied,
+            "allowed": False,
+        }
+
+    try:
+        payload = json.loads(outcome.scalar)
+        status_code = str(payload.get("status_code"))
+        body = str(payload.get("text", ""))
+    except (TypeError, ValueError):
+        status_code, body = None, str(outcome.scalar)
+
+    denied = any(m in body for m in _DENIAL_MARKERS)
+    return {
+        "statement_succeeded": True,
+        "status_code": status_code,
+        "body": _clip(body),
+        "error_code": None,
+        "error": None,
+        "denied_by_unity_catalog": denied,
+        # Allowed means the platform let the request out and the origin answered.
+        "allowed": not denied and status_code == "200",
+    }
+
+
+def _clip(text: str, limit: int = 500) -> str:
+    text = " ".join(text.split())
+    return text if len(text) <= limit else text[:limit] + " ...[truncated]"
+
 
 def call_function(w, fn: str, *args: str) -> SqlOutcome:
     """Invoke a function in the experiment schema with string literal args."""

--- a/experiments/udf_privilege_delegation/scripts/setup/02_provision_connection.py
+++ b/experiments/udf_privilege_delegation/scripts/setup/02_provision_connection.py
@@ -1,0 +1,199 @@
+"""Provision the Unity Catalog HTTP connection scenario.
+
+Rows 1-7 established that the UDF route to a delegated administrative action is
+closed: the function type that carries definer's rights cannot express identity
+administration, and the one that can has no credential to spend. A UC HTTP
+*connection* is the obvious next primitive, because it is the platform's own
+answer to "hold a credential somewhere the caller cannot read it".
+
+This script creates, as the high-privilege author:
+
+  udf_delegation_conn         an HTTP connection carrying a bearer token
+  f_sql_http_via_connection() a SQL UDF whose body calls http_request() against it
+
+and grants the caller EXECUTE on the function and *nothing on the connection*.
+That grant shape is the whole experiment: if the caller can invoke the function
+successfully while holding no privilege on the connection, the connection
+privilege resolved as definer, exactly as table SELECT did in row 1. If the
+platform refuses, it resolved as invoker and the connection is not a wrapping
+primitive at all.
+
+The target is example.com, not this workspace's own control plane. That is
+deliberate: this workspace enforces IP access lists, and the serverless egress
+address http_request() presents is not on the allow list, so a SCIM target
+would answer 403 before the privilege question was ever reached — the platform
+would refuse for a reason that has nothing to do with delegation. example.com is
+the same neutral target row 2 used, and it isolates the one question this row
+exists to answer. See the README caveat for what that does and does not license.
+
+The bearer token is a sentinel, not a credential. Whether the *connection*
+mechanism hides a secret from the caller is answered by row 9 reading it back,
+and that question does not need a real secret to be answered — a public repo is
+a bad place to find out otherwise.
+
+Idempotent: CREATE OR REPLACE / DROP IF EXISTS throughout.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from _common import (  # noqa: E402
+    CONNECTION_NAME,
+    CONNECTION_SCIM_NAME,
+    CONNECTION_SENTINEL_TOKEN,
+    FQ_SCHEMA,
+    LOWPRIV_DISPLAY_NAME,
+    admin_client,
+    info,
+    ok,
+    run_sql,
+    run_sql_or_die,
+    section,
+    step,
+    warehouse_id,
+)
+
+LOWPRIV_APP_ID = os.environ.get("EXPERIMENT_LOWPRIV_CLIENT_ID", "")
+
+# The connection's reach: one host, one base path. Everything the connection can
+# be pointed at afterwards lives under this prefix, which is the only shape
+# constraint the connection object itself provides.
+CONNECTION_HOST = "https://example.com"
+CONNECTION_BASE_PATH = "/"
+
+# The control-plane connection row 11 uses.
+SCIM_BASE_PATH = "/api/2.0/preview/scim/v2/"
+
+
+def main() -> int:
+    section("setup: Unity Catalog HTTP connection and its SQL wrapper")
+    if not LOWPRIV_APP_ID:
+        raise SystemExit(
+            "EXPERIMENT_LOWPRIV_CLIENT_ID is unset — run 00_create_lowpriv_principal.py first."
+        )
+
+    w = admin_client()
+    wh = warehouse_id(w)
+
+    step(f"creating connection {CONNECTION_NAME}")
+    run_sql(w, f"DROP CONNECTION IF EXISTS `{CONNECTION_NAME}`", wh=wh)
+    run_sql_or_die(
+        w,
+        f"""
+CREATE CONNECTION `{CONNECTION_NAME}` TYPE HTTP
+OPTIONS (
+  host '{CONNECTION_HOST}',
+  port '443',
+  base_path '{CONNECTION_BASE_PATH}',
+  bearer_token '{CONNECTION_SENTINEL_TOKEN}'
+)
+""",
+        wh=wh,
+    )
+    ok(f"connection created (host {CONNECTION_HOST}, base_path {CONNECTION_BASE_PATH})")
+
+    step("creating the admin-owned SQL UDF that wraps http_request()")
+    run_sql_or_die(
+        w,
+        f"""
+CREATE OR REPLACE FUNCTION {FQ_SCHEMA}.f_sql_http_via_connection()
+RETURNS STRING
+COMMENT 'SQL UDF owned by an admin whose body calls http_request() against an admin-owned connection.'
+RETURN (
+  SELECT to_json(http_request(
+    conn => '{CONNECTION_NAME}',
+    method => 'GET',
+    path => ''
+  ))
+)
+""",
+        wh=wh,
+    )
+    run_sql_or_die(
+        w,
+        f"GRANT EXECUTE ON FUNCTION {FQ_SCHEMA}.f_sql_http_via_connection TO `{LOWPRIV_APP_ID}`",
+        wh=wh,
+    )
+    ok("f_sql_http_via_connection created; caller granted EXECUTE")
+
+    step("creating the SQL SECURITY DEFINER procedure that wraps the same call")
+    run_sql_or_die(
+        w,
+        f"""
+CREATE OR REPLACE PROCEDURE {FQ_SCHEMA}.p_http_via_connection()
+LANGUAGE SQL
+SQL SECURITY DEFINER
+COMMENT 'The same http_request() call as the UDF, in the object that asks for definer rights explicitly.'
+AS BEGIN
+  SELECT to_json(http_request(
+    conn => '{CONNECTION_NAME}',
+    method => 'GET',
+    path => ''
+  ));
+END
+""",
+        wh=wh,
+    )
+    run_sql_or_die(
+        w,
+        f"GRANT EXECUTE ON PROCEDURE {FQ_SCHEMA}.p_http_via_connection TO `{LOWPRIV_APP_ID}`",
+        wh=wh,
+    )
+    ok("p_http_via_connection created; caller granted EXECUTE")
+    info(
+        "CREATE PROCEDURE requires the SQL SECURITY clause explicitly — there is no "
+        "default — so a definer-rights procedure is an intentional object, not an "
+        "accident of syntax"
+    )
+
+    step(f"creating connection {CONNECTION_SCIM_NAME} (this workspace's own SCIM API)")
+    run_sql(w, f"DROP CONNECTION IF EXISTS `{CONNECTION_SCIM_NAME}`", wh=wh)
+    run_sql_or_die(
+        w,
+        f"""
+CREATE CONNECTION `{CONNECTION_SCIM_NAME}` TYPE HTTP
+OPTIONS (
+  host '{w.config.host.rstrip("/")}',
+  port '443',
+  base_path '{SCIM_BASE_PATH}',
+  bearer_token '{CONNECTION_SENTINEL_TOKEN}'
+)
+""",
+        wh=wh,
+    )
+    ok(f"connection created (base_path {SCIM_BASE_PATH})")
+    info(
+        "the token is the same sentinel: row 11 asks whether the request reaches "
+        "authentication at all, which a real credential would only obscure"
+    )
+
+    # Row 9 grants USE CONNECTION and leaves it granted, so re-provisioning after a
+    # matrix run would otherwise start row 8 from a state that cannot answer it.
+    step("revoking any USE CONNECTION the caller carries from a previous run")
+    run_sql(
+        w,
+        f"REVOKE USE CONNECTION ON CONNECTION `{CONNECTION_NAME}` FROM `{LOWPRIV_APP_ID}`",
+        wh=wh,
+    )
+
+    step(f"confirming the caller ({LOWPRIV_DISPLAY_NAME}) holds nothing on the connection")
+    grants = run_sql_or_die(
+        w, f"SHOW GRANTS `{LOWPRIV_APP_ID}` ON CONNECTION `{CONNECTION_NAME}`", wh=wh
+    )
+    info(f"grants held by caller on the connection: {grants.rows or 'none'}")
+    if grants.rows:
+        raise SystemExit(
+            "The caller already holds a privilege on the connection — row 8 would "
+            "not be able to distinguish definer from invoker. Revoke it and re-run."
+        )
+    ok("caller holds no privilege on the connection")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/udf_privilege_delegation/scripts/setup/03_provision_delegated_job.py
+++ b/experiments/udf_privilege_delegation/scripts/setup/03_provision_delegated_job.py
@@ -1,0 +1,190 @@
+"""Provision the job-as-broker scenario.
+
+Rows 1-11 close the function and connection routes. What both lack is an
+execution context with an identity of its own: the SQL UDF has definer's rights
+but no grammar for identity administration, the Python UDF has the grammar but
+is anonymous, and the connection has a credential but re-checks it against the
+invoker. A job has all three — it runs as a named principal, on compute that
+holds that principal's credential, executing arbitrary code.
+
+This script creates, as the high-privilege author:
+
+  <workspace>/.../udf_delegation_create_sp   a notebook that creates one service
+                                             principal under a fixed name prefix
+  udf-delegation-broker-job                  a job running that notebook, whose
+                                             run-as identity is the author
+
+and grants the caller CAN_MANAGE_RUN — the permission that allows triggering a
+run and nothing else. The caller is deliberately not given CAN_MANAGE, which is
+the permission that would let it edit the task, change the run-as identity, or
+point the job at different code.
+
+The shape constraint lives in the notebook, not in the platform: the caller
+supplies a suffix, the notebook rejects anything that is not a short lowercase
+token and prepends the prefix itself. That is the substantive difference from
+every earlier row — the constraint is code the caller cannot reach, running as
+an identity the caller cannot borrow, rather than a convention the caller is
+trusted to follow.
+
+Run-as is the author rather than a second service principal on purpose. The
+question is whether a job executes with the run-as identity's privileges when a
+different, lower-privileged principal triggers it; that is answered by any
+run-as identity the caller is not. Using an identity that already exists avoids
+minting a second workspace admin to answer a question that does not need one.
+
+Idempotent: the notebook is overwritten and the job is looked up by name.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from databricks.sdk.service import jobs  # noqa: E402
+from databricks.sdk.service.workspace import ImportFormat, Language  # noqa: E402
+
+from _common import (  # noqa: E402
+    JOB_NAME,
+    JOB_SP_PREFIX,
+    admin_client,
+    info,
+    ok,
+    section,
+    step,
+)
+
+LOWPRIV_APP_ID = os.environ.get("EXPERIMENT_LOWPRIV_CLIENT_ID", "")
+
+NOTEBOOK_SOURCE = f'''# Databricks notebook source
+# The delegated action, and the only place its shape is enforced.
+#
+# The caller supplies `suffix` and nothing else. The name prefix, the
+# entitlements, and the fact that exactly one principal is created are decided
+# here, in code the caller holds no permission to read or modify, executing as
+# the job's run-as identity rather than the caller's.
+import json
+import re
+
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service import iam
+
+PREFIX = "{JOB_SP_PREFIX}"
+ALLOWED_SUFFIX = re.compile(r"^[a-z0-9-]{{1,24}}$")
+
+dbutils.widgets.text("suffix", "")
+suffix = dbutils.widgets.get("suffix")
+
+result = {{"requested_suffix": suffix}}
+
+if not ALLOWED_SUFFIX.match(suffix):
+    result["outcome"] = "rejected"
+    result["reason"] = "suffix must match ^[a-z0-9-]{{1,24}}$"
+    dbutils.notebook.exit(json.dumps(result))
+
+w = WorkspaceClient()
+result["run_as"] = w.current_user.me().user_name
+
+name = PREFIX + suffix
+try:
+    sp = w.service_principals.create(
+        display_name=name,
+        active=True,
+        entitlements=[iam.ComplexValue(value="workspace-access")],
+    )
+    result["outcome"] = "created"
+    result["created_display_name"] = sp.display_name
+    result["created_application_id"] = sp.application_id
+except Exception as exc:
+    result["outcome"] = "failed"
+    result["error_type"] = type(exc).__name__
+    result["error"] = str(exc)[:400]
+
+dbutils.notebook.exit(json.dumps(result))
+'''
+
+
+def notebook_path(w) -> str:
+    me = w.current_user.me().user_name
+    return f"/Users/{me}/udf_delegation_create_sp"
+
+
+def main() -> int:
+    section("setup: the job that brokers the delegated action")
+    if not LOWPRIV_APP_ID:
+        raise SystemExit(
+            "EXPERIMENT_LOWPRIV_CLIENT_ID is unset — run 00_create_lowpriv_principal.py first."
+        )
+
+    w = admin_client()
+    path = notebook_path(w)
+
+    step(f"uploading the notebook to {path}")
+    w.workspace.upload(
+        path=path,
+        content=NOTEBOOK_SOURCE.encode(),
+        format=ImportFormat.SOURCE,
+        language=Language.PYTHON,
+        overwrite=True,
+    )
+    ok("notebook uploaded")
+
+    existing = next(iter(w.jobs.list(name=JOB_NAME)), None)
+    if existing and existing.job_id:
+        step(f"deleting the previous job {existing.job_id} so the definition is exact")
+        w.jobs.delete(job_id=existing.job_id)
+
+    step(f"creating job {JOB_NAME!r} with run-as the author")
+    created = w.jobs.create(
+        name=JOB_NAME,
+        tasks=[
+            jobs.Task(
+                task_key="create_service_principal",
+                notebook_task=jobs.NotebookTask(
+                    notebook_path=path,
+                    base_parameters={"suffix": ""},
+                ),
+            )
+        ],
+        parameters=None,
+    )
+    job_id = created.job_id
+    ok(f"job created (job_id={job_id})")
+
+    step("granting the caller CAN_MANAGE_RUN — trigger only, no edit")
+    w.jobs.update_permissions(
+        job_id=str(job_id),
+        access_control_list=[
+            jobs.JobAccessControlRequest(
+                service_principal_name=LOWPRIV_APP_ID,
+                permission_level=jobs.JobPermissionLevel.CAN_MANAGE_RUN,
+            )
+        ],
+    )
+    ok("CAN_MANAGE_RUN granted")
+
+    perms = w.jobs.get_permissions(job_id=str(job_id))
+    for acl in perms.access_control_list or []:
+        if acl.service_principal_name == LOWPRIV_APP_ID:
+            levels = [p.permission_level for p in (acl.all_permissions or [])]
+            info(f"caller's effective job permissions: {levels}")
+            if jobs.JobPermissionLevel.CAN_MANAGE in levels:
+                raise SystemExit(
+                    "The caller holds CAN_MANAGE on the job, which would let it "
+                    "rewrite the task and invalidate rows 12-13. Revoke and re-run."
+                )
+    ok("caller can trigger the job and cannot manage it")
+
+    env_line = f"EXPERIMENT_JOB_ID={job_id}\n"
+    env_path = Path(__file__).resolve().parent.parent.parent / ".env"
+    text = env_path.read_text() if env_path.exists() else ""
+    lines = [x for x in text.splitlines(keepends=True) if not x.startswith("EXPERIMENT_JOB_ID=")]
+    env_path.write_text("".join(lines) + env_line)
+    ok("job id written to .env")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/udf_privilege_delegation/scripts/setup/99_teardown.py
+++ b/experiments/udf_privilege_delegation/scripts/setup/99_teardown.py
@@ -2,8 +2,13 @@
 
 Every matrix row must be re-runnable for reproduction, which means the
 experiment ends with an empty workspace rather than an orphaned sandbox: the
-schema and its functions, the target service principal from row 4, and the
-low-privilege caller identity itself.
+schema and its functions, the metastore-level connections, the broker job and
+its notebook, every service principal any row created, and the low-privilege
+caller identity itself.
+
+Connections and jobs are the ones worth being explicit about. Connections live
+in a flat metastore-wide namespace, so a schema drop does not touch them, and
+the broker job is created outside Unity Catalog entirely.
 """
 
 from __future__ import annotations
@@ -14,8 +19,12 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from _common import (  # noqa: E402
+    CONNECTION_NAME,
+    CONNECTION_SCIM_NAME,
     EXPERIMENT_ROOT,
     FQ_SCHEMA,
+    JOB_NAME,
+    JOB_SP_PREFIX,
     LOWPRIV_DISPLAY_NAME,
     admin_client,
     info,
@@ -25,9 +34,10 @@ from _common import (  # noqa: E402
     step,
 )
 
-# Both row-4 and row-7 create a target principal; teardown must know about
-# every one of them or the next run's pre-check fails on stale state.
+# Rows 4, 7 and 11 each create something with a name of its own; teardown must
+# know about every one of them or the next run's pre-checks fail on stale state.
 TARGET_NAMES = ("udf-delegation-target-sp", "udf-delegation-target-sp-embedded")
+CONNECTION_NAMES = (CONNECTION_NAME, CONNECTION_SCIM_NAME, "udf_delegation_scim_live_conn")
 
 
 def drop_principals(w, display_name: str) -> int:
@@ -35,6 +45,17 @@ def drop_principals(w, display_name: str) -> int:
     for sp in w.service_principals.list(filter=f'displayName eq "{display_name}"'):
         w.service_principals.delete(id=sp.id)
         dropped += 1
+    return dropped
+
+
+def drop_principals_by_prefix(w, prefix: str) -> list[str]:
+    """Row 12 creates principals whose names the caller partly chose, so they are
+    matched by the prefix the notebook enforces rather than by an exact name."""
+    dropped = []
+    for sp in w.service_principals.list():
+        if (sp.display_name or "").startswith(prefix):
+            w.service_principals.delete(id=sp.id)
+            dropped.append(sp.display_name or "")
     return dropped
 
 
@@ -48,6 +69,33 @@ def main() -> int:
         ok("schema dropped")
     else:
         info(f"schema drop reported: {outcome.error_code}: {outcome.error}")
+
+    for name in CONNECTION_NAMES:
+        step(f"dropping connection {name}")
+        outcome = run_sql(w, f"DROP CONNECTION IF EXISTS `{name}`")
+        if outcome.succeeded:
+            ok("dropped")
+        else:
+            info(f"reported: {outcome.error_code}: {outcome.error}")
+
+    step(f"deleting job {JOB_NAME!r} and its notebook")
+    for job in w.jobs.list(name=JOB_NAME):
+        if job.job_id:
+            settings = w.jobs.get(job_id=job.job_id).settings
+            w.jobs.delete(job_id=job.job_id)
+            ok(f"job {job.job_id} deleted")
+            task = (settings.tasks or [None])[0] if settings else None
+            path = task.notebook_task.notebook_path if task and task.notebook_task else None
+            if path:
+                try:
+                    w.workspace.delete(path=path)
+                    ok(f"notebook {path} deleted")
+                except Exception as exc:  # noqa: BLE001 - teardown reports, never aborts
+                    info(f"notebook delete reported: {type(exc).__name__}: {exc}")
+
+    step(f"dropping service principals created by the broker job ({JOB_SP_PREFIX}*)")
+    dropped = drop_principals_by_prefix(w, JOB_SP_PREFIX)
+    ok(f"removed {len(dropped)}: {dropped or 'none'}")
 
     for name in (*TARGET_NAMES, LOWPRIV_DISPLAY_NAME):
         step(f"dropping service principals named {name!r}")

--- a/experiments/udf_privilege_delegation/tests/test_common.py
+++ b/experiments/udf_privilege_delegation/tests/test_common.py
@@ -44,6 +44,49 @@ def test_write_result_redacts_before_committing(tmp_path, monkeypatch):
     assert _common.PLACEHOLDER_AUTHOR in blob
 
 
+def test_sdk_config_dump_is_stripped_without_eating_the_file(tmp_path, monkeypatch):
+    """The leak this rule exists for, and the way fixing it could go wrong.
+
+    Some SDK errors append the whole client config. Scripts truncate long errors
+    before recording them, so the dump can be cut mid-hostname — past every
+    exact-match replacement while still naming the workspace. Stripping it with a
+    greedy `.*` would delete every row recorded after the first such error, so
+    the match has to stop inside the string it started in.
+    """
+    results = tmp_path / "matrix_results.json"
+    monkeypatch.setattr(_common, "RESULTS_PATH", results)
+    monkeypatch.setattr(_common, "_redaction_map", dict)
+
+    _common.write_result(
+        "1",
+        question="q1",
+        status="fail",
+        finding="f1",
+        evidence={
+            # The quote inside the error is the detail that broke the first fix:
+            # serialised, it becomes \" and a pattern matching a raw " swallowed
+            # the escape, leaving a file json.loads could not read.
+            "error": (
+                'User x does not have permission on job 443632049865020. Request log:```POST '
+                '/api/2.0/preview/scim/v2/ServicePrincipals {"displayName": "x"}``` '
+                "Config: host=https://real-workspace.cloud.databricks.com, "
+                "account_id=abc, discovery_url=https://real-workspa"
+            ),
+            "nested": {"run_id": 185603648274530, "keep": "survives"},
+        },
+    )
+    _common.write_result("2", question="q2", status="pass", finding="f2", evidence={"b": 2})
+
+    blob = results.read_text()
+    assert "real-workspa" not in blob
+    assert "443632049865020" not in blob
+    assert "survives" in blob
+
+    payload = json.loads(blob)
+    assert set(payload["rows"]) == {"1", "2"}, "the strip ate rows recorded after it"
+    assert payload["rows"]["1"]["evidence"]["nested"]["run_id"] == 0
+
+
 def test_write_result_round_trips_and_stamps_environment(tmp_path, monkeypatch):
     results = tmp_path / "matrix_results.json"
     monkeypatch.setattr(_common, "RESULTS_PATH", results)

--- a/experiments/udf_privilege_delegation/tests/test_http_request_outcome.py
+++ b/experiments/udf_privilege_delegation/tests/test_http_request_outcome.py
@@ -1,0 +1,105 @@
+"""No-infra tests for the classifier rows 8, 10, 11 and 14 score on.
+
+Trap 4 in the evidence trail is the reason this file exists: `http_request()`
+returns a transport-shaped value for authorization refusals as well as for
+transport outcomes, so a Unity Catalog `PERMISSION_DENIED` arrives as
+`status_code = 403` inside a statement that *succeeded*. The first version of
+row 8 scored on statement success and would have reported the opposite of what
+happened.
+
+These cases pin the distinction that mistake turned on: succeeding is not being
+allowed, and a non-200 from the origin is not a refusal.
+"""
+
+import json
+
+import pytest
+
+import _common
+from delegation import _delegation_common
+
+
+class _FakeClient:
+    """Stands in for a WorkspaceClient; only run_sql touches it."""
+
+
+@pytest.fixture
+def run_sql(monkeypatch):
+    """Let each test hand the classifier one canned SqlOutcome."""
+
+    def _install(outcome):
+        monkeypatch.setattr(
+            _delegation_common, "run_sql", lambda w, sql: outcome
+        )
+
+    return _install
+
+
+def _struct(status_code, text):
+    return _common.SqlOutcome(True, rows=[[json.dumps({"status_code": status_code, "text": text})]])
+
+
+UC_REFUSAL = (
+    "[REMOTE_FUNCTION_HTTP_FAILED_ERROR] The remote HTTP request failed with code 403, "
+    'and error message \'HTTP request failed with status: {"error_code":"PERMISSION_DENIED",'
+    '"message":"Failed request to https://example.com:443/. Error: User is missing '
+    "USE CONNECTION on some_conn\"}' SQLSTATE: 57012"
+)
+
+
+def test_unity_catalog_refusal_inside_a_successful_statement_is_not_allowed(run_sql):
+    """The exact shape that made row 8 report the opposite of the truth."""
+    run_sql(_struct("403", UC_REFUSAL))
+
+    result = _delegation_common.http_request_outcome(_FakeClient(), "SELECT ...")
+
+    assert result["statement_succeeded"] is True
+    assert result["denied_by_unity_catalog"] is True
+    assert result["allowed"] is False
+
+
+def test_origin_answering_200_is_allowed(run_sql):
+    run_sql(_struct("200", "<html>Example Domain</html>"))
+
+    result = _delegation_common.http_request_outcome(_FakeClient(), "SELECT ...")
+
+    assert result["allowed"] is True
+    assert result["denied_by_unity_catalog"] is False
+
+
+@pytest.mark.parametrize("status_code", ["404", "405", "500"])
+def test_non_200_from_the_origin_is_not_a_platform_refusal(run_sql, status_code):
+    """Row 10 turns on this: a 404 from the far end proves the call was dispatched."""
+    run_sql(_struct(status_code, "Not Found"))
+
+    result = _delegation_common.http_request_outcome(_FakeClient(), "SELECT ...")
+
+    assert result["denied_by_unity_catalog"] is False
+    assert result["allowed"] is False
+    assert result["status_code"] == status_code
+
+
+def test_statement_level_failure_is_reported_with_its_error(run_sql):
+    """Row 10's path-traversal probe never becomes a struct at all."""
+    run_sql(
+        _common.SqlOutcome(
+            False,
+            error="[INVALID_HTTP_REQUEST_PATH] ... path traversal is not allowed.",
+            error_code="BAD_REQUEST",
+        )
+    )
+
+    result = _delegation_common.http_request_outcome(_FakeClient(), "SELECT ...")
+
+    assert result["statement_succeeded"] is False
+    assert result["allowed"] is False
+    assert "INVALID_HTTP_REQUEST_PATH" in result["error"]
+
+
+def test_long_bodies_are_clipped_before_they_reach_results(run_sql):
+    run_sql(_struct("200", "y" * 5000))
+
+    result = _delegation_common.http_request_outcome(_FakeClient(), "SELECT ...")
+
+    assert len(result["body"]) < 5000
+    assert result["body"].endswith("...[truncated]")


### PR DESCRIPTION
Closes #50.

## The question

Can an under-privileged principal cause service principals to be created — dynamically, in a shape somebody else fixed (naming, entitlements, quantity), auditable and revocable — while never handling and never needing to be trusted with a credential?

#46 established that a Unity Catalog UDF cannot do it. This sprint asks what can, ranks the candidates, and tests the two that were cheap to test live.

## The answer

**Broker the action through a job whose `run_as` identity holds the privilege, and grant the caller `CAN_MANAGE_RUN` and nothing else.** The credential lives on the compute where the caller has no read path to it, and the constraints live in job code the caller can neither read nor edit.

The candidate that looked closest — a UC HTTP connection wrapped in a SQL UDF — is refuted, and the refutation is the more interesting half of the PR.

## Findings matrix (new rows)

| # | Question | Result | Evidence |
|---|---|---|---|
| 8 | Does a SQL UDF resolve `USE CONNECTION` as **definer**, like table `SELECT`? | ❌ | **Invoker.** Caller with `EXECUTE` on the wrapper and nothing on the connection got the identical refusal it got calling directly: `PERMISSION_DENIED … User is missing USE CONNECTION`. Admin's identical call: 200. |
| 9 | Can a `USE CONNECTION` grantee read the stored credential? | ✅ | **Hidden.** `DESCRIBE CONNECTION`, `SHOW CONNECTIONS`, `system.information_schema.connections` and the REST API all allowed, none disclosed the sentinel. The one property rows 6–7 could not deliver. |
| 10 | Is `USE CONNECTION` scoped to the author's call or the connection? | ❌ | **The connection.** Unblessed path (404), `POST` (405), `DELETE` (405) — all answered by the origin, which proves the platform dispatched them. Only host + `base_path` bind (`../../etc/passwd` → `INVALID_HTTP_REQUEST_PATH`). |
| 11 | Can `http_request()` reach this workspace's own SCIM API? | ❌ | **Reached, then refused.** Sentinel → 401 about the credential (round trip completes); live credential → 403 from the workspace IP access list. Environment-specific, independent of privilege. |
| 12 | Can a `CAN_MANAGE_RUN` caller cause the shaped action? | ✅ | Refused the SCIM create directly, then triggered the job — principal present on admin read-back under the notebook's prefix. Suffix `../Evil Name` rejected, created nothing. |
| 13 | Does `CAN_MANAGE_RUN` withhold changing what the job does? | ✅ | Repoint task, change `run_as`, self-grant `CAN_MANAGE` → all `PermissionDenied`; read the notebook → `ResourceDoesNotExist`. Reading run output **is** allowed — by design. |
| 14 | Does a `SQL SECURITY DEFINER` procedure change row 8's answer? | ◑ | Changes it without delivering. Not refused for missing `USE CONNECTION`; fails at credential resolution (401, platform-emitted). Measured behaviour, not a documented contract. |

## What is in the PR

- **`docs/research/2026-07-29-service-principal-delegation-options.md`** — the deliverable. Ranked shortlist, one section per candidate, each answering: is the credential unreadable, where are shape constraints enforced, what must the caller be granted, GA/Preview, latency and cost, what breaks it. Explicitly labels live-tested vs. desk-researched.
- **Seven new matrix rows** as numbered scripts, with results committed and the README matrix extended.
- **Two new setup scripts** — the connection + its SQL UDF and `SQL SECURITY DEFINER` procedure; the broker job, its notebook, and the `CAN_MANAGE_RUN` grant.
- **Teardown extended** to connections (metastore-level, so a schema drop misses them), the job and its notebook, and principals matched by the row 12 prefix.
- **Two new measurement traps** in the evidence trail, both of which produced plausible-and-wrong statuses first: `http_request()` reports a UC refusal as `status_code 403` inside a *successful* statement, and one probe cannot separate "unreachable" from "not allowed".
- **Redaction rewritten** to walk the results object tree instead of the serialised JSON, after an SDK error dumped `account_id`, `workspace_id` and a truncated workspace URL into committed evidence. Now also scrubs IPv4 addresses, long object ids, and any credential a row registers.

## Verification

- `make teardown && make setup && make matrix` — one clean cycle; all 14 rows in `results/matrix_results.json` share that run.
- `uv run pytest -m "not infrastructure"` — 13 passed (5 pre-existing, 8 new covering the `http_request` classifier and the redaction bug).
- `uv run ruff check scripts tests` — clean.
- `make teardown` verified against the live workspace afterwards: no schema, no connections, no job, no notebook, no service principals, `.env` removed.

## Deviations and scope

- **Rows 8–10 and 14 target `example.com`, not SCIM.** Row 11 is why: this workspace's IP access list refuses the authenticated self-referential call, so a SCIM target would have answered 403 before the definer/invoker question was reached. Called out as a README caveat.
- **Row 12's `run_as` is the author, not a dedicated service principal.** The recommendation describes the SP shape; the measurement used an admin identity the caller is not, which answers the same question without minting a second workspace admin. Flagged in the README and worth a reviewer's eye — it is the one place the test is a notch weaker than the advice.
- **Five of the eight candidates are desk research**, labelled as such per section: Databricks Apps, IdP-driven SCIM, Terraform/CI, model serving, and native fine-grained roles.
- `http_request` is deprecated in favour of the UC connections proxy endpoint. The proxy takes the same `USE CONNECTION` grant, so rows 9 and 10 are expected to carry over — not measured.

Conclusions are customer-facing, so this is up for review rather than merge.

This pull request and its description were written by Isaac.

https://claude.ai/code/session_01MRid1FiRpdKrabtEmieHwL
