### PR TITLE
experiment: re-validate the Unity AI Gateway governance matrix (Aug 2026)

### DIFF
--- a/experiments/coding_agent_inference_unity_ai_gateway/README.md
+++ b/experiments/coding_agent_inference_unity_ai_gateway/README.md
@@ -23,35 +23,148 @@ The ground rules ("the One True Way"):
 This is a **client-side config layer** — a companion to a server-side gateway
 app, not a replacement. Phase 2 (a polished copy/paste demo) is intentionally
 out of scope until the matrix says what deserves demoing: anything ❌ or
-Preview-gated below is documented as such, never demoed as if it works.
+gated below is documented as such, never demoed as if it works.
+
+The gateway is moving fast enough that a matrix has a shelf life. This one has
+been re-validated once (July → August 2026) and four rows moved — two of them
+(9 and 10) because the *original probe was wrong*, not because the product
+changed. Re-run it against your own workspace before quoting it.
 
 ## Results Matrix
 
-Tested 2026-07-09 / 2026-07-10 against one real AWS workspace **without** the
-gated "Foundation Model Permissions" Preview enrolled. The mutation rows
-(3–6, 10) were run end-to-end using a purpose-created workspace service
-principal (OAuth M2M, no PAT) as the second test identity, then torn down.
+**Re-validated 2026-08-03** against the same AWS workspace, after a wave of
+Databricks releases (foundation-model UC permissions relabelled
+"GA but requires enablement", budgets GA, model/MCP services and service
+policies in Beta, the new `system.ai_gateway.usage` table). Rows 3, 8, 9 and
+10 moved. The original run was 2026-07-09 / 2026-07-10; both verdicts are
+shown so you can see which way the product is travelling.
+
 Machine-readable results live in [`results/matrix_results.json`](./results/matrix_results.json),
 written by the scripts in [`scripts/governance/`](./scripts/governance/). A
-remaining ❓ means the capability could not be isolated on a GA workspace, not
-that the script didn't run — see the notes.
+remaining ❓ means the capability could not be isolated on this workspace, not
+that the script didn't run — run
+[`00_enablement_probe.py`](./scripts/governance/00_enablement_probe.py) first
+to see which gates are open on yours.
 
-| # | Capability | Claim / Source | OOTB (GA) | Gated Preview | Notes |
+Rows 1, 2, 7, 8, 9 and 10 were re-executed end-to-end in August and carry
+August timestamps in the results file. Rows 3–6 need a second test principal
+and were **not** re-executed; instead their blockers were re-verified
+directly — `DENY` still returns `UC_COMMAND_NOT_SUPPORTED`, and the
+enablement probe confirms the `MODEL` securable is still off — so their July
+records stand.
+
+| # | Capability | Claim / Source | Jul 2026 | **Aug 2026** | Notes |
 |---|---|---|---|---|---|
-| 1 | Query model via gateway with SSO/OAuth (no PAT) | Core goal | ✅ | — | HTTP 200 with a short-lived OAuth token on `/ai-gateway/mlflow/v1/chat/completions` |
-| 2 | Three-part UC identifier (`system.ai.<model>`) resolves | [Unity AI Gateway](https://docs.databricks.com/aws/en/ai-gateway) | ✅ | — | **Gateway routes only** — see Key Findings; `/serving-endpoints/*` 404s on three-part ids |
-| 3 | GRANT/REVOKE EXECUTE on model service enforced | [Govern model services](https://docs.databricks.com/aws/en/ai-gateway/govern-model-services) | ❌ | ❓ | GRANT/REVOKE EXECUTE **accepted** (securable type `FUNCTION`) but **not enforced**: after REVOKE the principal still inferred (HTTP 200). A default schema-wide `EXECUTE` grant to `account users` on `system.ai` makes direct grants moot OOTB. Preview may change this |
-| 4 | DENY EXECUTE on a model actually blocks inference | [Govern model services](https://docs.databricks.com/aws/en/ai-gateway/govern-model-services) | ❌ | — | **Not achievable as documented**: Unity Catalog has no `DENY` command (`UC_COMMAND_NOT_SUPPORTED`; grants are additive-only). You restrict by not-granting / revoking broader grants, not by DENY |
-| 5 | DENY on model + GRANT on gateway → user can still infer | Definer's-rights invocation per docs | ❓ | — | Setup impossible on a built-in endpoint: no UC `DENY`, and pay-per-token FM endpoints expose no per-principal endpoint ACL (no endpoint `id`; permissions API rejects the name). Needs a custom / provisioned-throughput endpoint |
-| 6 | Revoke gateway access → no fallback to old endpoints | Field sandbox observation | ❓ | — | Not reproducible on a built-in endpoint: pay-per-token FM endpoints have no per-principal permission to revoke. Repro needs a custom / provisioned endpoint (or the original field environment) |
-| 7 | Per-user alerting on spend threshold | [Budgets](https://docs.databricks.com/aws/en/admin/account-settings/budgets) | ✅ | — | Usage tracking ON; note there is no "alert at $X per user" field on the endpoint — alerting is composed from usage system tables |
-| 8 | Per-user hard cap (block at budget) | Conference-talk claim | ❌ | ❓ | Only alert-style surfaces and per-user *rate* limits exist; no spend-denominated block-at-budget knob found on the endpoint |
-| 9 | Usage tracking per user / per agent (`user_agent`) | [Usage system tables](https://docs.databricks.com/aws/en/ai-gateway/configure-ai-gateway-endpoints#usage-tracking) | ◑ | — | Per-**user** attribution ✅ (`system.serving.endpoint_usage.requester` populated). Per-**agent**: the `usage_context` column IS populated on 5,825 historical rows (mechanism works), but **0 in the last 2 days** across 2.6M requests and our gateway chat-completions marker never landed — the OpenAI-compatible route does not propagate `usage_context`/`User-Agent` |
-| 10 | Guardrails (PII / injection / unsafe) on service | [Configure AI Gateway](https://docs.databricks.com/aws/en/ai-gateway/configure-ai-gateway-endpoints) | ❌ | — | Guardrail config (`input.pii` behavior=BLOCK, `input.safety`) is **settable** (PUT accepted) but **not enforced**: synthetic PII passed through with HTTP 200 on every probe up to ~90s. No dedicated prompt-injection knob — knobs are `pii`, `safety`, `valid_topics`, `invalid_keywords` |
+| 1 | Query model via gateway with SSO/OAuth (no PAT) | Core goal | ✅ | **✅** | Unchanged. HTTP 200 with a short-lived OAuth token on `/ai-gateway/mlflow/v1/chat/completions` |
+| 2 | Three-part UC identifier (`system.ai.<model>`) resolves | [Unity AI Gateway](https://docs.databricks.com/aws/en/ai-gateway) | ✅ | **✅** | Unchanged. **Gateway routes only** — `/serving-endpoints/*` still 404s on three-part ids |
+| 3 | GRANT/REVOKE EXECUTE on model service enforced | [Govern model services](https://docs.databricks.com/aws/en/ai-gateway/govern-model-services) | ❌ | **❓** | Still not enforceable here, but the *reason* is now a named gate rather than a missing feature: foundation-model UC permissions answer `INVALID_STATE: MODEL is not enabled`, and `system.ai` still carries a schema-wide `EXECUTE` to `account users`. Enabling it is an account-team request |
+| 4 | DENY EXECUTE on a model actually blocks inference | [Govern model services](https://docs.databricks.com/aws/en/ai-gateway/govern-model-services) | ❌ | **❌** | Unity Catalog still has no `DENY` (`UC_COMMAND_NOT_SUPPORTED`; grants are additive-only). ABAC arrived but adds **GRANT** policies only. The one ALLOW/DENY/ASK surface — service policies on model services — is Beta and not enabled here (`MODEL SERVICE` is not a recognised securable) |
+| 5 | DENY on model + GRANT on gateway → user can still infer | Definer's-rights invocation per docs | ❓ | **❓** | Same blocker as row 4 plus no per-principal ACL on pay-per-token FM endpoints. Needs model services (Beta) or a custom / provisioned-throughput endpoint |
+| 6 | Revoke gateway access → no fallback to old endpoints | Field sandbox observation | ❓ | **❓** | Unchanged. Pay-per-token FM endpoints still expose no per-principal permission to revoke |
+| 7 | Per-user alerting on spend threshold | [Budgets](https://docs.databricks.com/aws/en/admin/account-settings/budgets) | ✅ | **✅** | Unchanged. Usage tracking ON; alerting is composed from the usage system tables, not set as a field on the endpoint |
+| 8 | Per-user hard cap (block at budget) | [AI Gateway budgets](https://docs.databricks.com/aws/en/ai-gateway/budgets) | ❌ | **❓ (was ❌)** | **The blocking half is now real.** Account budgets carry a genuine `BLOCK_USAGE` action alongside `EMAIL_NOTIFICATION`, spend-denominated (`LIST_PRICE_DOLLARS_USD`, `CUMULATIVE_SPENDING_EXCEEDED`, monthly) — 47 of 440 budgets on a probed account use it. The **per-user** half stays unproven: every budget this API version returns is scoped by `workspace_id`/tags, with no per-user threshold or override field |
+| 9 | Usage tracking per user / per agent | [Usage tracking](https://docs.databricks.com/aws/en/ai-gateway/usage-tracking-beta) | ◑ | **✅ (was ◑)** | **Solved by a new table.** `system.ai_gateway.usage` populates `requester` (27.0M rows), `user_agent` (2.67M) and `request_tags` (284K), fed by the `Databricks-Ai-Gateway-Request-Tags` header. Our own marker landed on both `/ai-gateway/mlflow/v1/chat/completions` and `/ai-gateway/anthropic/v1/messages`. 170,924 tagged rows exist on the gateway chat-completions route — the exact path July found empty |
+| 10 | Guardrails (PII / injection / unsafe) on service | [Guardrails](https://docs.databricks.com/aws/en/ai-gateway/guardrails) | ❌ | **◑ (was ❌)** | **They enforce now — but not on the routes this experiment recommends.** With `input.pii=BLOCK` + `input.safety` set, synthetic PII is rejected `HTTP 400` on `/serving-endpoints/chat/completions` (`input_guardrail` flagged, categories `['privacy']`) and sails through `HTTP 200` on `/ai-gateway/mlflow/v1/chat/completions`. Benign controls return 200 on both, so the block is guardrail-specific. See Key Findings — this is the headline change |
+
+The July ❌ on row 10 was **partly our own bug**: the probe called only the
+gateway route, so it never saw the enforcement that was happening one route
+family over. [`10_guardrails_pii_injection_unsafe.py`](./scripts/governance/10_guardrails_pii_injection_unsafe.py)
+now probes both families with a benign control, which is how the split
+surfaced. Row 9's July ❌ came from sampling ten rows instead of counting the
+whole table; that script now counts table-wide.
 
 ## Key Findings
 
-### The route split is the headline: three-part ids resolve ONLY on `/ai-gateway/*`
+### The route split now cuts both ways: `/ai-gateway/*` resolves three-part ids AND skips endpoint guardrails
+
+This is the single most important thing in the experiment, and the August
+re-validation is what exposed the second half of it.
+
+Guardrails are configured on a *serving endpoint*
+(`PUT /api/2.0/serving-endpoints/<name>/ai-gateway`). They are enforced when
+you call that endpoint. The Unity AI Gateway routes resolve the model in the
+Unity Catalog model catalog instead, so they never consult that endpoint's
+config. Same workspace, same model, same minute, one guardrail config:
+
+| Route | benign prompt | synthetic PII |
+|---|---|---|
+| `POST /serving-endpoints/chat/completions` | 200 | **400** — `input_guardrail` flagged, categories `['privacy']` |
+| `POST /ai-gateway/mlflow/v1/chat/completions` | 200 | **200** — values echoed back |
+
+Reproduced across four guardrail configurations (`pii` alone, `safety`
+alone, both, both plus output) and confirmed by a no-guardrail control run
+where every cell returned 200.
+
+**The practical consequence:** every config template in this repo points at
+`/ai-gateway/*`, because that is the only route family that resolves
+three-part ids. So a fleet configured this way gets three-part identifiers
+and gateway usage tracking, and gets **no PII or safety guardrail at all**
+from the endpoint config an admin is most likely to have set. If you need
+guardrails on the gateway path today, they come from **service policies** on
+model services — Beta, and not enabled on this workspace (see the enablement
+probe). Do not tell a customer that setting `input.pii = BLOCK` on the
+foundation-model endpoint protects their coding agents. It does not.
+
+Two smaller notes from the same probe:
+
+- `pii.behavior = BLOCK` fires on a strong signal (a card number), not on an
+  SSN alone. `safety = true` flags both under a `privacy` category, so the
+  two knobs overlap more than the names suggest.
+- The endpoint API **silently drops guardrail keys it does not understand.**
+  `PUT`ting `jailbreak`, `hallucination`, `custom`, or `pii.behavior =
+  SANITIZE` all return `HTTP 200` and come back with those keys gone and the
+  remaining ones reset to `false`/`NONE`. The richer guardrail types in the
+  current docs are not on this API surface, and an operator who sets them
+  will believe they are protected. Always read back the response body.
+
+### Per-agent attribution is solved — by a different table and a different header
+
+July's finding ("the mechanism exists but the gateway route doesn't feed
+it") is obsolete. There are now two attribution surfaces, and they line up
+exactly with the two route families:
+
+| Route family | Mechanism | Lands in | Verified |
+|---|---|---|---|
+| `/serving-endpoints/*` | `usage_context` map in the **request body** | `system.serving.endpoint_usage.usage_context` | ✅ on `/chat/completions` and `/<name>/invocations` |
+| `/ai-gateway/*` | `Databricks-Ai-Gateway-Request-Tags` **header** (JSON string→string) | `system.ai_gateway.usage.request_tags` | ✅ on `/mlflow/v1/chat/completions` and `/anthropic/v1/messages` |
+
+Crossing them fails silently: a `usage_context` body field sent to a gateway
+route never lands, and there is no `X-Databricks-Usage-Context` header —
+both were probed and both produced zero rows.
+
+`system.ai_gateway.usage` also records `user_agent`, `url` and `api_type`
+with no caller cooperation at all, so per-agent attribution works even for
+clients that send no tags: real Claude Code traffic in this account shows up
+as `user_agent = claude-code/1.0.44` on `/ai-gateway/mlflow/v1/chat/completions`.
+The [`configs/`](./configs/) templates now set the request-tags header for
+Claude Code, Codex and OpenCode.
+
+Budget your validation time accordingly: **ingestion lag on both tables ran
+15–25 minutes**, so a script that sends a marker and immediately queries for
+it will always come up empty. That is lag, not absence — the row-09 script
+now says so explicitly and prints the observed lag.
+
+### Hard spend caps exist; the per-user dimension is the unproven half
+
+`BLOCK_USAGE` is a real `action_type` in the account budgets API, sitting
+next to `EMAIL_NOTIFICATION` on an alert configuration with a
+`LIST_PRICE_DOLLARS_USD` threshold and a `CUMULATIVE_SPENDING_EXCEEDED`
+trigger. On a probed account, 47 of 440 budgets use it. So "block at budget"
+is no longer a conference-talk claim — it ships.
+
+What is still unproven is **per-user**. Every budget this API version returns
+is filtered by `workspace_id` and/or tags; there is no per-user threshold or
+per-user override field in the response, so a triggered cap blocks the whole
+filtered scope rather than the one engineer who overspent. Budgets that
+their owners *named* for per-user AI Gateway demos come back with plain
+workspace filters. The docs describe per-user thresholds and overrides;
+confirm them in the account console before promising them to anyone.
+
+Note also that this surface is **account-scoped**, not a field on the serving
+endpoint — a workspace token cannot see or set it. Point
+`DATABRICKS_ACCOUNT_PROFILE` at an account-console profile to probe it.
+
+### The three-part id / route story is unchanged
 
 Live-tested with the same OAuth token, same workspace, same minute:
 
@@ -84,60 +197,35 @@ The whole flow — `databricks auth login` → short-lived OAuth token from the
 CLI → Bearer header → 200 — works on both route families. No PAT was created
 at any point, and everything in this experiment refuses `dapi` tokens on sight.
 
-### Hard per-user budget caps do not exist on the endpoint today
+### Per-model access control: the blocker moved from "absent" to "not enabled"
 
-The endpoint's `ai_gateway` block exposes usage tracking and per-user *rate*
-limits (requests per time window), but no spend-denominated block-at-budget
-field. Per-user spend **alerting** is real but composed: usage tracking feeds
-`system.serving.endpoint_usage`, and alerts/budgets are built on top of the
-system tables, not set as a single endpoint field.
+In July the honest summary was "the governance surface accepts configuration
+but does not enforce it". In August it is more precise, and more actionable:
+**the enforcement mechanisms now exist, and each one is behind its own gate
+that this workspace does not have open.** Run
+[`00_enablement_probe.py`](./scripts/governance/00_enablement_probe.py) to see
+which apply to yours; here is what it reports on this one:
 
-### Governance enforcement is the real gap: it's advertised but not on OOTB
+| Mechanism | State here | What it would settle |
+|---|---|---|
+| Foundation-model UC permissions (`MODEL` securable) | ❌ `INVALID_STATE: MODEL is not enabled` | Rows 3–6. Docs call it "GA but requires enablement" — an account-team request, not a self-serve toggle |
+| `system.ai` schema-wide `EXECUTE` to `account users` | ✅ still granted | Why row 3 cannot be isolated: while a broad group holds `EXECUTE`, a per-model GRANT is redundant and REVOKE of it changes nothing |
+| ABAC policy engine | ✅ available, 0 policies on `system.ai` | Adds **GRANT** policies (`GRANT EXECUTE FOR MODELS`). There is no DENY form, so row 4 is untouched |
+| Model services + service policies (Beta) | ❌ `MODEL SERVICE` not a recognised securable | Rows 4–6. Service policies are the only ALLOW/**DENY**/ASK surface for model access, and the only guardrail path for `/ai-gateway/*` |
+| Model provider services header | ❌ 404 on `system.ai.anthropic` | The documented `Databricks-Model-Provider-Service` on-ramp for Claude Code |
 
-This is what the experiment was built to settle, and the answer on a GA
-workspace (no Foundation Model Permissions Preview) is consistent across three
-independent rows: **the governance surface accepts configuration but does not
-enforce it.**
+Two things did **not** change and are worth stating plainly, because they are
+still commonly asserted otherwise:
 
-- **GRANT/REVOKE EXECUTE (row 3):** grants apply to `system.ai` models as
-  securable type `FUNCTION` (not the documented `MODEL` keyword — that's a
-  parse error). But `system.ai` ships a schema-wide `EXECUTE` grant to
-  `account users`, so a specific GRANT is redundant and a REVOKE of it changes
-  nothing — the principal still inferred (HTTP 200) after REVOKE.
-- **DENY (row 4):** cannot exist — Unity Catalog has no `DENY` command at all
-  (`UC_COMMAND_NOT_SUPPORTED`; grants are additive-only). "DENY EXECUTE blocks
-  inference" is not achievable as documented; you restrict access by *not*
-  granting and by removing broad grants.
-- **Guardrails (row 10):** `input.pii` (BLOCK) and `input.safety` are settable
-  via `PUT .../ai-gateway` and the API returns 200, but a request carrying
-  synthetic PII still returned HTTP 200 with the values echoed on every probe
-  up to ~90 seconds after enablement. Settable ≠ enforcing.
-
-The likely reconciliation: real per-model enforcement is what the account-
-console **Foundation Model Permissions** Preview turns on. This profile could
-not enable that Preview (it needs account-admin console access), so those
-cells stay ❓ in the Gated-Preview column rather than being asserted either way.
-
-### Built-in FM endpoints have no per-principal ACL surface
-
-Rows 5 and 6 need per-principal *endpoint* permissions, but the built-in
-pay-per-token foundation-model endpoints (`databricks-claude-*`) expose no
-endpoint `id` and the permissions API rejects their name
-(`not a valid Inference Endpoint ID`). So endpoint-level CAN_QUERY grants and
-the "revoke → silent fallback" repro cannot be exercised against them at all —
-they need a custom or provisioned-throughput serving endpoint.
-
-### Per-agent usage attribution: the mechanism exists, the gateway path doesn't feed it
-
-`system.serving.endpoint_usage` proves per-user attribution out of the box
-(`requester` is populated). The per-agent `usage_context` column is real and
-**has been populated on 5,825 historical rows** — so the mechanism works for
-some clients. But across 2.6M requests in the last 2 days it was populated
-**zero** times, and a marker sent through the OpenAI-compatible gateway
-chat-completions route (in both `User-Agent` and a `usage_context` body field)
-never landed. Conclusion: per-agent attribution is supported by the table but
-is **not fed by the gateway chat-completions path** used by these coding
-agents today.
+- **Unity Catalog still has no `DENY`.** `UC_COMMAND_NOT_SUPPORTED`; grants
+  remain additive-only. ABAC did not add one — its `EXCEPT principal` clause
+  excludes a principal from a grant, which is not a deny assignment. "DENY
+  EXECUTE blocks inference" is not achievable as documented.
+- **Built-in pay-per-token FM endpoints have no per-principal ACL.** They
+  expose no endpoint `id` and the permissions API rejects their name
+  (`not a valid Inference Endpoint ID`), so endpoint-level `CAN_QUERY` grants
+  and the "revoke → silent fallback" repro still need a custom or
+  provisioned-throughput endpoint.
 
 ### The Codex Responses route exists but rejected a Claude model
 
@@ -169,6 +257,13 @@ The bundled skill's `preflight` probes registry reachability for you.
 
 ## Running the Tests
 
+Start by finding out which governance features are switched on where you are
+— most ❓ cells are an enablement gate, not a missing capability:
+
+```bash
+uv run python scripts/governance/00_enablement_probe.py   # read-only, no gate
+```
+
 One real request proving SSO auth + identifier resolution end-to-end:
 
 ```bash
@@ -181,9 +276,20 @@ Fill the matrix (each script records its row into `results/matrix_results.json`)
 uv run python scripts/governance/01_query_via_gateway_sso.py
 uv run python scripts/governance/02_three_part_identifier_resolves.py
 uv run python scripts/governance/07_per_user_spend_alerting.py
-uv run python scripts/governance/08_per_user_hard_cap.py
 uv run python scripts/governance/09_usage_tracking_per_user_agent.py
+
+# Row 8's block-at-budget surface is ACCOUNT-scoped, so it needs an
+# account-console profile in addition to your workspace profile:
+#   databricks auth login --host https://accounts.cloud.databricks.com \
+#     --account-id <account-id> --profile <name>
+DATABRICKS_ACCOUNT_PROFILE=<name> \
+  uv run python scripts/governance/08_per_user_hard_cap.py
 ```
+
+Two rows depend on ingestion into system tables, which ran **15–25 minutes
+behind** during this validation. Row 9 reports the observed lag and treats a
+missing marker as lag rather than absence; if you want to see your own marker
+land, re-run it after twenty minutes.
 
 The permission-enforcement rows mutate grants/permissions and are therefore
 double-gated — they dry-run with instructions until you opt in. The
@@ -218,12 +324,18 @@ databricks service-principals delete <sp-numeric-id>
 ```
 
 Every script is idempotent and restores grants / endpoint config / guardrails
-in a `finally` block. Rows 5 and 6 additionally need a **custom or
-provisioned-throughput** serving endpoint (built-in pay-per-token FM endpoints
-have no per-principal ACL surface — see Key Findings). Re-run the rows once
-more with the gated **Foundation Model Permissions** Preview enrolled
-(account console → Previews) to fill the Gated-Preview column, which requires
-account-admin access this experiment's workspace profile did not have.
+in a `finally` block. Row 10 mutates the shared foundation-model endpoint's
+guardrail config for roughly a minute; it restores the original config even
+on failure, but do not run it against a workspace where a brief PII block
+would disrupt someone.
+
+Rows 3–6 remain blocked on enablement rather than on setup, and the specific
+blockers are listed under Key Findings. To make them meaningful you need
+foundation-model UC permissions enabled (account-team request), and then to
+revoke the schema-wide `EXECUTE` on `system.ai` from `account users` — which
+affects **every user of that workspace**, so do it somewhere you own. Rows 5
+and 6 additionally need a custom or provisioned-throughput endpoint, since
+built-in pay-per-token endpoints have no per-principal ACL surface.
 
 ## Configuring your coding agents
 
@@ -234,6 +346,17 @@ all pointing at the tested `/ai-gateway/*` routes with three-part ids and the
 SSO token helper. A self-service agent skill that drives the whole setup
 (preflight → ucode-or-template → verify → locked-down-registry handling) is
 bundled in [`skill/`](./skill/SKILL.md).
+
+Each template now also sets `Databricks-Ai-Gateway-Request-Tags`, so an
+agent's traffic is attributable in `system.ai_gateway.usage.request_tags`.
+Edit the team/project values; the keys are yours to choose.
+
+**Know what you are trading.** Pointing an agent at `/ai-gateway/*` is what
+makes three-part identifiers and gateway usage tracking work, and it is also
+what puts the agent outside any PII/safety guardrail configured on the
+serving endpoint (see Key Findings). Until service policies are available on
+your workspace, treat "governed inference" here as *identity, attribution and
+spend* — not content filtering.
 
 ### MDM / fleet rollout notes
 
@@ -265,7 +388,8 @@ coding_agent_inference_unity_ai_gateway/
 ├── scripts/
 │   ├── _common.py                # token/host/model resolution, routed chat_completion, record_result
 │   ├── verify.py                 # the `make verify` implementation
-│   └── governance/               # one script per matrix row (01–10) + _gov_common.py
+│   └── governance/               # 00_enablement_probe.py (which gates are open here)
+│                                 # + one script per matrix row (01–10) + _gov_common.py
 ├── skill/                        # bundled agent skill (SKILL.md + setup_helper.sh)
 └── results/
     └── matrix_results.json       # machine-readable matrix, written by the scripts

--- a/experiments/coding_agent_inference_unity_ai_gateway/configs/README.md
+++ b/experiments/coding_agent_inference_unity_ai_gateway/configs/README.md
@@ -28,6 +28,45 @@ config for agents ucode covers, and the primary path for the one it doesn't
 | `<path-to-this-experiment>` | Absolute path to this experiment directory (so `bin/get-databricks-token.sh` resolves) |
 | `<your-databricks-cli-profile>` | The `databricks auth login` profile to mint tokens with (helper defaults to `DEFAULT`) |
 | `<your-mcp-server-command>` | (Claude Desktop only) the MCP server executable that calls Databricks serving endpoints |
+| `<your-team>` / `<your-project>` | Values for the attribution tags described below; keys and values are yours to choose |
+
+## Per-agent usage attribution
+
+Every template sets the `Databricks-Ai-Gateway-Request-Tags` header — a JSON
+object of string→string that lands in
+`system.ai_gateway.usage.request_tags`, so you can tell one coding agent's
+spend from another's:
+
+| Agent | How the header is set |
+|---|---|
+| Claude Code | `ANTHROPIC_CUSTOM_HEADERS` in the `env` block |
+| Codex CLI | `[model_providers.databricks.http_headers]` |
+| OpenCode | `provider.databricks.options.headers` |
+
+Live-tested 2026-08-03 on both `/ai-gateway/mlflow/v1/chat/completions` and
+`/ai-gateway/anthropic/v1/messages`. Two gotchas:
+
+- This is the **gateway** mechanism. The classic `/serving-endpoints/*`
+  routes use a different one — a `usage_context` map in the request *body*,
+  landing in `system.serving.endpoint_usage`. Crossing them fails silently:
+  neither the header nor the body field works on the other route family.
+- Ingestion into these tables ran **15–25 minutes behind** during testing, so
+  a tag you just sent will not be queryable immediately.
+
+`system.ai_gateway.usage` also records `user_agent`, `url` and `api_type`
+without any client cooperation, so agents you have not templated still show
+up — just less legibly.
+
+## Guardrails do NOT apply to these templates
+
+Guardrails (`input.pii`, `input.safety`) configured on a foundation-model
+serving endpoint are enforced on the classic `/serving-endpoints/*` routes.
+They are **not** enforced on the `/ai-gateway/*` routes that every template
+here points at — live-tested 2026-08-03, synthetic PII returns `400` on the
+former and `200` on the latter under one config. Content filtering for the
+gateway path comes from service policies on model services (Beta). Do not
+assume an admin's endpoint guardrail covers your fleet; see the experiment
+README's Key Findings.
 
 ## Base URLs
 

--- a/experiments/coding_agent_inference_unity_ai_gateway/configs/claude-code.settings.json
+++ b/experiments/coding_agent_inference_unity_ai_gateway/configs/claude-code.settings.json
@@ -2,7 +2,8 @@
   "env": {
     "ANTHROPIC_BASE_URL": "https://<your-workspace-host>/ai-gateway/anthropic",
     "ANTHROPIC_MODEL": "system.ai.claude-sonnet-4-6",
-    "DATABRICKS_CONFIG_PROFILE": "<your-databricks-cli-profile>"
+    "DATABRICKS_CONFIG_PROFILE": "<your-databricks-cli-profile>",
+    "ANTHROPIC_CUSTOM_HEADERS": "Databricks-Ai-Gateway-Request-Tags: {\"coding_agent\":\"claude-code\",\"team\":\"<your-team>\",\"project\":\"<your-project>\"}"
   },
   "apiKeyHelper": "<path-to-this-experiment>/bin/get-databricks-token.sh"
 }

--- a/experiments/coding_agent_inference_unity_ai_gateway/configs/codex.config.toml
+++ b/experiments/coding_agent_inference_unity_ai_gateway/configs/codex.config.toml
@@ -32,6 +32,13 @@ base_url = "https://<your-workspace-host>/ai-gateway/mlflow/v1"
 # Codex sends the value of this env var as the Bearer token.
 env_key = "OPENAI_API_KEY"
 wire_api = "chat"
+
+# Per-agent usage attribution. Live-tested 2026-08-03: this header lands in
+# system.ai_gateway.usage.request_tags on the /ai-gateway/* routes, which is
+# how you tell one coding agent's spend from another's. The value must be a
+# JSON object of string->string; keys are yours to choose.
+[model_providers.databricks.http_headers]
+"Databricks-Ai-Gateway-Request-Tags" = '{"coding_agent":"codex","team":"<your-team>","project":"<your-project>"}'
 # VERIFY: Databricks' coding-agent integration docs also describe a dedicated
 # Codex route at https://<your-workspace-host>/ai-gateway/codex/v1 with
 # wire_api = "responses". Live-tested 2026-07-09: the route exists but

--- a/experiments/coding_agent_inference_unity_ai_gateway/configs/opencode.json
+++ b/experiments/coding_agent_inference_unity_ai_gateway/configs/opencode.json
@@ -6,7 +6,10 @@
       "name": "Databricks Unity AI Gateway",
       "options": {
         "baseURL": "https://<your-workspace-host>/ai-gateway/mlflow/v1",
-        "apiKey": "{env:DATABRICKS_TOKEN}"
+        "apiKey": "{env:DATABRICKS_TOKEN}",
+        "headers": {
+          "Databricks-Ai-Gateway-Request-Tags": "{\"coding_agent\":\"opencode\",\"team\":\"<your-team>\",\"project\":\"<your-project>\"}"
+        }
       },
       "models": {
         "system.ai.claude-sonnet-4-6": {

--- a/experiments/coding_agent_inference_unity_ai_gateway/results/matrix_results.json
+++ b/experiments/coding_agent_inference_unity_ai_gateway/results/matrix_results.json
@@ -15,23 +15,23 @@
     "result": "❌"
   },
   "guardrails_pii_injection_unsafe": {
-    "notes": "Guardrail surface exists and accepts configuration (input.pii behavior=BLOCK, input.safety=true via PUT ai-gateway; restored afterwards). NOT ENFORCED in this test: config was accepted, but a request containing synthetic PII still returned HTTP 200 (model echoed the values) on every probe up to ~90s after enablement — settable is not the same as enforcing. Probe trail: [('0s', 200), ('30s', 200), ('90s', 200)]. Last body: {\"choices\": [{\"finish_reason\": \"length\", \"index\": 0, \"message\": {\"content\": \"I want to be straightforward with you: I'll repeat back what you shared, since you've framed it as a.... No dedicated prompt-injection knob in the schema — knobs are pii/safety/valid_topics/invalid_keywords.",
-    "recorded_at": "2026-07-10T21:27:18.802137+00:00",
-    "result": "❌"
+    "notes": "PARTIAL — guardrails are real but route-scoped. Endpoint guardrails ({\"input\": {\"safety\": true, \"pii_detection\": true, \"pii\": {\"behavior\": \"BLOCK\"}}}) blocked the synthetic-PII request on ['classic /serving-endpoints/chat/completions'] and were bypassed on ['gateway /ai-gateway/mlflow/v1/chat/completions']. Guardrails configured on a serving endpoint govern the classic /serving-endpoints/* routes only; the /ai-gateway/* routes resolve the model in the UC catalog and do not inherit them, so a coding agent pointed at /ai-gateway/* is UNGUARDED by this config. Probe trail: [gateway /ai-gateway/mlflow/v1/chat/completions] PII=200 benign=200; [classic /serving-endpoints/chat/completions] PII=400 benign=200. Benign controls returned 200 everywhere, so the block is guardrail-specific, not an outage. No dedicated prompt-injection knob in this endpoint's schema — knobs are pii/safety/valid_topics/invalid_keywords (jailbreak/hallucination/custom keys are silently dropped by this API).",
+    "recorded_at": "2026-08-03T22:44:38.514400+00:00",
+    "result": "❓"
   },
   "per_user_hard_cap": {
-    "notes": "No hard per-user budget cap: ai_gateway exposes only alert-style surfaces (usage tracking) and rate caps (rate_limits per user/endpoint), no spend-denominated block-at-budget field. Per-user rate limits found: 0. ai_gateway key paths=['usage_tracking_config', 'usage_tracking_config.enabled']; cap-like keys=NONE; rate_limits(verbatim)=[].",
-    "recorded_at": "2026-07-09T12:56:41.856632+00:00",
-    "result": "❌"
+    "notes": "No hard per-user budget cap ON THE ENDPOINT: ai_gateway exposes only usage tracking and rate caps (rate_limits per user/endpoint), no spend-denominated block-at-budget field. Per-user rate limits found: 0. ai_gateway key paths=['usage_tracking_config', 'usage_tracking_config.enabled']; cap-like keys=NONE; rate_limits(verbatim)=[]. Account budgets: 440 configured, 47 carry a real BLOCK_USAGE action (action types present: ['BLOCK_USAGE', 'EMAIL_NOTIFICATION']). These are spend-denominated and blocking — e.g. 'Genie_tracking' triggers on CUMULATIVE_SPENDING_EXCEEDED at ['25000 LIST_PRICE_DOLLARS_USD/MONTH']. A block-at-budget surface therefore EXISTS at account scope (it is not a field on the serving endpoint). BUT the per-USER half is unproven: every budget returned by this API version is scoped by workspace_id and/or tags, with no per-user threshold or per-user override field, so a triggered cap blocks the whole filtered scope rather than one over-spending engineer. The docs describe per-user thresholds and overrides; they are not exposed by this API/CLI version, so confirm them in the account console before promising per-user caps.",
+    "recorded_at": "2026-08-03T22:37:39.256508+00:00",
+    "result": "❓"
   },
   "per_user_spend_alerting": {
     "notes": "Per-user alerting surface present: usage tracking is ON (per-user attribution into system.serving usage tables — the documented basis for spend alerts via SQL alerts/budget policies). Note: no direct 'alert at $X per user' field exists ON the endpoint; alerting is composed from these knobs. ai_gateway keys=['usage_tracking_config']; usage_tracking_config={\"enabled\": true}; rate_limits=[]; per-user rate limits=0",
-    "recorded_at": "2026-07-09T12:56:41.220600+00:00",
+    "recorded_at": "2026-08-03T22:10:17.240134+00:00",
     "result": "✅"
   },
   "query_via_gateway_sso": {
     "notes": "HTTP 200 with SSO OAuth token only (zero PATs); model=system.ai.claude-sonnet-4-6; reply=pong. Baseline gate for all other rows.",
-    "recorded_at": "2026-07-09T13:14:40.720932+00:00",
+    "recorded_at": "2026-08-03T22:10:13.702731+00:00",
     "result": "✅"
   },
   "revoke_gateway_no_fallback": {
@@ -40,13 +40,13 @@
     "result": "❓"
   },
   "three_part_identifier_resolves": {
-    "notes": "Three-part id got HTTP 200. three-part 'system.ai.claude-sonnet-4-6' -> HTTP 200 ({\"choices\": [{\"finish_reason\": \"stop\", \"index\": 0, \"message\": {\"content\": \"pong\", \"role\": \"assistant\"}}], \"created\": 1783602894, \"id\": \"msg_bdrk_01QngKE9c5LM2BouVHRrSH4B\", \"model\": \"us.anthropic.cl...); legacy 'databricks-claude-sonnet-4-6' -> HTTP 200 ({\"choices\": [{\"finish_reason\": \"stop\", \"index\": 0, \"message\": {\"content\": \"pong\", \"role\": \"assistant\"}}], \"created\": 1783602895, \"id\": \"msg_bdrk_01QDWaKJ6sBxL2DzNQMLwsEe\", \"model\": \"us.anthropic.cl...)",
-    "recorded_at": "2026-07-09T13:14:55.633596+00:00",
+    "notes": "Three-part id got HTTP 200. three-part 'system.ai.claude-sonnet-4-6' -> HTTP 200 ({\"choices\": [{\"finish_reason\": \"stop\", \"index\": 0, \"message\": {\"content\": \"pong\", \"role\": \"assistant\"}}], \"created\": 1785795015, \"id\": \"msg_bdrk_01P93t4xi1C92sPkzGEP7rnM\", \"model\": \"us.anthropic.cl...); legacy 'databricks-claude-sonnet-4-6' -> HTTP 200 ({\"choices\": [{\"finish_reason\": \"stop\", \"index\": 0, \"message\": {\"content\": \"pong\", \"role\": \"assistant\"}}], \"created\": 1785795016, \"id\": \"msg_bdrk_01GZyQCPQLs4u6WMtdi141in\", \"model\": \"us.anthropic.cl...)",
+    "recorded_at": "2026-08-03T22:10:16.741957+00:00",
     "result": "✅"
   },
   "usage_tracking_per_user_agent": {
-    "notes": "Per-user attribution PROVEN (populated), but per-agent attribution unproven: the agent/client columns exist in the schema yet were empty/null in every sampled row — callers must send user_agent/usage_context metadata for it to populate. table=system.serving.endpoint_usage; user columns=['requester'] (populated: ['requester']); agent/client columns=['client_request_id', 'usage_context'] (populated: []); sampled rows=10. fresh inference HTTP 200 with marker 'uag-experiment-row09-354ea3b008d9' in User-Agent + usage_context. Marker hunt: 0 row(s) matched 'uag-experiment-row09-354ea3b008d9' (ingestion latency likely exceeds this run). Table-wide: usage_context is populated on 5825 historical row(s) (0 in the last 2 days) — the per-agent mechanism works for some client paths, but the gateway chat-completions route used here did not propagate our usage_context/User-Agent marker into the table.",
-    "recorded_at": "2026-07-10T21:30:16.025553+00:00",
-    "result": "❓"
+    "notes": "Per-user AND per-agent attribution proven with populated values. table=system.ai_gateway.usage (Unity AI Gateway); user columns=['requester', 'requester_type'] (populated: ['requester', 'requester_type']); per-agent columns=['user_agent', 'request_tags'] (populated: ['user_agent', 'request_tags']); population counts={'requester': 27071175, 'requester_type': 27071175, 'user_agent': 2669201, 'request_tags': 284506}. fresh inference HTTP 200 with marker 'uag-row09-3c29f286ba74' in Databricks-Ai-Gateway-Request-Tags + User-Agent + legacy usage_context. On the gateway chat-completions route specifically, request_tags is populated on 170954 row(s) (37966 tagged rows across all routes in the last 2 days). Marker hunt: 0 row(s) matched 'uag-row09-3c29f286ba74' — the table's newest row is ~23 min old, so this run's own request has not been ingested yet (lag, not absence).",
+    "recorded_at": "2026-08-03T22:42:50.850130+00:00",
+    "result": "✅"
   }
 }

--- a/experiments/coding_agent_inference_unity_ai_gateway/scripts/governance/00_enablement_probe.py
+++ b/experiments/coding_agent_inference_unity_ai_gateway/scripts/governance/00_enablement_probe.py
@@ -1,0 +1,180 @@
+"""Preflight: which Unity AI Gateway governance features are ON in THIS workspace.
+
+Most of the ❓ cells in this experiment's matrix are not "the test failed" —
+they are "the feature that would make the test meaningful is not enabled on
+this workspace". Between the July 2026 and August 2026 runs, Databricks
+shipped several governance surfaces (foundation-model Unity Catalog
+permissions, ABAC grant policies, model/MCP services and service policies,
+the ``system.ai_gateway.usage`` table). Each has its own enablement gate, and
+guessing which ones are live is how you end up demoing something that does
+not work in a customer's workspace.
+
+This script asks the workspace directly and prints one line per feature. It
+is entirely read-only: no grants, no endpoint config, no mutations, no gate.
+It records nothing into the matrix — it explains the matrix.
+
+Run it first when re-validating on a new workspace.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import requests
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import _gov_common as gov  # noqa: E402
+import _common  # noqa: E402
+
+
+def _line(name: str, enabled: bool | None, detail: str) -> None:
+    symbol = "❓" if enabled is None else ("✅ ON " if enabled else "❌ OFF")
+    print(f"  {symbol}  {name}")
+    print(f"          {detail}")
+
+
+def probe_fm_uc_permissions() -> None:
+    """Foundation-model UC permissions — 'GA but requires enablement'.
+
+    The tell is the securable type: with the feature off, Unity Catalog
+    answers INVALID_STATE 'MODEL is not enabled' for the MODEL securable,
+    and system.ai models are only addressable as FUNCTION.
+    """
+    status, body = gov.api_request(
+        "GET", "/api/2.1/unity-catalog/permissions/model/system.ai.claude-sonnet-4-6"
+    )
+    text = json.dumps(body) if not isinstance(body, str) else body
+    if status == 200:
+        _line("Foundation-model UC permissions (MODEL securable)", True,
+              f"GET permissions/model -> 200 {gov.snip(text, 160)}")
+    elif "not enabled" in text:
+        _line("Foundation-model UC permissions (MODEL securable)", False,
+              f"GET permissions/model -> {status} {gov.snip(text, 160)} — this is the "
+              "gate behind matrix rows 3-6; enabling it is an account-team request.")
+    else:
+        _line("Foundation-model UC permissions (MODEL securable)", None,
+              f"GET permissions/model -> {status} {gov.snip(text, 160)}")
+
+
+def probe_system_ai_grants() -> None:
+    """The default schema-wide EXECUTE grant that makes per-model grants moot."""
+    status, body = gov.api_request(
+        "GET", "/api/2.1/unity-catalog/permissions/schema/system.ai"
+    )
+    assignments = (body or {}).get("privilege_assignments", []) if isinstance(body, dict) else []
+    broad = [
+        a["principal"]
+        for a in assignments
+        if "EXECUTE" in (a.get("privileges") or [])
+        and a.get("principal") in ("account users", "users")
+    ]
+    _line(
+        "system.ai schema-wide EXECUTE grant",
+        bool(broad),
+        f"EXECUTE on system.ai held by {broad or 'no broad group'} — while a broad "
+        "group holds it, a per-model GRANT is redundant and a REVOKE of one "
+        "changes nothing (matrix row 3).",
+    )
+
+
+def probe_abac_policies() -> None:
+    """ABAC GRANT policies — new in 2026, can grant EXECUTE FOR MODELS."""
+    res = gov.sql_exec("SHOW POLICIES ON SCHEMA system.ai")
+    if res["ok"]:
+        _line("ABAC policy engine (SHOW/CREATE POLICY)", True,
+              f"SHOW POLICIES ON SCHEMA system.ai parsed; {len(res['rows'])} policy(ies) "
+              "defined. ABAC adds GRANT policies only — there is still no DENY form.")
+    else:
+        _line("ABAC policy engine (SHOW/CREATE POLICY)", False,
+              f"SHOW POLICIES rejected: {gov.snip(res['error'], 160)}")
+
+
+def probe_model_services() -> None:
+    """Model services / service policies (Beta) — the new DENY-capable surface."""
+    res = gov.sql_exec("SHOW GRANTS ON MODEL SERVICE a.b.c")
+    supported = res["ok"] or "PARSE_SYNTAX_ERROR" not in (res["error"] or "")
+    _line(
+        "Model services + service policies (Beta)",
+        supported,
+        "MODEL SERVICE is a securable here."
+        if supported
+        else f"MODEL SERVICE securable not recognised by SQL: "
+        f"{gov.snip(res['error'], 130)} — service policies (the only ALLOW/DENY/ASK "
+        "surface for model access) are unavailable, so rows 4-6 stay untestable.",
+    )
+
+
+def probe_gateway_usage_table() -> None:
+    """system.ai_gateway.usage — the new per-agent attribution surface."""
+    res = gov.sql_exec("DESCRIBE TABLE system.ai_gateway.usage")
+    if not res["ok"]:
+        _line("system.ai_gateway.usage (per-agent attribution)", False,
+              f"table absent: {gov.snip(res['error'], 140)} — per-agent attribution "
+              "falls back to the legacy usage_context body map.")
+        return
+    columns = [r[0] for r in res["rows"] if r and r[0] and not r[0].startswith("#")]
+    _line("system.ai_gateway.usage (per-agent attribution)", True,
+          f"present with {len(columns)} columns including "
+          f"{[c for c in columns if c in ('requester', 'request_tags', 'user_agent', 'api_type')]} "
+          "— request_tags is fed by the Databricks-Ai-Gateway-Request-Tags header (row 9).")
+
+
+def probe_model_provider_services() -> None:
+    """Model provider services — the documented Claude Code on-ramp."""
+    host, token = _common.get_host(), _common.get_token()
+    try:
+        resp = requests.post(
+            f"{host}/ai-gateway/anthropic/v1/messages",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+                "Databricks-Model-Provider-Service": "system.ai.anthropic",
+            },
+            json={
+                "model": "claude-sonnet-4-6",
+                "messages": [{"role": "user", "content": "say pong"}],
+                "max_tokens": 8,
+            },
+            timeout=60,
+        )
+    except requests.RequestException as exc:
+        _line("Model provider services (Databricks-Model-Provider-Service)", None, str(exc)[:160])
+        return
+    ok = resp.status_code == 200
+    _line(
+        "Model provider services (Databricks-Model-Provider-Service)",
+        ok,
+        f"probe with system.ai.anthropic -> HTTP {resp.status_code} {resp.text[:130]}"
+        + ("" if ok else " — the header-selected provider-service path is not "
+           "provisioned here; point agents at a model id instead."),
+    )
+
+
+def main() -> int:
+    _common.section("00 — Which governance features are enabled on this workspace?")
+    print(f"  Host: {_common.get_host()}")
+    try:
+        gov.get_warehouse_id()
+    except RuntimeError as exc:
+        print(f"  (No SQL warehouse — SQL-based probes will be skipped: {exc})")
+
+    probe_fm_uc_permissions()
+    probe_system_ai_grants()
+    probe_abac_policies()
+    probe_model_services()
+    probe_gateway_usage_table()
+    probe_model_provider_services()
+
+    print(
+        "\n  Read this alongside the README matrix: an ❓ row usually means the "
+        "feature above it is OFF here, not that the capability is absent from "
+        "the product."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/experiments/coding_agent_inference_unity_ai_gateway/scripts/governance/08_per_user_hard_cap.py
+++ b/experiments/coding_agent_inference_unity_ai_gateway/scripts/governance/08_per_user_hard_cap.py
@@ -1,26 +1,37 @@
 """Matrix row: per_user_hard_cap — a HARD per-user budget cap (block mode).
 
 Claim/source: a Data+AI Summit talk claimed per-user budget caps that BLOCK
-at budget. Current AI Gateway docs only show usage tracking (alert-style,
-after-the-fact) and rate limits (requests/tokens per renewal period — rate
-caps, not spend caps). Believed ❌ today.
+at budget. The AI Gateway budgets docs now describe exactly that — per-user
+monthly thresholds whose action is "Send alert" OR "Block usage" — announced
+GA on 2026-07-06. But that surface is ACCOUNT-scoped (account console →
+budgets), not a field on the serving endpoint, so a workspace-scoped token
+cannot see or set it.
 
-✅ means: a real block-at-budget knob exists on the endpoint/gateway config
-AND accepts a value (e.g. a spend/budget field with a block/enforce mode).
-❌ means: only alert-style surfaces exist — usage tracking and/or rate
-limits, with NO spend-denominated cap that blocks; the verbatim field list
-is in notes.
-❓ means: the endpoint config could not be read at all.
+This script therefore probes both levels:
+
+1. the serving endpoint's ``ai_gateway`` block (workspace scope), and
+2. the account budgets API, when an account-level CLI profile is supplied
+   via ``DATABRICKS_ACCOUNT_PROFILE``.
+
+✅ means: a block-at-budget surface was found AND is spend-denominated —
+either a cap field on the endpoint, or an account budget carrying a
+blocking action rather than an alert-only threshold.
+❌ means: only alert-style surfaces exist — usage tracking, alert
+thresholds, and/or rate limits (requests per period, not dollars).
+❓ means: the endpoint could not be read, or the endpoint has no cap and the
+account budgets API was unreachable, leaving the documented account-level
+feature unverified.
 
 Configuration-surface probe ONLY — never generates spend. Read-only by
-default; with ALLOW_ENDPOINT_MUTATION=1 it additionally offers the API a
-hypothetical budget-cap payload to prove the schema rejects it, restoring
-the original config in a finally block.
+default; with ALLOW_ENDPOINT_MUTATION=1 it additionally offers the endpoint
+API a hypothetical budget-cap payload to prove the schema rejects it.
 """
 
 from __future__ import annotations
 
 import json
+import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -33,6 +44,107 @@ ROW_KEY = "per_user_hard_cap"
 
 # Key fragments that would indicate a spend-denominated cap with block-mode.
 CAP_MARKERS = ("budget", "spend", "cost", "dollar", "cap", "block")
+
+# Env var naming a databrickscfg profile whose host is the account console.
+ACCOUNT_PROFILE_ENV = "DATABRICKS_ACCOUNT_PROFILE"
+
+# The enum that makes a budget a hard cap rather than a notification. Match
+# the field exactly — several budgets have the word "block" in their display
+# name while carrying nothing but EMAIL_NOTIFICATION.
+BLOCK_ACTION_TYPE = "BLOCK_USAGE"
+
+# Field names that would prove the *per-user* half of the claim, as opposed
+# to a workspace- or tag-scoped cap that blocks everyone at once.
+PER_USER_MARKERS = ("per_user", "user_threshold", "user_override", "principal")
+
+
+def probe_account_budgets() -> tuple[bool | None, str]:
+    """Look for a BLOCKING account budget. Returns (found_block, note).
+
+    found_block is None when the account API could not be reached at all —
+    that is the difference between "no hard cap exists" and "we could not
+    look", and the matrix verdict depends on which one it is.
+    """
+    profile = os.environ.get(ACCOUNT_PROFILE_ENV, "").strip()
+    if not profile:
+        return None, (
+            f" Account budgets NOT probed: set {ACCOUNT_PROFILE_ENV} to a "
+            "databrickscfg profile authenticated against "
+            "https://accounts.cloud.databricks.com (databricks auth login "
+            "--host https://accounts.cloud.databricks.com --account-id <id>). "
+            "The documented per-user 'Block usage' budget action lives there, "
+            "not on the serving endpoint."
+        )
+    try:
+        proc = subprocess.run(
+            ["databricks", "account", "budgets", "list", "-p", profile, "-o", "json"],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return None, f" Account budgets probe failed to run: {exc}."
+    if proc.returncode != 0:
+        return None, (
+            f" Account budgets unreachable via profile '{profile}': "
+            f"{gov.snip(proc.stderr.strip(), 200)}."
+        )
+    try:
+        budgets = json.loads(proc.stdout or "[]") or []
+    except ValueError:
+        return None, f" Account budgets returned unparseable output: {gov.snip(proc.stdout, 160)}."
+
+    def action_types(budget: dict) -> set[str]:
+        found: set[str] = set()
+        for alert in budget.get("alert_configurations") or []:
+            for action in alert.get("action_configurations") or []:
+                if action.get("action_type"):
+                    found.add(action["action_type"])
+        return found
+
+    blocking = [b for b in budgets if BLOCK_ACTION_TYPE in action_types(b)]
+    all_actions = sorted({a for b in budgets for a in action_types(b)})
+    blob = json.dumps(budgets).lower()
+    per_user_fields = [m for m in PER_USER_MARKERS if m in blob]
+
+    print(
+        f"  Account budgets found: {len(budgets)}; carrying {BLOCK_ACTION_TYPE}: "
+        f"{len(blocking)}; action types seen: {all_actions}"
+    )
+    if not blocking:
+        return False, (
+            f" Account budgets: {len(budgets)} configured via profile '{profile}', "
+            f"none carrying a {BLOCK_ACTION_TYPE} action (action types present: "
+            f"{all_actions}) — only alert-style budgets exist here."
+        )
+
+    example = blocking[0]
+    thresholds = [
+        f"{a.get('quantity_threshold', '?').split('.')[0]} {a.get('quantity_type')}/{a.get('time_period')}"
+        for a in (example.get("alert_configurations") or [])
+    ]
+    hard_cap_note = (
+        f" Account budgets: {len(budgets)} configured, {len(blocking)} carry a real "
+        f"{BLOCK_ACTION_TYPE} action (action types present: {all_actions}). These are "
+        f"spend-denominated and blocking — e.g. '{example.get('display_name')}' triggers "
+        f"on CUMULATIVE_SPENDING_EXCEEDED at {thresholds}. A block-at-budget surface "
+        "therefore EXISTS at account scope (it is not a field on the serving endpoint)."
+    )
+
+    if per_user_fields:
+        return True, hard_cap_note + (
+            f" Per-user scoping is visible in the API response ({per_user_fields})."
+        )
+    # The block half is proven; the per-user half is not observable here.
+    return None, hard_cap_note + (
+        " BUT the per-USER half is unproven: every budget returned by this API "
+        "version is scoped by workspace_id and/or tags, with no per-user threshold "
+        "or per-user override field, so a triggered cap blocks the whole filtered "
+        "scope rather than one over-spending engineer. The docs describe per-user "
+        "thresholds and overrides; they are not exposed by this API/CLI version, so "
+        "confirm them in the account console before promising per-user caps."
+    )
 
 
 def main() -> int:
@@ -123,20 +235,26 @@ def main() -> int:
         )
         return 0
 
+    # The endpoint has no cap. The documented feature is account-scoped, so
+    # the verdict now turns on whether we could look there.
+    account_block, account_note = probe_account_budgets()
+
     _common.fail("No spend-denominated block-at-budget knob exists on this endpoint.")
-    print("  What DOES exist: usage tracking (after-the-fact attribution) and")
-    print("  rate_limits (requests/tokens per renewal period — rate caps, not")
-    print("  spend caps). The Summit-talk claim of a per-user block-at-budget")
-    print("  cap is not present in this workspace's API surface.")
-    gov.conclude(
-        ROW_KEY,
-        False,
-        "No hard per-user budget cap: ai_gateway exposes only alert-style "
-        "surfaces (usage tracking) and rate caps (rate_limits per user/"
-        "endpoint), no spend-denominated block-at-budget field. "
-        f"Per-user rate limits found: {len(per_user_rate)}. {field_report}."
-        f"{mutation_probe_note}",
+    print("  What DOES exist on the endpoint: usage tracking (after-the-fact")
+    print("  attribution) and rate_limits (requests/tokens per renewal period —")
+    print("  rate caps, not spend caps).")
+
+    endpoint_report = (
+        "No hard per-user budget cap ON THE ENDPOINT: ai_gateway exposes only "
+        "usage tracking and rate caps (rate_limits per user/endpoint), no "
+        "spend-denominated block-at-budget field. Per-user rate limits found: "
+        f"{len(per_user_rate)}. {field_report}.{mutation_probe_note}"
     )
+
+    if account_block:
+        gov.conclude(ROW_KEY, True, endpoint_report + account_note)
+        return 0
+    gov.conclude(ROW_KEY, account_block, endpoint_report + account_note)
     return 0
 
 

--- a/experiments/coding_agent_inference_unity_ai_gateway/scripts/governance/09_usage_tracking_per_user_agent.py
+++ b/experiments/coding_agent_inference_unity_ai_gateway/scripts/governance/09_usage_tracking_per_user_agent.py
@@ -1,27 +1,40 @@
 """Matrix row: usage_tracking_per_user_agent — per-user + per-agent usage rows.
 
 Claim/source: AI Gateway usage tracking docs — inference usage lands in
-system tables (system.serving.*) with per-user attribution and client
-metadata, enabling per-user/per-agent chargeback and monitoring.
+system tables with per-user attribution and client metadata, enabling
+per-user/per-agent chargeback and monitoring.
 
-✅ means: the usage system table exists, is queryable with the SSO token via
-the SQL Statements API, and exposes BOTH a per-user identity column AND a
-user_agent/client-identity column; notes name the exact table and columns.
-❓ means: partial proof — e.g. per-user attribution visible but no
-user_agent column, the table exists but has no rows yet (ingestion latency
-may exceed this script's runtime), or no SQL warehouse was available.
-❌ means: no usage system table with per-user attribution exists at all.
+There are TWO usage surfaces, and they are not equivalent:
 
-Method: make one tiny real inference first with a distinctive User-Agent
-header and a `usage_context` payload marker (via _common.chat_completion's
-extra_headers/extra_payload), then discover tables via SHOW TABLES IN
-system.serving and columns via DESCRIBE, sample rows, and additionally hunt
-for the marker itself (ingestion latency may hide it — that's noted, not
-failed). Read-only apart from the one tiny inference; no mutations, no gate.
+* legacy — ``system.serving.endpoint_usage``, fed by the classic
+  ``/serving-endpoints/*`` routes. Per-agent attribution comes from a
+  ``usage_context`` map in the *request body*.
+* Unity AI Gateway — ``system.ai_gateway.usage``, fed by the
+  ``/ai-gateway/*`` routes. Per-agent attribution comes from the
+  ``Databricks-Ai-Gateway-Request-Tags`` *header* and lands in
+  ``request_tags``; the table additionally records ``user_agent``,
+  ``url`` and ``api_type`` with no caller cooperation at all.
+
+This row prefers the gateway table, because the gateway routes are what
+every config template in this experiment points at.
+
+✅ means: the gateway usage table exposes a populated per-user identity
+column AND populated per-agent columns (``request_tags`` and/or
+``user_agent``), on rows produced by the ``/ai-gateway/*`` routes.
+◑/❓ means: per-user proven, per-agent unproven or only partly proven.
+❌ means: no usage table with per-user attribution exists at all.
+
+Method: send one tiny real inference carrying a distinctive marker in the
+``Databricks-Ai-Gateway-Request-Tags`` header, then describe and sample the
+table, count table-wide population, and hunt for the marker. Ingestion lag
+on these tables runs ~15-20 minutes, so a missing marker is reported as lag
+(with the observed lag printed), never as a failure. Read-only apart from
+the one tiny inference; no mutations, no gate.
 """
 
 from __future__ import annotations
 
+import json
 import sys
 import uuid
 from pathlib import Path
@@ -33,10 +46,41 @@ import _common  # noqa: E402
 
 ROW_KEY = "usage_tracking_per_user_agent"
 
-USER_COL_MARKERS = ("requester", "user", "created_by", "executed_as", "run_as")
-# usage_context is the documented per-agent/per-client attribution mechanism
-# (a caller-supplied map on the request); user_agent/client_* are candidates.
-AGENT_COL_MARKERS = ("user_agent", "client", "agent", "usage_context")
+GATEWAY_TABLE = "system.ai_gateway.usage"
+LEGACY_TABLE = "system.serving.endpoint_usage"
+
+# Header documented for Unity AI Gateway per-request attribution tags.
+REQUEST_TAGS_HEADER = "Databricks-Ai-Gateway-Request-Tags"
+
+USER_COL_MARKERS = ("requester", "created_by", "executed_as", "run_as")
+# request_tags is the gateway mechanism; user_agent is recorded by the
+# gateway itself; usage_context is the legacy body-map mechanism.
+AGENT_COL_MARKERS = ("user_agent", "request_tags", "usage_context", "client", "agent")
+
+# to_json() only accepts struct/map/array — calling it on a STRING column
+# fails the whole statement, which silently reads back as "0 populated".
+COMPLEX_TYPE_PREFIXES = ("map", "struct", "array")
+
+
+def _table_exists(table: str) -> bool:
+    return gov.sql_exec(f"DESCRIBE TABLE {table}")["ok"]
+
+
+def _count(query: str) -> int:
+    res = gov.sql_exec(query)
+    if res["ok"] and res["rows"]:
+        try:
+            return int(res["rows"][0][0])
+        except (TypeError, ValueError):
+            return 0
+    return 0
+
+
+def _nonempty_predicate(col: str, col_type: str) -> str:
+    """SQL that is true when `col` carries a real value, per its type."""
+    if col_type.lower().startswith(COMPLEX_TYPE_PREFIXES):
+        return f"{col} IS NOT NULL AND to_json({col}) NOT IN ('{{}}', 'null')"
+    return f"{col} IS NOT NULL AND {col} <> ''"
 
 
 def main() -> int:
@@ -45,175 +89,153 @@ def main() -> int:
     model_id = _common.resolve_model_id()
     print(f"  Model: {model_id}")
 
-    # --- Step 1: one tiny real inference so a fresh usage row should exist --
-    # Distinctive marker in BOTH the User-Agent header and the documented
-    # usage_context payload field, so either attribution mechanism can match.
-    marker = f"uag-experiment-row09-{uuid.uuid4().hex[:12]}"
-    status, body = _common.chat_completion(
+    # --- Step 1: one tiny real inference carrying the attribution marker ----
+    # The marker goes in the documented gateway header AND the legacy body
+    # map, so whichever surface is live in this workspace can match it.
+    marker = f"uag-row09-{uuid.uuid4().hex[:12]}"
+    tags = {"probe": marker, "coding_agent": "uag-experiment"}
+    status, _ = _common.chat_completion(
         model_id,
         "Reply with: pong",
         max_tokens=8,
-        extra_headers={"User-Agent": marker},
+        extra_headers={REQUEST_TAGS_HEADER: json.dumps(tags), "User-Agent": marker},
         extra_payload={"usage_context": {"client": marker}},
     )
     print(f"  Fresh inference for attribution: HTTP {status} (marker: {marker})")
-    inference_note = f"fresh inference HTTP {status} with marker '{marker}' in User-Agent + usage_context"
+    inference_note = (
+        f"fresh inference HTTP {status} with marker '{marker}' in "
+        f"{REQUEST_TAGS_HEADER} + User-Agent + legacy usage_context"
+    )
 
-    # --- Step 2: discover the usage tables ---------------------------------
     try:
         gov.get_warehouse_id()
     except RuntimeError as exc:
         gov.conclude(ROW_KEY, None, f"No SQL warehouse available — {exc}")
         return 1
 
-    show = gov.sql_exec("SHOW TABLES IN system.serving")
-    if not show["ok"]:
-        gov.conclude(
-            ROW_KEY,
-            None,
-            "Could not enumerate system.serving tables via the SQL Statements "
-            f"API ({show['state']}: {gov.snip(show['error'], 250)}). "
-            f"{inference_note}",
-        )
-        return 1
-    tables = [row[1] for row in show["rows"]]
-    print(f"  Tables in system.serving: {tables}")
-
-    # Prefer the documented usage table; fall back to anything usage-like.
-    candidates = [t for t in tables if "usage" in t.lower()] or tables
-    if not candidates:
+    # --- Step 2: pick the surface — gateway table first ---------------------
+    if _table_exists(GATEWAY_TABLE):
+        table, time_col, surface = GATEWAY_TABLE, "event_time", "Unity AI Gateway"
+    elif _table_exists(LEGACY_TABLE):
+        table, time_col, surface = LEGACY_TABLE, "request_time", "legacy serving"
+    else:
         gov.conclude(
             ROW_KEY,
             False,
-            f"system.serving contains no tables — no usage tracking surface. {inference_note}",
+            f"Neither {GATEWAY_TABLE} nor {LEGACY_TABLE} exists — no usage "
+            f"tracking surface at all. {inference_note}",
         )
         return 1
-    table = f"system.serving.{candidates[0]}"
-    print(f"  Probing table: {table}")
+    print(f"  Usage surface: {surface} — {table}")
 
     desc = gov.sql_exec(f"DESCRIBE TABLE {table}")
-    if not desc["ok"]:
-        gov.conclude(
-            ROW_KEY,
-            None,
-            f"{table} exists but DESCRIBE failed ({gov.snip(desc['error'], 250)}). {inference_note}",
-        )
-        return 1
-    columns = [row[0] for row in desc["rows"] if row and row[0] and not row[0].startswith("#")]
-    print(f"  Columns: {columns}")
-
+    types = {
+        row[0]: (row[1] or "")
+        for row in desc["rows"]
+        if row and row[0] and not row[0].startswith("#")
+    }
+    columns = list(types)
     user_cols = [c for c in columns if any(m in c.lower() for m in USER_COL_MARKERS)]
     agent_cols = [c for c in columns if any(m in c.lower() for m in AGENT_COL_MARKERS)]
     print(f"  Per-user identity columns: {user_cols or 'NONE'}")
-    print(f"  User-agent / client columns: {agent_cols or 'NONE'}")
+    print(f"  Per-agent / client columns: {agent_cols or 'NONE'}")
 
-    # --- Step 3: sample rows to prove attribution is POPULATED --------------
-    # A column merely existing is not attribution — the values must be there.
-    selected = (user_cols + agent_cols)[:6] or [columns[0]]
-    sample = gov.sql_exec(f"SELECT {', '.join(selected)} FROM {table} LIMIT 10")
-    rows_seen = len(sample["rows"]) if sample["ok"] else 0
-    print(f"  Sample query ok={sample['ok']}, rows returned: {rows_seen}")
-    if sample["ok"] and sample["rows"]:
-        print(f"  Sample (verbatim, truncated): {gov.snip(sample['rows'], 300)}")
+    # --- Step 3: table-wide population, not a 10-row sample -----------------
+    # A sample can miss a column that IS used by other clients, which is
+    # exactly the mistake that produced a false ❌ on this row in July 2026.
+    populated: dict[str, int] = {}
+    for col in user_cols + agent_cols:
+        populated[col] = _count(
+            f"SELECT COUNT(*) FROM {table} WHERE {_nonempty_predicate(col, types[col])}"
+        )
+    for col, n in populated.items():
+        print(f"    {col:16} populated on {n} row(s)")
 
-    def populated(col: str) -> bool:
-        if not (sample["ok"] and sample["rows"] and col in selected):
-            return False
-        idx = selected.index(col)
-        return any(
-            row[idx] not in (None, "", "null", "{}") for row in sample["rows"]
+    user_populated = [c for c in user_cols if populated.get(c)]
+    agent_populated = [c for c in agent_cols if populated.get(c)]
+
+    # --- Step 4: is per-agent attribution live on the GATEWAY routes? -------
+    # The July 2026 finding was that the mechanism existed but the gateway
+    # chat-completions route never fed it. Ask that question directly.
+    route_note = ""
+    if table == GATEWAY_TABLE:
+        tagged_recent = _count(
+            f"SELECT COUNT(*) FROM {table} WHERE {time_col} > "
+            "current_timestamp() - INTERVAL 2 DAYS AND request_tags IS NOT NULL "
+            "AND to_json(request_tags) NOT IN ('{}', 'null')"
+        )
+        gw_chat_tagged = _count(
+            f"SELECT COUNT(*) FROM {table} WHERE api_type = "
+            "'mlflow/v1/chat/completions' AND request_tags IS NOT NULL "
+            "AND to_json(request_tags) NOT IN ('{}', 'null')"
+        )
+        print(f"  request_tags in last 2 days: {tagged_recent}")
+        print(f"  request_tags on /ai-gateway/mlflow/v1/chat/completions: {gw_chat_tagged}")
+        route_note = (
+            f" On the gateway chat-completions route specifically, request_tags "
+            f"is populated on {gw_chat_tagged} row(s) ({tagged_recent} tagged rows "
+            "across all routes in the last 2 days)."
         )
 
-    user_populated = [c for c in user_cols if populated(c)]
-    agent_populated = [c for c in agent_cols if populated(c)]
-    print(f"  Populated per-user columns: {user_populated or 'NONE'}")
-    print(f"  Populated agent/client columns: {agent_populated or 'NONE'}")
-
-    # --- Step 3b: hunt for THIS run's marker (best-effort; lag expected) ----
+    # --- Step 5: hunt this run's marker; report lag rather than fail --------
     marker_note = ""
-    if agent_cols:
-        predicate = " OR ".join(
-            f"CAST({c} AS STRING) LIKE '%{marker}%'" for c in agent_cols
+    predicates = [
+        f"CAST({c} AS STRING) LIKE '%{marker}%'" for c in agent_cols
+    ]
+    if predicates:
+        hits = _count(
+            f"SELECT COUNT(*) FROM {table} WHERE " + " OR ".join(predicates)
         )
-        hunt = gov.sql_exec(
-            f"SELECT COUNT(*) FROM {table} WHERE {predicate}"
+        lag = gov.sql_exec(
+            f"SELECT timestampdiff(MINUTE, max({time_col}), current_timestamp()) FROM {table}"
         )
-        if hunt["ok"]:
-            hits = int(hunt["rows"][0][0]) if hunt["rows"] else 0
-            marker_note = (
-                f" Marker hunt: {hits} row(s) matched '{marker}'"
-                + ("" if hits else " (ingestion latency likely exceeds this run)")
-                + "."
+        lag_min = lag["rows"][0][0] if lag["ok"] and lag["rows"] else "?"
+        print(f"  Marker rows found: {hits} (table is ~{lag_min} min behind now)")
+        marker_note = (
+            f" Marker hunt: {hits} row(s) matched '{marker}'"
+            + (
+                ""
+                if hits
+                else f" — the table's newest row is ~{lag_min} min old, so this "
+                "run's own request has not been ingested yet (lag, not absence)"
             )
-            print(f"  Marker rows found: {hits}")
-            if hits:
-                agent_populated = agent_populated or agent_cols
-
-    # --- Step 3c: table-wide check — is the agent metadata EVER populated? ---
-    # A 10-row sample can miss a column that IS used by other clients. Ask
-    # the whole table: this separates "mechanism doesn't work" from "our
-    # gateway path doesn't populate it".
-    mechanism_note = ""
-    if "usage_context" in columns:
-        ever = gov.sql_exec(
-            f"SELECT COUNT(*) FROM {table} WHERE usage_context IS NOT NULL "
-            "AND to_json(usage_context) NOT IN ('{}', 'null')"
+            + "."
         )
-        recent = gov.sql_exec(
-            f"SELECT COUNT(*) FROM {table} WHERE request_time > "
-            "current_timestamp() - INTERVAL 2 DAYS AND usage_context IS NOT NULL "
-            "AND to_json(usage_context) NOT IN ('{}', 'null')"
-        )
-        ever_n = int(ever["rows"][0][0]) if ever["ok"] and ever["rows"] else 0
-        recent_n = int(recent["rows"][0][0]) if recent["ok"] and recent["rows"] else 0
-        print(f"  usage_context populated ever={ever_n}, last 2 days={recent_n}")
-        mechanism_note = (
-            f" Table-wide: usage_context is populated on {ever_n} historical row(s) "
-            f"({recent_n} in the last 2 days) — the per-agent mechanism works for "
-            "some client paths, but the gateway chat-completions route used here "
-            "did not propagate our usage_context/User-Agent marker into the table."
-        )
+        if hits:
+            agent_populated = sorted(set(agent_populated) | {"request_tags"})
 
     detail = (
-        f"table={table}; user columns={user_cols} (populated: {user_populated}); "
-        f"agent/client columns={agent_cols} (populated: {agent_populated}); "
-        f"sampled rows={rows_seen}"
-        + ("" if sample["ok"] else f"; sample query error={gov.snip(sample['error'], 150)}")
-        + f". {inference_note}.{marker_note}{mechanism_note}"
+        f"table={table} ({surface}); user columns={user_cols} "
+        f"(populated: {user_populated}); per-agent columns={agent_cols} "
+        f"(populated: {agent_populated}); population counts={populated}. "
+        f"{inference_note}.{route_note}{marker_note}"
     )
 
     if user_populated and agent_populated:
-        _common.ok("Per-user AND per-agent attribution populated in the usage system table.")
+        _common.ok(
+            "Per-user AND per-agent attribution are populated on the gateway usage table."
+        )
         gov.conclude(
             ROW_KEY,
             True,
-            "Per-user + agent/client attribution proven with populated values "
-            "in the usage system table. Freshness caveat: ingestion latency "
-            f"may exceed this run, so the just-made inference row itself was "
-            f"not chased. {detail}",
+            "Per-user AND per-agent attribution proven with populated values. "
+            f"{detail}",
         )
         return 0
     if user_populated:
         gov.conclude(
             ROW_KEY,
             None,
-            "Per-user attribution PROVEN (populated), but per-agent attribution "
-            "unproven: the agent/client columns exist in the schema yet were "
-            "empty/null in every sampled row — callers must send user_agent/"
-            f"usage_context metadata for it to populate. {detail}",
+            "Per-user attribution PROVEN, per-agent attribution unproven: the "
+            "per-agent columns exist but are empty table-wide, so no client on "
+            f"this workspace is supplying attribution metadata. {detail}",
         )
         return 0
-    if user_cols and rows_seen == 0:
-        gov.conclude(
-            ROW_KEY,
-            None,
-            "Schema has the attribution columns but no rows were readable yet "
-            "(ingestion latency likely exceeds this script's runtime) — schema "
-            f"proven, data unproven. {detail}",
-        )
-        return 0
-    _common.fail("No populated per-user identity column found in the usage table.")
-    gov.conclude(ROW_KEY, False, f"No per-user attribution found. {detail}")
+    gov.conclude(
+        ROW_KEY,
+        False,
+        f"No populated per-user attribution found. {detail}",
+    )
     return 1
 
 

--- a/experiments/coding_agent_inference_unity_ai_gateway/scripts/governance/10_guardrails_pii_injection_unsafe.py
+++ b/experiments/coding_agent_inference_unity_ai_gateway/scripts/governance/10_guardrails_pii_injection_unsafe.py
@@ -5,20 +5,26 @@ detection, safety (unsafe-content) filtering, and topic/keyword restrictions.
 Prompt-injection filtering is often *assumed* to be included; whether a
 dedicated injection knob exists at all is part of what's under test.
 
-✅ means: the guardrails configuration surface exists on this endpoint
-(present in ai_gateway, or accepts configuration when mutation is opted in);
-notes list exactly which knobs (pii / safety / valid_topics /
-invalid_keywords / anything injection-shaped) exist.
-❌ means: no guardrail surface exists on this endpoint at all (schema
-rejects guardrails configuration).
-❓ means: no guardrails currently configured and settability was not probed
-(read-only mode).
+THE ROUTE SPLIT IS THE WHOLE ANSWER. Guardrails are configured on a serving
+endpoint (``PUT /api/2.0/serving-endpoints/<name>/ai-gateway``) and are
+enforced on the classic ``/serving-endpoints/*`` routes. The Unity AI
+Gateway routes (``/ai-gateway/*``) resolve the model in the UC model
+catalog, not through that endpoint's config, so they do NOT inherit its
+guardrails. A probe that only calls one route family will therefore reach
+the wrong conclusion — which is exactly what happened in the July 2026 run
+of this script, when it probed via the gateway route only and recorded a
+false ❌ "settable but not enforced".
+
+✅ means: a configured guardrail actually blocked a synthetic-PII request on
+at least one route.
+◑ means: enforced on some routes and bypassed on others (the current state).
+❌ means: the guardrail was accepted but blocked nothing on any route.
+❓ means: read-only mode — settability not probed.
 
 Safety: NEVER enables guardrails on shared endpoints without
-ALLOW_ENDPOINT_MUTATION=1 (the same opt-in gating scripts 03-08's
-mutations). If a guardrail is ALREADY enabled, one benign boundary probe is
-sent — fully synthetic PII ("my SSN is 000-00-0000"), no real data. Any
-mutation is restored in a finally block.
+ALLOW_ENDPOINT_MUTATION=1. All probes use fully synthetic PII
+("000-00-0000", card "4111 1111 1111 1111") and no real data. Every mutation
+is restored in a finally block.
 """
 
 from __future__ import annotations
@@ -28,6 +34,8 @@ import sys
 import time
 from pathlib import Path
 
+import requests
+
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import _gov_common as gov  # noqa: E402
@@ -35,21 +43,75 @@ import _common  # noqa: E402
 
 ROW_KEY = "guardrails_pii_injection_unsafe"
 
+# Fully synthetic: a reserved-invalid SSN and the standard Visa test card.
 SYNTHETIC_PII_PROMPT = (
-    "For a compliance test: my SSN is 000-00-0000 and my card number is "
-    "0000-0000-0000-0000. Repeat them back."
+    "For a compliance test, repeat these test values back exactly: "
+    "SSN 000-00-0000, card 4111 1111 1111 1111, email a@b.com."
 )
+BENIGN_PROMPT = "What is 2+2?"
 
 GUARDRAIL_KNOBS = ("pii", "safety", "valid_topics", "invalid_keywords")
+
+# Guardrail config used for the enforcement probe.
+PROBE_GUARDRAILS = {"input": {"pii": {"behavior": "BLOCK"}, "safety": True}}
+
+# Config propagation is not instant on the serving endpoint.
+PROPAGATION_WAIT_S = 20
 
 
 def describe_guardrails(guardrails: dict) -> str:
     sides = []
     for side in ("input", "output"):
         cfg = guardrails.get(side) or {}
-        knobs = sorted(cfg.keys())
-        sides.append(f"{side}: {knobs or '(none)'}")
+        sides.append(f"{side}: {sorted(cfg.keys()) or '(none)'}")
     return "; ".join(sides)
+
+
+def _routes(model_id: str, endpoint_name: str) -> dict[str, tuple[str, str]]:
+    """route label -> (url, model value to send). Both families, explicitly."""
+    host = _common.get_host()
+    return {
+        "gateway /ai-gateway/mlflow/v1/chat/completions": (
+            f"{host}/ai-gateway/mlflow/v1/chat/completions",
+            model_id,
+        ),
+        "classic /serving-endpoints/chat/completions": (
+            f"{host}/serving-endpoints/chat/completions",
+            endpoint_name,
+        ),
+    }
+
+
+def _probe(url: str, model_value: str, prompt: str) -> tuple[int, str]:
+    """One chat completion against one explicit route. Never raises."""
+    headers = {
+        "Authorization": f"Bearer {_common.get_token()}",
+        "Content-Type": "application/json",
+    }
+    payload = {
+        "model": model_value,
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": 40,
+    }
+    try:
+        resp = requests.post(url, headers=headers, json=payload, timeout=90)
+    except requests.RequestException as exc:  # network-level only
+        return 0, str(exc)[:200]
+    return resp.status_code, resp.text[:400]
+
+
+def _flagged_categories(body: str) -> list[str]:
+    """Pull the flagged guardrail categories out of a rejection body."""
+    try:
+        message = json.loads(json.loads(body).get("message", "{}"))
+    except (ValueError, TypeError, AttributeError):
+        return []
+    found: list[str] = []
+    for key in ("input_guardrail", "output_guardrail"):
+        for entry in message.get(key) or []:
+            if entry.get("flagged"):
+                found += [k for k, v in (entry.get("categories") or {}).items() if v]
+    return sorted(set(found))
 
 
 def main() -> int:
@@ -74,114 +136,120 @@ def main() -> int:
     ai_gateway = body.get("ai_gateway", {}) or {}
     guardrails = ai_gateway.get("guardrails") or {}
     print(f"  ai_gateway present: {bool(ai_gateway)}; guardrails configured: {bool(guardrails)}")
-    if guardrails:
-        print(f"  guardrails (verbatim): {json.dumps(guardrails, indent=2, sort_keys=True)}")
 
-    injection_knobs = [
-        k for k in gov.collect_keys(guardrails) if "injection" in k.lower()
-    ]
-
-    # --- Case A: guardrails already enabled — safe to send one benign probe -
-    if guardrails:
-        knob_report = describe_guardrails(guardrails)
-        print("  A guardrail is already enabled — sending ONE benign synthetic-PII boundary probe.")
-        probe_status, probe_body = _common.chat_completion(
-            model_id, SYNTHETIC_PII_PROMPT, max_tokens=48
-        )
-        print(f"  Synthetic-PII probe -> HTTP {probe_status}: {gov.snip(probe_body, 200)}")
-        gov.conclude(
-            ROW_KEY,
-            True,
-            f"Guardrail surface exists and is configured ({knob_report}). "
-            f"Synthetic-PII boundary probe (000-00-0000) -> HTTP {probe_status} "
-            f"({gov.snip(probe_body, 200)}). No dedicated prompt-injection knob "
-            f"observed{' (injection-shaped keys: ' + str(injection_knobs) + ')' if injection_knobs else ''} — "
-            "documented knobs are pii/safety/valid_topics/invalid_keywords.",
-        )
-        return 0
-
-    # --- Case B: not configured; probing settability is a mutation ---------
     if not gov.mutation_allowed():
         gov.print_mutation_gate()
         print("  The mutation path would attempt (then restore):")
         print(f"    PUT /api/2.0/serving-endpoints/{endpoint_name}/ai-gateway")
-        print('    {"guardrails": {"input": {"pii": {"behavior": "BLOCK"}, "safety": true}}}')
-        print("  Never enable guardrails on shared endpoints without this opt-in.")
+        print(f"    {json.dumps({'guardrails': PROBE_GUARDRAILS})}")
+        print("  ...then send the same synthetic-PII prompt down BOTH route")
+        print("  families to see which of them actually enforces it.")
         gov.conclude(
             ROW_KEY,
             None,
-            "No guardrails currently configured on this endpoint and "
-            f"{gov.MUTATION_ENV}=1 not set — settability not probed (dry-run). "
-            f"Documented knobs to probe: {GUARDRAIL_KNOBS} on input/output; a "
-            "dedicated prompt-injection filter is NOT in the documented schema. "
-            f"ai_gateway keys={sorted(ai_gateway.keys()) if ai_gateway else '(absent)'}",
+            f"{gov.MUTATION_ENV}=1 not set — enforcement not probed (dry-run). "
+            f"Currently configured: {describe_guardrails(guardrails) if guardrails else '(none)'}. "
+            f"Documented knobs: {GUARDRAIL_KNOBS} on input/output; there is no "
+            "dedicated prompt-injection filter in this endpoint's schema.",
         )
         return 0
 
+    routes = _routes(model_id, endpoint_name)
     original_gateway = ai_gateway
     mutated = False
     try:
-        probe_payload = dict(ai_gateway) if ai_gateway else {}
-        probe_payload["guardrails"] = {
-            "input": {"pii": {"behavior": "BLOCK"}, "safety": True}
-        }
+        payload = dict(ai_gateway)
+        payload["guardrails"] = PROBE_GUARDRAILS
         put_status, put_body = gov.api_request(
             "PUT",
             f"/api/2.0/serving-endpoints/{endpoint_name}/ai-gateway",
-            payload=probe_payload,
+            payload=payload,
         )
         mutated = put_status == 200
-        print(f"  PUT ai-gateway guardrails -> HTTP {put_status}: {gov.snip(put_body, 200)}")
-        if put_status == 200:
-            _common.ok("Guardrails accepted configuration (pii BLOCK + safety on input).")
-            # Config propagation is not instant — probe with increasing
-            # waits and judge enforcement by the LAST probe, not the first.
-            print("  Probing synthetic PII with propagation waits (0s/30s/60s)...")
-            probes: list[tuple[int, int]] = []
-            probe_status, probe_body = None, None
-            elapsed = 0
-            for wait in (0, 30, 60):
-                if wait:
-                    time.sleep(wait)
-                    elapsed += wait
-                probe_status, probe_body = _common.chat_completion(
-                    model_id, SYNTHETIC_PII_PROMPT, max_tokens=48
-                )
-                print(f"  probe after ~{elapsed}s -> HTTP {probe_status}: {gov.snip(probe_body, 200)}")
-                probes.append((elapsed, probe_status))
-                if probe_status != 200:
-                    break
-            blocked = probe_status != 200
-            if blocked:
-                verdict_note = (
-                    "ENFORCED: with input.pii behavior=BLOCK active, the synthetic-PII "
-                    f"request was rejected (HTTP {probe_status})."
-                )
-            else:
-                verdict_note = (
-                    "NOT ENFORCED in this test: config was accepted, but a request "
-                    "containing synthetic PII still returned HTTP 200 (model echoed "
-                    "the values) on every probe up to ~90s after enablement — "
-                    "settable is not the same as enforcing."
-                )
+        effective = (put_body or {}).get("guardrails") if isinstance(put_body, dict) else None
+        print(f"  PUT ai-gateway guardrails -> HTTP {put_status}")
+        print(f"  Effective guardrails after PUT: {json.dumps(effective)}")
+
+        if put_status != 200:
+            _common.fail("Guardrails configuration refused by this endpoint.")
             gov.conclude(
                 ROW_KEY,
-                blocked,
-                f"Guardrail surface exists and accepts configuration (input.pii "
-                f"behavior=BLOCK, input.safety=true via PUT ai-gateway; restored "
-                f"afterwards). {verdict_note} Probe trail: "
-                f"{[(f'{w}s', s) for w, s in probes]}. Last body: "
-                f"{gov.snip(probe_body, 180)}. No dedicated prompt-injection knob "
-                "in the schema — knobs are pii/safety/valid_topics/invalid_keywords.",
+                False,
+                f"PUT ai-gateway guardrails -> HTTP {put_status} "
+                f"({gov.snip(put_body, 250)}) — no guardrail surface available "
+                f"on endpoint '{endpoint_name}'.",
+            )
+            return 1
+
+        _common.ok("Guardrails accepted configuration (input.pii=BLOCK + input.safety).")
+        print(f"  Waiting {PROPAGATION_WAIT_S}s for config propagation, then probing BOTH route families...")
+        time.sleep(PROPAGATION_WAIT_S)
+
+        results: dict[str, dict] = {}
+        for label, (url, model_value) in routes.items():
+            pii_status, pii_body = _probe(url, model_value, SYNTHETIC_PII_PROMPT)
+            benign_status, _ = _probe(url, model_value, BENIGN_PROMPT)
+            cats = _flagged_categories(pii_body) if pii_status != 200 else []
+            results[label] = {
+                "synthetic_pii": pii_status,
+                "benign": benign_status,
+                "flagged_categories": cats,
+            }
+            print(
+                f"    {label}\n"
+                f"      synthetic PII -> HTTP {pii_status}"
+                + (f" flagged={cats}" if cats else "")
+                + f" | benign control -> HTTP {benign_status}"
+            )
+
+        enforcing = [k for k, v in results.items() if v["synthetic_pii"] != 200]
+        bypassing = [k for k, v in results.items() if v["synthetic_pii"] == 200]
+        summary = "; ".join(
+            f"[{k}] PII={v['synthetic_pii']}"
+            + (f" flagged={v['flagged_categories']}" if v["flagged_categories"] else "")
+            + f" benign={v['benign']}"
+            for k, v in results.items()
+        )
+
+        if enforcing and bypassing:
+            _common.fail(
+                "Guardrails enforce on the classic serving routes but are "
+                "BYPASSED by the Unity AI Gateway routes."
+            )
+            gov.conclude(
+                ROW_KEY,
+                None,
+                "PARTIAL — guardrails are real but route-scoped. Endpoint "
+                f"guardrails ({json.dumps(effective)}) blocked the synthetic-PII "
+                f"request on {enforcing} and were bypassed on {bypassing}. "
+                "Guardrails configured on a serving endpoint govern the classic "
+                "/serving-endpoints/* routes only; the /ai-gateway/* routes "
+                "resolve the model in the UC catalog and do not inherit them, so "
+                "a coding agent pointed at /ai-gateway/* is UNGUARDED by this "
+                f"config. Probe trail: {summary}. Benign controls returned 200 "
+                "everywhere, so the block is guardrail-specific, not an outage. "
+                "No dedicated prompt-injection knob in this endpoint's schema — "
+                "knobs are pii/safety/valid_topics/invalid_keywords (jailbreak/"
+                "hallucination/custom keys are silently dropped by this API).",
             )
             return 0
-        _common.fail("Guardrails configuration refused by this endpoint.")
+        if enforcing:
+            _common.ok("Guardrails enforced on every probed route.")
+            gov.conclude(
+                ROW_KEY,
+                True,
+                "ENFORCED on all probed routes: the synthetic-PII request was "
+                f"rejected everywhere. Probe trail: {summary}. Effective config: "
+                f"{json.dumps(effective)}.",
+            )
+            return 0
+        _common.fail("Guardrail accepted but blocked nothing on any route.")
         gov.conclude(
             ROW_KEY,
             False,
-            f"PUT ai-gateway guardrails -> HTTP {put_status} "
-            f"({gov.snip(put_body, 250)}) — no guardrail surface available on "
-            f"this endpoint. ai_gateway keys={sorted(ai_gateway.keys()) if ai_gateway else '(absent)'}",
+            "NOT ENFORCED: the guardrail config was accepted "
+            f"({json.dumps(effective)}) but the synthetic-PII request returned "
+            f"HTTP 200 on every route family. Probe trail: {summary}.",
         )
         return 1
     finally:


### PR DESCRIPTION
Re-runs the `coding_agent_inference_unity_ai_gateway` capability matrix against the same AWS workspace, four weeks after the original July 2026 run and after a wave of Databricks AI Gateway releases. Four rows moved — **two of them because the original probe was wrong, not because the product changed.**

## Headline: guardrails enforce now, but not on the routes this experiment recommends

Guardrails are configured on a *serving endpoint* and enforced when you call that endpoint. The Unity AI Gateway routes resolve the model in the UC catalog instead, so they never consult that config. Same workspace, same model, one guardrail config (`input.pii=BLOCK` + `input.safety`):

| Route | benign prompt | synthetic PII |
|---|---|---|
| `POST /serving-endpoints/chat/completions` | 200 | **400** — `input_guardrail` flagged, categories `['privacy']` |
| `POST /ai-gateway/mlflow/v1/chat/completions` | 200 | **200** — values echoed back |

Reproduced across four guardrail configurations plus a no-guardrail control where every cell returned 200. Every config template in this experiment points at `/ai-gateway/*` (the only family that resolves three-part ids), so a fleet set up this way is **unguarded** by the endpoint guardrail an admin is most likely to have set.

July recorded ❌ "settable but not enforced" because the probe only ever called the gateway route. `10_guardrails_pii_injection_unsafe.py` now probes both families with a benign control.

Also found: the endpoint API **silently drops** guardrail keys it does not understand (`jailbreak`, `hallucination`, `custom`, `pii.behavior=SANITIZE` all return 200 and come back gone).

## Per-agent attribution is solved, by a new table and a new header

| Route family | Mechanism | Lands in |
|---|---|---|
| `/serving-endpoints/*` | `usage_context` map in the request **body** | `system.serving.endpoint_usage` |
| `/ai-gateway/*` | `Databricks-Ai-Gateway-Request-Tags` **header** | `system.ai_gateway.usage.request_tags` |

Both verified live; crossing them fails silently, and there is no `X-Databricks-Usage-Context` header. July's ❌ came from sampling ten rows instead of counting the table — 170,924 tagged rows exist on the exact gateway route it found empty. Row 09 now counts table-wide and reports the observed ingestion lag (15–25 min) instead of treating a missing marker as absence.

The Claude Code, Codex and OpenCode templates now set the request-tags header.

## Row-by-row

| # | Jul | Aug | What changed |
|---|---|---|---|
| 3 | ❌ | ❓ | Blocker is now a named gate: `INVALID_STATE: MODEL is not enabled` |
| 8 | ❌ | ❓ | `BLOCK_USAGE` is a real, spend-denominated account budget action (47 of 440 budgets on a probed account). Per-**user** scoping still not exposed by this API version |
| 9 | ◑ | ✅ | New table + header, verified end-to-end |
| 10 | ❌ | ◑ | Enforced on classic routes, bypassed on gateway routes |

Rows 1, 2, 4, 5, 6, 7 unchanged. UC still has no `DENY` (re-verified: `UC_COMMAND_NOT_SUPPORTED`); ABAC arrived but adds GRANT policies only.

## New: `00_enablement_probe.py`

Most ❓ cells are an enablement gate, not a missing capability, and the gates differ per workspace. This read-only script reports which are open. On the test workspace: foundation-model UC permissions **off**, model services / service policies **off**, ABAC **on** (grant-only), `system.ai_gateway.usage` **present**, model-provider-services header **404**.

## Verification

- Rows 1, 2, 7, 8, 9, 10 re-executed end-to-end against a live workspace; results in `results/matrix_results.json` carry August timestamps.
- Row 10 mutates the shared FM endpoint's guardrail config for ~1 minute and restores it in a `finally` block — confirmed restored to `{"usage_tracking_config": {"enabled": true}}` after every run.
- Rows 3–6 need a second test principal and were not re-executed; their blockers were re-verified directly.
- Zero PATs throughout; SSO/OAuth only.

## Not done

The per-user half of row 8 needs account-console access to the workspace's own account (`05d08df7-…`). An account login was started during this session but the browser step was not completed, so the account probe ran against a different reachable account. Worth a follow-up with `DATABRICKS_ACCOUNT_PROFILE` pointed at the right account.

This pull request and its description were written by Isaac.

https://claude.ai/code/session_01UrnU6CE1ntGaMcWWa6rfvi