### PR TITLE
fix: probe model services over REST — the SQL check reported a false OFF

### DIFF
--- a/experiments/coding_agent_inference_unity_ai_gateway/README.md
+++ b/experiments/coding_agent_inference_unity_ai_gateway/README.md
@@ -57,8 +57,8 @@ records stand.
 | 1 | Query model via gateway with SSO/OAuth (no PAT) | Core goal | ✅ | **✅** | Unchanged. HTTP 200 with a short-lived OAuth token on `/ai-gateway/mlflow/v1/chat/completions` |
 | 2 | Three-part UC identifier (`system.ai.<model>`) resolves | [Unity AI Gateway](https://docs.databricks.com/aws/en/ai-gateway) | ✅ | **✅** | Unchanged. **Gateway routes only** — `/serving-endpoints/*` still 404s on three-part ids |
 | 3 | GRANT/REVOKE EXECUTE on model service enforced | [Govern model services](https://docs.databricks.com/aws/en/ai-gateway/govern-model-services) | ❌ | **❓** | Still not enforceable here, but the *reason* is now a named gate rather than a missing feature: foundation-model UC permissions answer `INVALID_STATE: MODEL is not enabled`, and `system.ai` still carries a schema-wide `EXECUTE` to `account users`. Enabling it is an account-team request |
-| 4 | DENY EXECUTE on a model actually blocks inference | [Govern model services](https://docs.databricks.com/aws/en/ai-gateway/govern-model-services) | ❌ | **❌** | Unity Catalog still has no `DENY` (`UC_COMMAND_NOT_SUPPORTED`; grants are additive-only). ABAC arrived but adds **GRANT** policies only. The one ALLOW/DENY/ASK surface — service policies on model services — is Beta and not enabled here (`MODEL SERVICE` is not a recognised securable) |
-| 5 | DENY on model + GRANT on gateway → user can still infer | Definer's-rights invocation per docs | ❓ | **❓** | Same blocker as row 4 plus no per-principal ACL on pay-per-token FM endpoints. Needs model services (Beta) or a custom / provisioned-throughput endpoint |
+| 4 | DENY EXECUTE on a model actually blocks inference | [Govern model services](https://docs.databricks.com/aws/en/ai-gateway/govern-model-services) | ❌ | **❌** | Unity Catalog still has no `DENY` (`UC_COMMAND_NOT_SUPPORTED`; grants are additive-only). ABAC arrived but adds **GRANT** policies only. The one ALLOW/DENY/ASK surface — service policies on model services — is Beta and not enabled here (the ABAC policy API does not accept `MODEL_SERVICE` as a securable type) |
+| 5 | DENY on model + GRANT on gateway → user can still infer | Definer's-rights invocation per docs | ❓ | **❓** | Same blocker as row 4. The pay-per-token *endpoint* has no per-principal ACL; the corresponding `MODEL_SERVICE` does, so this is exercisable on a workspace where those grants can be safely mutated |
 | 6 | Revoke gateway access → no fallback to old endpoints | Field sandbox observation | ❓ | **❓** | Unchanged. Pay-per-token FM endpoints still expose no per-principal permission to revoke |
 | 7 | Per-user alerting on spend threshold | [Budgets](https://docs.databricks.com/aws/en/admin/account-settings/budgets) | ✅ | **✅** | Unchanged. Usage tracking ON; alerting is composed from the usage system tables, not set as a field on the endpoint |
 | 8 | Per-user hard cap (block at budget) | [AI Gateway budgets](https://docs.databricks.com/aws/en/ai-gateway/budgets) | ❌ | **❓ (was ❌)** | Account budgets carry a `BLOCK_USAGE` action alongside `EMAIL_NOTIFICATION`, spend-denominated (`LIST_PRICE_DOLLARS_USD`, `CUMULATIVE_SPENDING_EXCEEDED`, monthly) — 47 of 440 budgets on a probed account use it. The **per-user** half stays unproven: every budget this API version returns is scoped by `workspace_id`/tags, with no per-user threshold or override field |
@@ -201,8 +201,20 @@ which apply to yours; here is what it reports on this one:
 | Foundation-model UC permissions (`MODEL` securable) | ❌ `INVALID_STATE: MODEL is not enabled` | Rows 3–6. Docs call it "GA but requires enablement" — an account-team request, not a self-serve toggle |
 | `system.ai` schema-wide `EXECUTE` to `account users` | ✅ still granted | Why row 3 cannot be isolated: while a broad group holds `EXECUTE`, a per-model GRANT is redundant and REVOKE of it changes nothing |
 | ABAC policy engine | ✅ available, 0 policies on `system.ai` | Adds **GRANT** policies (`GRANT EXECUTE FOR MODELS`). There is no DENY form, so row 4 is untouched |
-| Model services + service policies (Beta) | ❌ `MODEL SERVICE` not a recognised securable | Rows 4–6. Service policies are the only ALLOW/**DENY**/ASK surface for model access, and the only guardrail path for `/ai-gateway/*` |
+| Model services (`MODEL_SERVICE` securable) | ✅ 11 in `system.ai`, each with its own ACL | The per-model ACL for the `/ai-gateway/*` routes: `GET permissions/model_service/system.ai.glm-5-2` → `200 ['account users:EXECUTE']` |
+| Service policies on `MODEL_SERVICE` (Beta) | ❌ policy API rejects the securable type | Rows 4–6. Service policies are the only ALLOW/**DENY**/ASK surface for model access, and the guardrail path for `/ai-gateway/*` |
 | Model provider services header | ❌ 404 on `system.ai.anthropic` | The documented `Databricks-Model-Provider-Service` on-ramp for Claude Code |
+
+`MODEL` and `MODEL_SERVICE` are different securables and can be in opposite
+states, as they are here. `MODEL` is the foundation-model-permissions preview
+over registered models; `MODEL_SERVICE` is the Unity AI Gateway object the
+`/ai-gateway/*` routes resolve. Note also that there is no
+`SHOW GRANTS ON MODEL SERVICE` DDL — SQL returns `PARSE_SYNTAX_ERROR` whether
+or not the feature is live, so the probe asks the REST API instead. The
+service-policy verdict comes from the ABAC policy API, which reports the
+securable types it accepts: `CATALOG, FUNCTION, METASTORE, MODEL, SCHEMA,
+SECRET, TABLE, VOLUME` — `MODEL_SERVICE` and `MCP_SERVICE` are not among them
+on this workspace.
 
 Two things did not change between runs:
 
@@ -210,11 +222,14 @@ Two things did not change between runs:
   remain additive-only. ABAC did not add one — its `EXCEPT principal` clause
   excludes a principal from a grant, which is not a deny assignment. "DENY
   EXECUTE blocks inference" is not achievable as documented.
-- **Built-in pay-per-token FM endpoints have no per-principal ACL.** They
+- **Built-in pay-per-token FM *endpoints* have no per-principal ACL.** They
   expose no endpoint `id` and the permissions API rejects their name
   (`not a valid Inference Endpoint ID`), so endpoint-level `CAN_QUERY` grants
   and the "revoke → silent fallback" repro still need a custom or
-  provisioned-throughput endpoint.
+  provisioned-throughput endpoint. The corresponding **model service** does
+  have a per-principal ACL, which is a different object and a different route
+  family — rows 5 and 6 could be exercised against it on a workspace where
+  mutating those grants is safe.
 
 ### The Codex Responses route exists but rejected a Claude model
 
@@ -323,8 +338,11 @@ blockers are listed under Key Findings. To make them meaningful you need
 foundation-model UC permissions enabled (account-team request), and then to
 revoke the schema-wide `EXECUTE` on `system.ai` from `account users` — which
 affects **every user of that workspace**, so do it somewhere you own. Rows 5
-and 6 additionally need a custom or provisioned-throughput endpoint, since
-built-in pay-per-token endpoints have no per-principal ACL surface.
+and 6 need a per-principal ACL to revoke: either a custom or
+provisioned-throughput endpoint, or the `MODEL_SERVICE` securable, which
+carries its own ACL (`PATCH /api/2.1/unity-catalog/permissions/model_service/
+<catalog>.<schema>.<name>`) — again, on a workspace you own, since the only
+grant on the shared ones is `account users: EXECUTE`.
 
 ## Configuring your coding agents
 

--- a/experiments/coding_agent_inference_unity_ai_gateway/scripts/governance/00_enablement_probe.py
+++ b/experiments/coding_agent_inference_unity_ai_gateway/scripts/governance/00_enablement_probe.py
@@ -39,8 +39,10 @@ def _line(name: str, enabled: bool | None, detail: str) -> None:
 def probe_fm_uc_permissions() -> None:
     """Foundation-model UC permissions — 'GA but requires enablement'.
 
-    The tell is the securable type: with the feature off, Unity Catalog
-    answers INVALID_STATE 'MODEL is not enabled' for the MODEL securable,
+    This is the ``MODEL`` securable (registered models). It is a DIFFERENT
+    feature from ``MODEL_SERVICE`` (the Unity AI Gateway securable probed
+    below) — the two can be, and here are, in opposite states. With this
+    feature off, Unity Catalog answers INVALID_STATE 'MODEL is not enabled'
     and system.ai models are only addressable as FUNCTION.
     """
     status, body = gov.api_request(
@@ -93,18 +95,88 @@ def probe_abac_policies() -> None:
 
 
 def probe_model_services() -> None:
-    """Model services / service policies (Beta) — the new DENY-capable surface."""
-    res = gov.sql_exec("SHOW GRANTS ON MODEL SERVICE a.b.c")
-    supported = res["ok"] or "PARSE_SYNTAX_ERROR" not in (res["error"] or "")
-    _line(
-        "Model services + service policies (Beta)",
-        supported,
-        "MODEL SERVICE is a securable here."
-        if supported
-        else f"MODEL SERVICE securable not recognised by SQL: "
-        f"{gov.snip(res['error'], 130)} — service policies (the only ALLOW/DENY/ASK "
-        "surface for model access) are unavailable, so rows 4-6 stay untestable.",
+    """Unity AI Gateway model services — the MODEL_SERVICE UC securable.
+
+    Probe over REST, not SQL. There is no ``SHOW GRANTS ON MODEL SERVICE``
+    DDL — asking SQL about it returns PARSE_SYNTAX_ERROR whether or not the
+    feature is live, so a SQL probe reports a false OFF. The securable is
+    real and carries its own per-principal ACL; that is what to ask.
+    """
+    status, body = gov.api_request(
+        "GET",
+        "/api/2.1/unity-catalog/model-services"
+        "?catalog_name=system&schema_name=ai&max_results=200",
     )
+    services = (body or {}).get("model_services", []) if isinstance(body, dict) else []
+    if status != 200:
+        _line("Model services (MODEL_SERVICE securable)", False,
+              f"GET model-services -> {status} {gov.snip(body, 150)} — the Unity AI "
+              "Gateway model catalog is not available on this workspace.")
+        return
+
+    # Show an ACL that actually carries a grant when one exists — a service
+    # with no direct assignments reads as "ACL broken" when it only means
+    # nobody granted on that specific service.
+    acl_note = ""
+    for service in services[:5]:
+        name = service["name"].split("/")[-1]
+        acl_status, acl = gov.api_request(
+            "GET", f"/api/2.1/unity-catalog/permissions/model_service/{name}"
+        )
+        if acl_status != 200:
+            acl_note = (
+                f" Per-service ACL unreadable: permissions/model_service/{name} -> "
+                f"HTTP {acl_status} {gov.snip(acl, 120)}."
+            )
+            break
+        holders = [
+            f"{a.get('principal')}:{','.join(a.get('privileges') or [])}"
+            for a in ((acl or {}).get("privilege_assignments") or [])
+        ]
+        acl_note = (
+            f" Per-service ACL is live: permissions/model_service/{name} -> "
+            f"HTTP 200 {holders or '(no direct assignments on this one)'}."
+        )
+        if holders:
+            break
+    _line(
+        "Model services (MODEL_SERVICE securable)",
+        True,
+        f"{len(services)} model service(s) in system.ai.{acl_note} This is the "
+        "per-model ACL surface for the /ai-gateway/* routes — distinct from the "
+        "MODEL securable above, and distinct from service policies below.",
+    )
+
+
+def probe_service_policies() -> None:
+    """Service policies (Beta) — the only ALLOW/DENY/ASK surface for AI assets.
+
+    Service policies are ABAC policies scoped to a MODEL_SERVICE or
+    MCP_SERVICE. The honest test is whether the policy API accepts those
+    securable types at all; its rejection message enumerates the types it
+    does support, which is the most legible evidence available.
+    """
+    status, body = gov.api_request(
+        "GET",
+        "/api/2.1/unity-catalog/policies/MODEL_SERVICE/system.ai.claude-sonnet-4-6",
+    )
+    text = json.dumps(body) if not isinstance(body, str) else body
+    if status == 200:
+        count = len((body or {}).get("policies", []))
+        _line("Service policies on MODEL_SERVICE (Beta)", True,
+              f"policies API accepts MODEL_SERVICE; {count} policy(ies) attached. "
+              "Built-in guardrails are system.ai.block_pii / block_unsafe_content / "
+              "block_jailbreak / block_hallucination.")
+        return
+    # The rejection body is JSON; take only the human-readable type list.
+    supported = ""
+    if "Supported types" in text:
+        supported = text.split("Supported types:", 1)[1].split('"', 1)[0].strip(" .")
+    _line("Service policies on MODEL_SERVICE (Beta)", False,
+          f"policies API rejects MODEL_SERVICE -> HTTP {status}"
+          + (f"; it supports only: {supported}." if supported else f" {gov.snip(text, 150)}")
+          + " Service policies are the guardrail path for /ai-gateway/* and the only "
+          "ALLOW/DENY/ASK surface for model access, so rows 4-6 stay untestable here.")
 
 
 def probe_gateway_usage_table() -> None:
@@ -165,6 +237,7 @@ def main() -> int:
     probe_system_ai_grants()
     probe_abac_policies()
     probe_model_services()
+    probe_service_policies()
     probe_gateway_usage_table()
     probe_model_provider_services()
 


### PR DESCRIPTION
`00_enablement_probe.py` reported **"Model services + service policies (Beta): OFF"** on a workspace where model services are on. The check ran `SHOW GRANTS ON MODEL SERVICE a.b.c` and read `PARSE_SYNTAX_ERROR` as "not a securable here" — but there is no such DDL, so that error comes back identically whether or not the feature exists. It was testing SQL's vocabulary, not the workspace.

## What's actually true

Model services are live: **11 in `system.ai`**, each carrying its own per-principal ACL.

```
GET /api/2.1/unity-catalog/model-services?catalog_name=system&schema_name=ai
  -> 200, 11 services, securable_type: MODEL_SERVICE

GET /api/2.1/unity-catalog/permissions/model_service/system.ai.glm-5-2
  -> 200 {"privilege_assignments":[{"principal":"account users","privileges":["EXECUTE"]}]}
```

The probe now asks REST instead of SQL.

## Two securables, opposite states

The old single row conflated them:

| Securable | What it is | State here |
|---|---|---|
| `MODEL` | foundation-model-permissions preview over registered models | ❌ `INVALID_STATE: MODEL is not enabled` |
| `MODEL_SERVICE` | the Unity AI Gateway object `/ai-gateway/*` resolves | ✅ 11 in `system.ai`, ACL live |

Service policies now get their own row, with a verdict sourced from the ABAC policy API rather than inferred. Asking it about `MODEL_SERVICE` returns `400` and enumerates what it does accept — `CATALOG, FUNCTION, METASTORE, MODEL, SCHEMA, SECRET, TABLE, VOLUME`. `MODEL_SERVICE` and `MCP_SERVICE` are absent, which is the real evidence that service policies aren't available on this workspace.

## What does not change

Every matrix verdict. Rows 4–6 stay ❓/❌ for the same reason as before — the ALLOW/DENY/ASK surface isn't available here, and UC still has no `DENY`. Only the evidence behind the conclusion changes.

One README correction rides along: "built-in pay-per-token FM endpoints have no per-principal ACL" was true of the **endpoint** and wrongly generalized. The corresponding **model service** does have one, so rows 5 and 6 are exercisable against `MODEL_SERVICE` on a workspace where mutating those grants is safe — noted rather than attempted here, since the only grant on the shared services is `account users: EXECUTE`.

## Verification

- Probe re-executed against the live workspace; output in the commit message reflects the real run.
- All scripts parse; read-only throughout — no grants, endpoint configs, or policies were mutated.

This pull request and its description were written by Isaac.

https://claude.ai/code/session_01CW4Ts55VQV9hd22YgyjVbW