### PR TITLE
docs: say at the top that this experiment is paused, and how to resume it

### DIFF
--- a/experiments/coding_agent_inference_unity_ai_gateway/README.md
+++ b/experiments/coding_agent_inference_unity_ai_gateway/README.md
@@ -1,5 +1,48 @@
 # Coding Agent Inference over Unity AI Gateway (SSO)
 
+## ⏸️ Paused — further work expected
+
+**This experiment is not finished.** Several matrix rows below are ❓ because the
+capability that would make them testable is not switched on in the environment
+this runs against — not because the tests were skipped. They are expected to be
+answered once those gates open.
+
+| Waiting on | Blocks |
+|---|---|
+| Foundation-model Unity Catalog permissions enabled on the workspace | **Rows 3–6.** While the `MODEL` securable is off and a broad group holds `EXECUTE` on `system.ai`, a per-model GRANT is redundant and a REVOKE changes nothing — the enforcement question cannot be isolated |
+| Service policies attachable to the `MODEL_SERVICE` securable | **Rows 4–6, and the successor to row 10.** This is the only ALLOW/DENY/ASK surface for model access, and the guardrail path for the `/ai-gateway/*` routes every config template here points at |
+| Account-scoped budgets with a blocking action enabled on the account | **The per-user half of row 8.** The blocking action itself is proven; per-user scoping is not |
+
+### To resume
+
+1. **Find out which gates are open.** This is what the preflight exists for:
+   ```bash
+   uv run python scripts/governance/00_enablement_probe.py
+   ```
+2. **Re-run the rows behind any gate now reporting `✅ ON`:**
+   ```bash
+   # Rows 3–6 — also needs a second test principal (see Running the Tests)
+   ALLOW_ENDPOINT_MUTATION=1 uv run python scripts/governance/03_grant_revoke_execute_enforced.py
+   ALLOW_ENDPOINT_MUTATION=1 uv run python scripts/governance/04_deny_execute_blocks_inference.py
+   ALLOW_ENDPOINT_MUTATION=1 uv run python scripts/governance/05_deny_model_grant_gateway.py
+   ALLOW_ENDPOINT_MUTATION=1 uv run python scripts/governance/06_revoke_gateway_no_fallback.py
+
+   # Row 8 — needs a profile authenticated against the account console
+   DATABRICKS_ACCOUNT_PROFILE=<profile> uv run python scripts/governance/08_per_user_hard_cap.py
+
+   # Row 10 — re-probe once a service policy can be attached to the model service
+   ALLOW_ENDPOINT_MUTATION=1 uv run python scripts/governance/10_guardrails_pii_injection_unsafe.py
+   ```
+3. **Update the affected matrix rows and Key Findings.** The scripts rewrite
+   `results/matrix_results.json` themselves; the prose is yours.
+4. **Delete any row of the table above that has cleared.** This block is a live
+   claim about what is still outstanding, not a changelog — resolved gates
+   belong in Key Findings as history.
+
+**Last checked:** 2026-08-06 — the first two gates were verified closed by the
+preflight above. The third could not be checked from the account this experiment
+runs in, and row 8 records it as unproven rather than absent.
+
 ## Overview
 
 This experiment establishes — with hard testing against a real workspace — which


### PR DESCRIPTION
The matrix has ❓ rows that are waiting on capabilities being switched on in the environment the experiment runs against — not rows that were skipped. Until now that distinction lived in a merged PR description and a paragraph buried under "Running the Tests", so neither reader could tell the two apart:

- a **human** skimming the README sees ❓ cells and can't tell "nobody tried this" from "this resumes when a gate opens";
- an **agent** picking the work back up has no machine-followable statement of what to check, what to re-run, and which rows to update.

## What's added

A **⏸️ Paused** block directly under the title, above the matrix:

- **A gate table** — each capability being waited on, paired with the matrix rows it blocks and one line on why those rows can't be isolated without it.
- **An executable resume path** — starts with `00_enablement_probe.py` (which exists precisely to answer "which gates are open here"), then names the exact script per row, with the env vars each one needs.
- **A self-cleanup instruction** — delete gate rows as they clear, so the block stays a live claim about what's outstanding rather than accumulating into a changelog.
- **A `Last checked` date**, so staleness is visible without git archaeology.

## Public-repo safety

This kind of header is unusually prone to leaking, because the natural way to write a blocker is a person, a date, and an internal roadmap item. This one is written to avoid that:

- capabilities are named the way the **public docs** name them;
- the environment is described by **shape** ("the workspace this runs against", "the account"), not coordinates;
- no people, no customers, no account or workspace ids, no internal feature names, no timelines or roadmap dates.

Verified by scanning the whole README for names, customer references, account ids, workspace hostnames, dated roadmap claims and internal links — the only URL match is the generic public account-console endpoint in an existing setup command.

## Accuracy

- All seven referenced scripts exist at the paths given.
- The `Last checked` line is scoped honestly: the first two gates were verified closed by the preflight this session; the third could not be checked from this experiment's own account, and says so rather than implying a negative result.

## Follow-up

The convention itself is filed as a `shareables-experiment` skill improvement in the marketplace repo (randypitcherii/rpw-agent-marketplace-private#844), including the sanitization rules — so the next experiment gets this shape from the skill rather than by hand.

This pull request and its description were written by Isaac.

https://claude.ai/code/session_017h36JxraAazL5wrZKDSsFv