### PR TITLE
fix: follow rpw_prod catalog rename

### DIFF
--- a/databricks/demos/dbt/Makefile
+++ b/databricks/demos/dbt/Makefile
@@ -15,7 +15,10 @@
 DEPLOY_DATE := $(shell date +%Y-%m-%d)
 GIT_SHA := $(shell git rev-parse HEAD)
 
-.PHONY: deploy-dev deploy-prod deploy-prod-local
+.PHONY: test deploy-dev deploy-prod deploy-prod-local
+
+test:
+	uv run --with pytest pytest tests -q
 
 deploy-dev:
 	databricks bundle deploy -t dev --var="deployed_at=$(DEPLOY_DATE)"

--- a/databricks/demos/dbt/README.md
+++ b/databricks/demos/dbt/README.md
@@ -213,8 +213,8 @@ run, not via manual GRANT statements.
 Default production artifact paths:
 
 ```text
-/Volumes/fe_randy_pitcher_workspace_catalog/dbt_artifacts/dbt_demo_artifacts/state/latest
-/Volumes/fe_randy_pitcher_workspace_catalog/dbt_artifacts/dbt_demo_artifacts/docs/latest
+/Volumes/rpw_prod/dbt_artifacts/dbt_demo_artifacts/state/latest
+/Volumes/rpw_prod/dbt_artifacts/dbt_demo_artifacts/docs/latest
 ```
 
 Deploy and run:

--- a/databricks/demos/dbt/databricks.yml
+++ b/databricks/demos/dbt/databricks.yml
@@ -7,7 +7,7 @@ include:
 variables:
   production_catalog:
     description: Unity Catalog catalog used by production dbt runs.
-    default: fe_randy_pitcher_workspace_catalog
+    default: rpw_prod
   production_schema:
     description: Default schema for production dbt models without a layer-specific schema.
     default: dbt

--- a/databricks/demos/dbt/docs_app/app.py
+++ b/databricks/demos/dbt/docs_app/app.py
@@ -15,7 +15,7 @@ from urllib.parse import urlsplit
 from databricks.sdk import WorkspaceClient
 
 
-DEFAULT_ARTIFACT_CATALOG = "fe_randy_pitcher_workspace_catalog"
+DEFAULT_ARTIFACT_CATALOG = "rpw_prod"
 DEFAULT_ARTIFACT_SCHEMA = "dbt_artifacts"
 DEFAULT_ARTIFACT_VOLUME = "dbt_demo_artifacts"
 DEPLOYMENT_ENVIRONMENT = os.environ.get("DBT_DEPLOYMENT_ENVIRONMENT", "production")

--- a/databricks/demos/dbt/docs_app/app.yaml
+++ b/databricks/demos/dbt/docs_app/app.yaml
@@ -8,7 +8,7 @@ env:
   - name: DBT_ARTIFACT_VOLUME_FULL_NAME
     valueFrom: dbt-docs-volume
   - name: DBT_ARTIFACT_CATALOG
-    value: fe_randy_pitcher_workspace_catalog
+    value: rpw_prod
   - name: DBT_ARTIFACT_SCHEMA
     value: dbt_artifacts
   - name: DBT_ARTIFACT_VOLUME

--- a/databricks/demos/dbt/tests/test_catalog_defaults.py
+++ b/databricks/demos/dbt/tests/test_catalog_defaults.py
@@ -1,0 +1,20 @@
+"""Deployment defaults for the DEFAULT-profile workspace."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+OLD_CATALOG = "fe_randy_pitcher_workspace_catalog"
+
+
+def test_active_dbt_sources_use_the_renamed_catalog() -> None:
+    bundle = (ROOT / "databricks.yml").read_text()
+    active_sources = [
+        bundle,
+        (ROOT / "docs_app" / "app.py").read_text(),
+        (ROOT / "docs_app" / "app.yaml").read_text(),
+        (ROOT / "README.md").read_text(),
+    ]
+
+    assert "default: rpw_prod" in bundle
+    assert all(OLD_CATALOG not in source for source in active_sources)

--- a/databricks/demos/simple_dispatcher_agent/README.md
+++ b/databricks/demos/simple_dispatcher_agent/README.md
@@ -120,18 +120,18 @@ databricks bundle validate -t prod
 
 # Deploy + run against your dev sandbox
 databricks bundle deploy -t dev \
-  --var base_catalog=<catalog> --var genie_space_id=<space-id>
+  --var base_catalog=rpw_prod --var genie_space_id=<space-id>
 databricks bundle run deploy_dispatcher -t dev \
-  --var base_catalog=<catalog> --var genie_space_id=<space-id>
+  --var base_catalog=rpw_prod --var genie_space_id=<space-id>
 
 # Production (also creates/refreshes the scale-to-zero serving endpoint).
 # genie_tables: comma-separated FQNs of the tables your Genie space queries —
 # the deployed endpoint's credential is scoped to declared resources only,
 # so without this the Genie route fails with table-level PermissionDenied.
-databricks bundle deploy -t prod --var base_catalog=<catalog> --var genie_space_id=<space-id> \
-  --var genie_tables=<catalog>.<schema>.<table>[,...]
-databricks bundle run deploy_dispatcher -t prod --var base_catalog=<catalog> --var genie_space_id=<space-id> \
-  --var genie_tables=<catalog>.<schema>.<table>[,...]
+databricks bundle deploy -t prod --var base_catalog=rpw_prod --var genie_space_id=<space-id> \
+  --var genie_tables=rpw_prod.<schema>.<table>[,...]
+databricks bundle run deploy_dispatcher -t prod --var base_catalog=rpw_prod --var genie_space_id=<space-id> \
+  --var genie_tables=rpw_prod.<schema>.<table>[,...]
 ```
 
 **Targets** (same env-isolation pattern as `databricks_gsheets_reader`):

--- a/databricks/demos/simple_dispatcher_agent/databricks.yml
+++ b/databricks/demos/simple_dispatcher_agent/databricks.yml
@@ -7,7 +7,7 @@ workspace:
 variables:
   base_catalog:
     description: Catalog hosting the web_search UDF and the registered agent model.
-    default: your_catalog
+    default: rpw_prod
   base_schema:
     description: >
       Schema base name.

--- a/databricks/demos/simple_dispatcher_agent/tests/test_bundle.py
+++ b/databricks/demos/simple_dispatcher_agent/tests/test_bundle.py
@@ -1,0 +1,13 @@
+"""Deployment defaults for the DEFAULT-profile workspace."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_bundle_defaults_to_the_renamed_catalog() -> None:
+    bundle = (ROOT / "databricks.yml").read_text()
+
+    assert "default: rpw_prod" in bundle
+    assert "fe_randy_pitcher_workspace_catalog" not in bundle

--- a/databricks/libraries/databricks_gsheets_reader/databricks.yml
+++ b/databricks/libraries/databricks_gsheets_reader/databricks.yml
@@ -7,7 +7,7 @@ workspace:
 variables:
   base_catalog:
     description: Catalog base that _dev, _test, _prod can be appended to for catalog-level env isolation
-    default: your_catalog
+    default: rpw_prod
   base_schema:
     description: >
       Schema base name.

--- a/databricks/libraries/databricks_gsheets_reader/tests/test_bundle.py
+++ b/databricks/libraries/databricks_gsheets_reader/tests/test_bundle.py
@@ -1,0 +1,13 @@
+"""Deployment defaults for the DEFAULT-profile workspace."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_bundle_defaults_to_the_renamed_catalog() -> None:
+    bundle = (ROOT / "databricks.yml").read_text()
+
+    assert "default: rpw_prod" in bundle
+    assert "fe_randy_pitcher_workspace_catalog" not in bundle

--- a/databricks/libraries/hive_to_delta/DEBUGGING.md
+++ b/databricks/libraries/hive_to_delta/DEBUGGING.md
@@ -703,7 +703,7 @@ aws glue get-tables --database-name hive_to_delta_test --query 'TableList[].Name
 # Expected: standard_table, cross_bucket_table, cross_region_table
 
 # Check converted tables in Unity Catalog
-export CATALOG=fe_randy_pitcher_workspace_catalog
+export CATALOG=rpw_prod
 export SCHEMA=hive_to_delta_tests
 
 databricks tables list --catalog $CATALOG --schema $SCHEMA --output json | \
@@ -716,7 +716,7 @@ databricks tables list --catalog $CATALOG --schema $SCHEMA --output json | \
 export AWS_PROFILE=fe-sandbox
 export DATABRICKS_CONFIG_PROFILE=fe
 export HIVE_TO_DELTA_TEST_WAREHOUSE_ID=<warehouse-id>
-export HIVE_TO_DELTA_TEST_CATALOG=fe_randy_pitcher_workspace_catalog
+export HIVE_TO_DELTA_TEST_CATALOG=rpw_prod
 export HIVE_TO_DELTA_TEST_SCHEMA=hive_to_delta_tests
 export HIVE_TO_DELTA_TEST_GLUE_DATABASE=hive_to_delta_test
 

--- a/databricks/libraries/hive_to_delta/Makefile
+++ b/databricks/libraries/hive_to_delta/Makefile
@@ -7,7 +7,7 @@
 export AWS_PROFILE ?= aws-sandbox-field-eng_databricks-sandbox-admin
 export AWS_REGION ?= us-east-1
 export HIVE_TO_DELTA_TEST_GLUE_DATABASE ?= hive_to_delta_test
-export HIVE_TO_DELTA_TEST_CATALOG ?= fe_randy_pitcher_workspace_catalog
+export HIVE_TO_DELTA_TEST_CATALOG ?= rpw_prod
 export HIVE_TO_DELTA_TEST_SCHEMA ?= hive_to_delta_tests
 
 # Default target
@@ -49,7 +49,7 @@ help:
 	@echo "  AWS_PROFILE                      - AWS CLI profile (default: aws-sandbox-field-eng_databricks-sandbox-admin)"
 	@echo "  AWS_REGION                       - AWS region (default: us-east-1)"
 	@echo "  HIVE_TO_DELTA_TEST_GLUE_DATABASE - Glue database name (default: hive_to_delta_test)"
-	@echo "  HIVE_TO_DELTA_TEST_CATALOG       - Unity Catalog name (default: fe_randy_pitcher_workspace_catalog)"
+	@echo "  HIVE_TO_DELTA_TEST_CATALOG       - Unity Catalog name (default: rpw_prod)"
 	@echo "  HIVE_TO_DELTA_TEST_SCHEMA        - Unity Catalog schema (default: hive_to_delta_tests)"
 	@echo "  HIVE_TO_DELTA_TEST_WAREHOUSE_ID  - SQL Warehouse ID (auto-detected if not set)"
 	@echo ""

--- a/databricks/libraries/hive_to_delta/README.md
+++ b/databricks/libraries/hive_to_delta/README.md
@@ -953,7 +953,7 @@ make test                # Everything
 |----------|---------|---------|
 | `HIVE_TO_DELTA_TEST_WAREHOUSE_ID` | auto-discovered | SQL Warehouse for cross-bucket tests |
 | `HIVE_TO_DELTA_TEST_GLUE_DATABASE` | `hive_to_delta_test` | Source Hive database |
-| `HIVE_TO_DELTA_TEST_CATALOG` | `fe_randy_pitcher_workspace_catalog` | Target Unity Catalog |
+| `HIVE_TO_DELTA_TEST_CATALOG` | `rpw_prod` | Target Unity Catalog |
 | `HIVE_TO_DELTA_TEST_SCHEMA` | `hive_to_delta_tests` | Target schema |
 | `DATABRICKS_CONFIG_PROFILE` | none | Databricks CLI profile |
 | `AWS_PROFILE` | none | AWS credentials profile |

--- a/databricks/libraries/hive_to_delta/TESTING.md
+++ b/databricks/libraries/hive_to_delta/TESTING.md
@@ -75,7 +75,7 @@ Markers are defined in `pyproject.toml`.
 |----------|---------|---------|
 | `HIVE_TO_DELTA_TEST_WAREHOUSE_ID` | auto-discovered | SQL Warehouse for cross-bucket tests |
 | `HIVE_TO_DELTA_TEST_GLUE_DATABASE` | `hive_to_delta_test` | Source Hive database |
-| `HIVE_TO_DELTA_TEST_CATALOG` | `fe_randy_pitcher_workspace_catalog` | Target Unity Catalog |
+| `HIVE_TO_DELTA_TEST_CATALOG` | `rpw_prod` | Target Unity Catalog |
 | `HIVE_TO_DELTA_TEST_SCHEMA` | `hive_to_delta_tests` | Target schema |
 | `DATABRICKS_CONFIG_PROFILE` | none | Databricks CLI profile |
 | `AWS_PROFILE` | none | AWS credentials profile |

--- a/databricks/libraries/hive_to_delta/tests/conftest.py
+++ b/databricks/libraries/hive_to_delta/tests/conftest.py
@@ -85,9 +85,9 @@ def target_catalog() -> str:
     """Return the Unity Catalog name for test tables.
 
     Reads from HIVE_TO_DELTA_TEST_CATALOG env var,
-    defaults to "fe_randy_pitcher_workspace_catalog".
+    defaults to "rpw_prod".
     """
-    return os.environ.get("HIVE_TO_DELTA_TEST_CATALOG", "fe_randy_pitcher_workspace_catalog")
+    return os.environ.get("HIVE_TO_DELTA_TEST_CATALOG", "rpw_prod")
 
 
 @pytest.fixture(scope="session")

--- a/experiments/duckdb-unity-catalog/scripts/_common.py
+++ b/experiments/duckdb-unity-catalog/scripts/_common.py
@@ -2,7 +2,7 @@
 
 import os
 
-CATALOG = "fe_randy_pitcher_workspace_catalog"
+CATALOG = "rpw_prod"
 SCHEMA = "duckdb_uc_experiment"
 FULL_SCHEMA = f"{CATALOG}.{SCHEMA}"
 WORKSPACE = "fe-vm-fe-randy-pitcher-workspace.cloud.databricks.com"

--- a/experiments/duckdb-unity-catalog/scripts/iceberg_rest_eval.py
+++ b/experiments/duckdb-unity-catalog/scripts/iceberg_rest_eval.py
@@ -51,7 +51,7 @@ except ImportError:
 # ---------------------------------------------------------------------------
 
 WORKSPACE = "fe-vm-fe-randy-pitcher-workspace.cloud.databricks.com"
-CATALOG = "fe_randy_pitcher_workspace_catalog"
+CATALOG = "rpw_prod"
 SCHEMA = "duckdb_uc_experiment"
 ENDPOINT = f"https://{WORKSPACE}/api/2.1/unity-catalog/iceberg-rest"
 

--- a/experiments/duckdb-unity-catalog/tests/test_catalog_defaults.py
+++ b/experiments/duckdb-unity-catalog/tests/test_catalog_defaults.py
@@ -1,0 +1,15 @@
+"""Defaults for scripts targeting the DEFAULT-profile workspace."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_active_scripts_use_the_renamed_catalog() -> None:
+    scripts = [
+        (ROOT / "scripts" / "_common.py").read_text(),
+        (ROOT / "scripts" / "iceberg_rest_eval.py").read_text(),
+    ]
+
+    assert all('CATALOG = "rpw_prod"' in script for script in scripts)

--- a/experiments/pulsar-to-uc-managed-tables/databricks/databricks.yml
+++ b/experiments/pulsar-to-uc-managed-tables/databricks/databricks.yml
@@ -17,6 +17,7 @@ variables:
     default: persistent://public/default/uc-ingest-eval
   uc_catalog:
     description: Target Unity Catalog
+    default: rpw_prod
   uc_schema:
     description: Target schema
     default: pulsar_uc_ingest_eval

--- a/experiments/pulsar-to-uc-managed-tables/template.env
+++ b/experiments/pulsar-to-uc-managed-tables/template.env
@@ -9,7 +9,7 @@ PULSAR_TOPIC=persistent://public/default/uc-ingest-eval
 
 # --- Databricks ---
 DATABRICKS_CONFIG_PROFILE=DEFAULT
-UC_CATALOG=<your-catalog>
+UC_CATALOG=rpw_prod
 UC_SCHEMA=pulsar_uc_ingest_eval
 DATABRICKS_WAREHOUSE_ID=<warehouse-id-for-verification-queries>
 

--- a/experiments/pulsar-to-uc-managed-tables/tests/test_bundle.py
+++ b/experiments/pulsar-to-uc-managed-tables/tests/test_bundle.py
@@ -1,0 +1,13 @@
+"""Deployment defaults for the DEFAULT-profile workspace."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_bundle_and_template_default_to_the_renamed_catalog() -> None:
+    bundle = (ROOT / "databricks" / "databricks.yml").read_text()
+    template = (ROOT / "template.env").read_text()
+
+    assert "default: rpw_prod" in bundle
+    assert "UC_CATALOG=rpw_prod" in template


### PR DESCRIPTION
## What

- update active dbt, GSheets, Simple Dispatcher, Pulsar, DuckDB, and Hive-to-Delta defaults after the DEFAULT-workspace catalog rename
- update dbt docs App bindings and artifact paths
- add regression assertions for deployment defaults while retaining historical experiment results unchanged

## Why

Unity Catalog preserved the catalog object, data, and grants when `fe_randy_pitcher_workspace_catalog` became `rpw_prod`, but jobs, App bindings, volume paths, and registered-model deployment inputs store names. Nine jobs, one docs App, and one serving endpoint still referenced the removed name.

Part of #65

## Verification

- dbt catalog tests → 1 passed; dev and prod bundle validation → green
- GSheets suite → 54 passed, 11 skipped; dev and prod bundle validation → green
- Simple Dispatcher suite → 17 passed; dev and prod bundle validation → green
- Pulsar suite → 8 passed; Ruff → green; dev bundle validation → green
- DuckDB catalog-default test → 1 passed
- Hive-to-Delta targeted configuration/model tests → 24 passed
- broader Hive-to-Delta run → 143 passed, with existing live-compute setup errors and four unrelated inventory-filter failures