### PR TITLE
fix: rotate dispatcher experiment with catalog

### DIFF
--- a/databricks/demos/simple_dispatcher_agent/databricks.yml
+++ b/databricks/demos/simple_dispatcher_agent/databricks.yml
@@ -87,7 +87,7 @@ targets:
     mode: development
     variables:
       target_schema: "${var.base_schema}_${workspace.current_user.short_name}"
-      target_experiment: "/Users/${workspace.current_user.userName}/${bundle.name}_dev_${workspace.current_user.short_name}"
+      target_experiment: "/Users/${workspace.current_user.userName}/${bundle.name}_dev_${workspace.current_user.short_name}_${var.base_catalog}"
       deploy_endpoint: "false"
     workspace:
       root_path: /Users/${workspace.current_user.userName}/.bundles/${bundle.name}
@@ -100,7 +100,7 @@ targets:
     mode: development
     variables:
       target_schema: "${var.base_schema}_${var.pr_number}"
-      target_experiment: "/Users/${workspace.current_user.userName}/${bundle.name}_test_${var.pr_number}"
+      target_experiment: "/Users/${workspace.current_user.userName}/${bundle.name}_test_${var.pr_number}_${var.base_catalog}"
       deploy_endpoint: "false"
     workspace:
       root_path: /Users/${workspace.current_user.userName}/.bundles/${bundle.name}/pr_${var.pr_number}
@@ -113,7 +113,7 @@ targets:
     mode: production
     variables:
       target_schema: "${var.base_schema}"
-      target_experiment: "/Workspace/deployments/${bundle.name}/${bundle.name}_prod"
+      target_experiment: "/Workspace/deployments/${bundle.name}/${bundle.name}_prod_${var.base_catalog}"
       deploy_endpoint: "true"
     workspace:
       root_path: /Workspace/deployments/${bundle.name}

--- a/databricks/demos/simple_dispatcher_agent/tests/test_bundle.py
+++ b/databricks/demos/simple_dispatcher_agent/tests/test_bundle.py
@@ -11,3 +11,15 @@ def test_bundle_defaults_to_the_renamed_catalog() -> None:
 
     assert "default: rpw_prod" in bundle
     assert "fe_randy_pitcher_workspace_catalog" not in bundle
+
+
+def test_experiment_names_rotate_with_catalog_renames() -> None:
+    bundle = (ROOT / "databricks.yml").read_text()
+    experiment_lines = [
+        line
+        for line in bundle.splitlines()
+        if line.lstrip().startswith("target_experiment:") and '"' in line
+    ]
+
+    assert len(experiment_lines) == 3
+    assert all("${var.base_catalog}" in line for line in experiment_lines)


### PR DESCRIPTION
## What

- include the active catalog in every Simple Dispatcher MLflow experiment path
- add a regression assertion covering dev, test, and prod targets

## Why

MLflow trace locations are immutable after experiment creation. After the catalog rename, the existing production experiment remained bound to `fe_randy_pitcher_workspace_catalog`, so deployment against `rpw_prod` failed before model registration. Catalog-qualified experiment names create the required new experiment now and rotate automatically on future catalog changes.

Part of #65

## Verification

- Simple Dispatcher suite → 18 passed, 0 failed
- dev, test, and prod bundle validation → green
- reproduced the production failure as an MLflow trace-location binding conflict before this change