### PR TITLE
docs: both dbt SPs need CAN_USE on the SQL warehouse

### DIFF
--- a/databricks/demos/dbt/README.md
+++ b/databricks/demos/dbt/README.md
@@ -213,7 +213,9 @@ by display name:
   a CI run of unreviewed PR code cannot write to production by accident.
 
 The deploying identity needs CAN_USE on both SPs — including `dbt_prod_sp` itself, since the
-CD job redeploys this bundle as the production SP and must set the CI job's `run_as`.
+CD job redeploys this bundle as the production SP and must set the CI job's `run_as`. Both
+SPs also need CAN_USE on the `dbt_wh` SQL warehouse (dbt's first connection fails with
+PERMISSION_DENIED on the SQL endpoint otherwise).
 
 Production runs also apply **grants as code**: every `dbt build` grants `SELECT` on the marts
 to `account users` (see `+grants` in `dbt_project.yml`) — consumers get access as part of the


### PR DESCRIPTION
One sentence in the grants paragraph: `dbt_prod_sp` and `dbt_ci_sp` both need CAN_USE on the `dbt_wh` warehouse. Found live — the first CI run as the new CI SP failed at dbt's first connection with PERMISSION_DENIED on the SQL endpoint until the grant was added.

This PR's own CI run doubles as the PR-path verification of the new CI identity (dedicated SP, builds in `rpw_ci`).

This pull request and its description were written by Isaac.