### PR TITLE
Add 'whoops' column to cost_by_product

### DIFF
--- a/databricks/demos/dbt/models/marts/finance/cost_by_product.sql
+++ b/databricks/demos/dbt/models/marts/finance/cost_by_product.sql
@@ -6,6 +6,7 @@ select
     currency_code,
     count(distinct workspace_id) as n_workspaces,
     sum(usage_quantity)          as usage_quantity,
-    sum(list_cost)               as list_cost
+    sum(list_cost)               as list_cost,
+    1/0 as whoops
 from {{ ref('int_usage_priced') }}
 group by billing_origin_product, usage_date, cloud, currency_code

--- a/databricks/demos/dbt/models/marts/finance/cost_by_product.sql
+++ b/databricks/demos/dbt/models/marts/finance/cost_by_product.sql
@@ -7,6 +7,6 @@ select
     count(distinct workspace_id) as n_workspaces,
     sum(usage_quantity)          as usage_quantity,
     sum(list_cost)               as list_cost,
-    1/0 as whoops
+    upper() as whoops
 from {{ ref('int_usage_priced') }}
 group by billing_origin_product, usage_date, cloud, currency_code


### PR DESCRIPTION
Added a new column 'whoops' that divides 1 by 0, which may cause an error.