### PR TITLE
dbt CD refreshes docs after slim build; docs site in Indianapolis time

### DIFF
--- a/databricks/demos/dbt/docs_app/app.py
+++ b/databricks/demos/dbt/docs_app/app.py
@@ -11,6 +11,7 @@ from http import HTTPStatus
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from urllib.parse import urlsplit
+from zoneinfo import ZoneInfo
 
 from databricks.sdk import WorkspaceClient
 
@@ -100,6 +101,17 @@ def _load_json(path: Path):
         return json.load(file)
 
 
+# All displayed timestamps render in Indianapolis local time; %Z shows EST/EDT
+# so daylight saving is never ambiguous.
+DISPLAY_TIMEZONE = ZoneInfo("America/Indiana/Indianapolis")
+
+
+def _format_display_time(parsed: datetime) -> str:
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(DISPLAY_TIMEZONE).strftime("%Y-%m-%d %H:%M:%S %Z")
+
+
 def _format_iso_timestamp(value: str | None) -> str:
     if not value:
         return "Unknown"
@@ -110,14 +122,14 @@ def _format_iso_timestamp(value: str | None) -> str:
     except ValueError:
         return value
 
-    return parsed.astimezone(UTC).strftime("%Y-%m-%d %H:%M:%S UTC")
+    return _format_display_time(parsed)
 
 
 def _format_epoch_millis(value: int | None) -> str:
     if not value:
         return "Unknown"
 
-    return datetime.fromtimestamp(value / 1000, tz=UTC).strftime("%Y-%m-%d %H:%M:%S UTC")
+    return _format_display_time(datetime.fromtimestamp(value / 1000, tz=UTC))
 
 
 def _enum_value(value) -> str | None:

--- a/databricks/demos/dbt/resources/dbt_cd.job.yml
+++ b/databricks/demos/dbt/resources/dbt_cd.job.yml
@@ -10,7 +10,9 @@
 #   2. Slim production build: `dbt build -s state:modified+ --fail-fast`
 #      against the captured production state, then the state manifest is
 #      refreshed so the next CI/CD diff compares against what is now live.
-#      First deploy (no state yet) falls back to a full build.
+#      First deploy (no state yet) falls back to a full build. Finally,
+#      `dbt docs generate` refreshes the hosted docs so the site always shows
+#      what this deploy just shipped (not just the next scheduled docs run).
 #
 # Like CI, the task downloads the repo tarball at `git_ref` -- prod deploys
 # exactly the merged commit, not whatever happens to be synced anywhere.
@@ -21,7 +23,8 @@ resources:
       description: >-
         On merge to production: redeploys the bundle at the merged SHA, then
         slim-builds only changed models (state:modified+) and refreshes
-        captured production state. Triggered by GitHub Actions; never scheduled.
+        captured production state and the hosted dbt docs. Triggered by
+        GitHub Actions; never scheduled.
       # deploys must serialize -- two concurrent bundle deploys corrupt nothing
       # but the loser's terraform lock makes the run fail confusingly
       max_concurrent_runs: 1

--- a/databricks/demos/dbt/scripts/databricks_dbt_runner.py
+++ b/databricks/demos/dbt/scripts/databricks_dbt_runner.py
@@ -282,6 +282,22 @@ def main() -> None:
             if try_download_prod_manifest(args.artifacts_volume, project):
                 build += ["-s", "state:modified+", "--state", "prod_state"]
             dbt(build, project, env)
+            if args.artifacts_volume:
+                # refresh the hosted docs too: without this, a merge is live in
+                # the catalog but invisible on the docs site until the next
+                # scheduled prod-docs run (same path prod-docs writes)
+                dbt(
+                    [
+                        "docs",
+                        "generate",
+                        "--target",
+                        "prod",
+                        "--target-path",
+                        f"{args.artifacts_volume}/docs/latest",
+                    ],
+                    project,
+                    env,
+                )
         elif args.mode == "prod-source-freshness":
             dbt(["source", "freshness", "--target", "prod"], project, env)
         elif args.mode == "prod-build":


### PR DESCRIPTION
Closes #78.

## Problem

A merge is live in the prod catalog but invisible on the docs site until the next 06:00 `dbt Daily` run (bit us on PR #76's metric views), and docs timestamps render in UTC.

## Changes

- `scripts/databricks_dbt_runner.py` `cd` mode: after the slim build (which already refreshes captured state), run `dbt docs generate --target prod` into the artifacts volume's `docs/latest` — same path `prod-docs` writes.
- `docs_app/app.py`: all displayed timestamps formatted in `America/Indiana/Indianapolis` with `%Z` (EST/EDT).
- `resources/dbt_cd.job.yml`: description/comments follow.

## Verification

- Timestamp helpers exercised directly: `2026-09-01T14:30:00Z → 2026-09-01 10:30:00 EDT`, `2026-01-15T14:30:00Z → 2026-01-15 09:30:00 EST`, epoch-millis path EDT, None → `Unknown`, unparseable passthrough.
- `make pytest` green; both files compile.
- The merge of this PR itself exercises the new CD path end-to-end: docs site should show the metric views (and EST/EDT times) right after CD completes.

This pull request and its description were written by Isaac.